### PR TITLE
Update Dockerfiles to use a consistent Node.js version (20.15.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN conan install . --build missing --output-folder=./dependencies --options=lib
     ./premake5 gmake && \
     make config=release
 
-FROM public.ecr.aws/docker/library/node:18 as server-builder
+FROM public.ecr.aws/docker/library/node:20.15.0 as server-builder
 
 WORKDIR /server
 
@@ -42,7 +42,7 @@ COPY . .
 
 RUN npm run build
 
-FROM public.ecr.aws/docker/library/node:18-slim
+FROM public.ecr.aws/docker/library/node:20.15.0-slim
 
 # Install curl:Necessary for local health checks
 RUN apt-get update && apt-get install -y curl git && apt-get install -y liblua5.3-dev libsqlite3-dev libevent-dev
@@ -64,4 +64,4 @@ COPY --from=core-integrator-builder /repositories/mercury-scripts ./mercury/scri
 
 CMD ["node", "./src/index.js"]
 
-EXPOSE 4000 7911 7922
+EXPOSE 4000 7711 7911 7922

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -31,7 +31,7 @@ RUN conan install . --build missing --output-folder=./dependencies --options=lib
     ./premake5 gmake && \
     make config=release
 
-FROM public.ecr.aws/docker/library/node:20
+FROM public.ecr.aws/docker/library/node:20.15.0
 
 RUN apt-get update &&  apt-get install -y liblua5.3-dev
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -30,7 +30,7 @@ RUN conan install . --build missing --output-folder=./dependencies --options=lib
     ./premake5 gmake && \
     make config=release
 
-FROM public.ecr.aws/docker/library/node:18 as server-builder
+FROM public.ecr.aws/docker/library/node:20.15.0 as server-builder
 
 WORKDIR /server
 
@@ -44,7 +44,7 @@ COPY . .
 
 RUN npm run build
 
-FROM public.ecr.aws/docker/library/node:18-slim
+FROM public.ecr.aws/docker/library/node:20.15.0-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
All Dockerfiles were using different versions of Node.js, which could lead to inconsistencies and potential issues during development and deployment. This commit standardizes the Node.js version to 20.15.0 across all Dockerfiles to ensure uniformity and compatibility.