### PR TITLE
fix: :bug: Fix duel status for mercury duels in edopro lobby

### DIFF
--- a/src/mercury/room/domain/MercuryRoom.ts
+++ b/src/mercury/room/domain/MercuryRoom.ts
@@ -288,6 +288,7 @@ export class MercuryRoom extends YgoRoom {
 
 	dueling(): void {
 		this._state = DuelState.DUELING;
+		this.isStart = "start";
 		this.roomState?.removeAllListener();
 		this.roomState = new MercuryDuelingState(this.emitter, this._logger);
 	}
@@ -335,7 +336,7 @@ export class MercuryRoom extends YgoRoom {
 			no_check: this._hostInfo.noCheck,
 			no_shuffle: this._hostInfo.noShuffle,
 			banlist_hash: this._banListHash,
-			istart: "waiting",
+			istart: this.isStart,
 			main_min: 40,
 			main_max: 60,
 			extra_min: 0,

--- a/src/modules/room/domain/Room.ts
+++ b/src/modules/room/domain/Room.ts
@@ -100,7 +100,6 @@ interface RoomAttr {
 	noCheck: boolean;
 	noShuffle: boolean;
 	banListHash: number;
-	isStart: string;
 	mainMin: number;
 	mainMax: number;
 	extraMin: number;
@@ -137,7 +136,6 @@ export class Room extends YgoRoom {
 	public readonly handshake: number;
 	public readonly password: string;
 	private _replay: Replay;
-	private isStart: string;
 	private readonly _kick: Client[] = [];
 	private _duel?: ChildProcessWithoutNullStreams;
 	private readonly _lastMessageToTeam: { team: number; message: Buffer }[] = [];
@@ -174,7 +172,6 @@ export class Room extends YgoRoom {
 		this.noCheck = attr.noCheck;
 		this.noShuffle = attr.noShuffle;
 		this.banListHash = attr.banListHash;
-		this.isStart = attr.isStart;
 		this.deckRules = new DeckRules({
 			mainMin: attr.mainMin,
 			mainMax: attr.mainMax,
@@ -258,7 +255,6 @@ export class Room extends YgoRoom {
 			rule: message.allowed,
 			noCheck: Boolean(message.dontCheckDeckContent),
 			noShuffle: Boolean(message.dontShuffleDeck),
-			isStart: "waiting",
 			mainMin: message.mainDeckMin,
 			mainMax: message.mainDeckMax,
 			extraMin: message.extraDeckMin,

--- a/src/modules/shared/room/domain/YgoRoom.ts
+++ b/src/modules/shared/room/domain/YgoRoom.ts
@@ -30,6 +30,7 @@ export abstract class YgoRoom {
 	protected _clientWhoChoosesTurn: YgoClient;
 	protected _match: Match | null;
 	protected _firstToPlay: number;
+	protected isStart: string;
 
 	protected constructor({
 		team0,
@@ -48,6 +49,7 @@ export abstract class YgoRoom {
 		this.bestOf = bestOf;
 		this.t0Positions = Array.from({ length: this.team0 }, (_, index) => index);
 		this.t1Positions = Array.from({ length: this.team1 }, (_, index) => this.team0 + index);
+		this.isStart = "waiting";
 	}
 
 	emit(event: string, message: unknown, socket: ISocket): void {


### PR DESCRIPTION
When a mercury duel started, it kept showing open status in the lobby.