### PR TITLE
fix: :ambulance: Auth for mercury players

### DIFF
--- a/src/mercury/client/domain/MercuryClient.ts
+++ b/src/mercury/client/domain/MercuryClient.ts
@@ -1,4 +1,5 @@
 import net from "net";
+import { MercuryPlayerInfoToCoreMessage } from "src/mercury/messages/server-to-core";
 
 import { ClientMessage } from "../../../modules/messages/MessageProcessor";
 import { Team } from "../../../modules/room/domain/Team";
@@ -118,7 +119,13 @@ export class MercuryClient extends YgoClient {
 	private sendPendingMessages(): void {
 		this._pendingMessages.forEach((message) => {
 			this._logger.debug(`Message: ${message.toString("hex")}`);
-			this._coreClient.write(message);
+			const messageType = message.readInt8(2);
+			if (messageType === 0x10) {
+				const playerInfoMessage = MercuryPlayerInfoToCoreMessage.create(this.name);
+				this._coreClient.write(playerInfoMessage);
+			} else {
+				this._coreClient.write(message);
+			}
 		});
 
 		this._pendingMessages = [];

--- a/src/mercury/room/domain/MercuryRoom.ts
+++ b/src/mercury/room/domain/MercuryRoom.ts
@@ -1,4 +1,6 @@
 import { Team } from "@modules/room/domain/Team";
+import { UserFinder } from "@modules/user/application/UserFinder";
+import { UserRedisRepository } from "@modules/user/infrastructure/UserRedisRepository";
 import { spawn } from "child_process";
 import net from "net";
 import { EventEmitter } from "stream";
@@ -265,7 +267,11 @@ export class MercuryRoom extends YgoRoom {
 
 	waiting(): void {
 		this.roomState?.removeAllListener();
-		this.roomState = new MercuryWaitingState(this.emitter, this._logger);
+		this.roomState = new MercuryWaitingState(
+			new UserFinder(new UserRedisRepository()),
+			this.emitter,
+			this._logger
+		);
 	}
 
 	rps(): void {

--- a/src/modules/room/domain/RoomState.ts
+++ b/src/modules/room/domain/RoomState.ts
@@ -1,3 +1,6 @@
+import { ErrorMessages } from "@modules/messages/server-to-client/error-messages/ErrorMessages";
+import { ErrorClientMessage } from "@modules/messages/server-to-client/ErrorClientMessage";
+import { ServerErrorClientMessage } from "@modules/messages/server-to-client/ServerErrorMessageClientMessage";
 import { EventEmitter } from "stream";
 
 import { mercuryConfig } from "../../../mercury/config";
@@ -72,6 +75,21 @@ export abstract class RoomState {
 
 			throw new Error("Version mismatch");
 		}
+	}
+
+	protected sendExistingPlayerErrorMessage(
+		playerInfoMessage: PlayerInfoMessage,
+		socket: ISocket
+	): void {
+		socket.send(
+			ServerErrorClientMessage.create(
+				`Ya existe un jugador con el nombre :${playerInfoMessage.name}`
+			)
+		);
+		socket.send(ErrorClientMessage.create(ErrorMessages.JOINERROR));
+		socket.destroy();
+
+		return;
 	}
 
 	private handleChat(message: ClientMessage, room: YgoRoom, client: YgoClient): void {

--- a/src/modules/room/domain/states/waiting/WaitingState.ts
+++ b/src/modules/room/domain/states/waiting/WaitingState.ts
@@ -288,7 +288,7 @@ export class WaitingState extends RoomState {
 		this.logger.debug("WAITING: JOIN");
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
 		if (this.playerAlreadyInRoom(playerInfoMessage, room, socket)) {
-			this.sendErrorMessage(playerInfoMessage, socket);
+			this.sendExistingPlayerErrorMessage(playerInfoMessage, socket);
 
 			return;
 		}
@@ -315,18 +315,6 @@ export class WaitingState extends RoomState {
 			return;
 		}
 		this.player(place, joinGameMessage, socket, playerInfoMessage, room, []);
-	}
-
-	private sendErrorMessage(playerInfoMessage: PlayerInfoMessage, socket: ISocket): void {
-		socket.send(
-			ServerErrorClientMessage.create(
-				`Ya existe un jugador con el nombre :${playerInfoMessage.name}`
-			)
-		);
-		socket.send(ErrorClientMessage.create(ErrorMessages.JOINERROR));
-		socket.destroy();
-
-		return;
 	}
 
 	private spectator(


### PR DESCRIPTION
Validate player credentials for ranked rooms, hide passwords in lobby, and check duplicate players.