### PR TITLE
Fix compilation with gcc13

### DIFF
--- a/core/src/modules/duel/application/DuelFinishHandler.h
+++ b/core/src/modules/duel/application/DuelFinishHandler.h
@@ -6,7 +6,8 @@
 
 #include <vector>
 #include <iostream>
-#include "assert.h"
+#include <cstdint>
+#include <cassert>
 
 class DuelFinishHandler
 {

--- a/core/src/modules/duel/messages/application/BroadcastMessageSender.h
+++ b/core/src/modules/duel/messages/application/BroadcastMessageSender.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <iostream>
+#include <cstdint>
 
 class BroadcastMessageSender {
 public:

--- a/core/src/modules/duel/messages/application/BufferMessageSender.h
+++ b/core/src/modules/duel/messages/application/BufferMessageSender.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <iostream>
+#include <cstdint>
 
 class BufferMessageSender {
 public:

--- a/core/src/modules/duel/messages/application/DrawCardHandler.h
+++ b/core/src/modules/duel/messages/application/DrawCardHandler.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <iostream>
+#include <cstdint>
 
 #include "../../../shared/Read.h"
 #include "../../../shared/Write.h"

--- a/core/src/modules/duel/messages/application/DuelFinishedMessageSender.h
+++ b/core/src/modules/duel/messages/application/DuelFinishedMessageSender.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <iostream>
+#include <cstdint>
 
 class DuelFinishedMessageSender
 {

--- a/core/src/modules/duel/messages/application/DuelMessageSender.h
+++ b/core/src/modules/duel/messages/application/DuelMessageSender.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <iostream>
+#include <cstdint>
 
 class DuelMessageSender {
 public:

--- a/core/src/modules/duel/messages/application/FieldMessageSender.h
+++ b/core/src/modules/duel/messages/application/FieldMessageSender.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <iostream>
+#include <cstdint>
 
 class FieldMessageSender {
 public:

--- a/core/src/modules/duel/messages/application/LogMessageSender.h
+++ b/core/src/modules/duel/messages/application/LogMessageSender.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <iostream>
+#include <cstdint>
 
 class LogMessageSender {
 public:

--- a/core/src/modules/duel/messages/application/RefreshMessageSender.h
+++ b/core/src/modules/duel/messages/application/RefreshMessageSender.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <iostream>
+#include <cstdint>
 
 class RefreshMessageSender {
 public:

--- a/core/src/modules/duel/messages/application/TimeLimitMessageSender.h
+++ b/core/src/modules/duel/messages/application/TimeLimitMessageSender.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <iostream>
+#include <cstdint>
 
 class TimeLimitMessageSender {
 public:

--- a/core/src/modules/duel/messages/application/UpdateCardMessageSender.h
+++ b/core/src/modules/duel/messages/application/UpdateCardMessageSender.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <iostream>
+#include <cstdint>
 
 class UpdateCardMessageSender {
 public:

--- a/core/src/modules/duel/messages/application/WaitingMessageSender.h
+++ b/core/src/modules/duel/messages/application/WaitingMessageSender.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <iostream>
+#include <cstdint>
 
 class WaitingMessageSender {
 public:

--- a/core/src/modules/shared/QueryRequest.h
+++ b/core/src/modules/shared/QueryRequest.h
@@ -1,8 +1,9 @@
 #ifndef QUERY_REQUEST
 #define QUERY_REQUEST
 
-#include "variant"
-#include "iostream"
+#include <variant>
+#include <iostream>
+#include <cstdint>
 
 #define QUERY_CODE         0x1
 #define QUERY_POSITION     0x2

--- a/core/src/modules/shared/Read.h
+++ b/core/src/modules/shared/Read.h
@@ -2,7 +2,8 @@
 #define READ
 
 #include <cstring>
-#include "iostream"
+#include <iostream>
+#include <cstdint>
 
 template<typename T>
 constexpr T Read(const uint8_t*& ptr) noexcept


### PR DESCRIPTION
Gcc 13 cleaned up its headers and now there are less "auto inclusion" of other standard headers, so cstdint has to be included by hand.