### PR TITLE
feat: update server messages to English

### DIFF
--- a/src/edopro/messages/domain/ServerInfoMessage.ts
+++ b/src/edopro/messages/domain/ServerInfoMessage.ts
@@ -1,12 +1,22 @@
 export enum ServerInfoMessage {
-	WELCOME = "Bienvenido al servidor YGOPro Evolution",
-	RANKED_ROOM_CREATION_SUCCESS = "Sala Ranked creada de manera exitosa!",
-	GAIN_POINTS_CALL_TO_ACTION = "Trata de sumar puntos para el ranking!",
+	WELCOME = "Welcome to YGOPro Evolution Server",
+	RANKED_ROOM_CREATION_SUCCESS = "Ranked Room created successfully!",
+	GAIN_POINTS_CALL_TO_ACTION = "Try to gain points to the ranking!",
 
-	UN_RANKED_ROOM_CREATION_SUCCESS = "Sala Unranked creada de manera exitosa!",
-	NOT_GAIN_POINTS = "Esta partida no suma puntos para el ranking!",
+	UN_RANKED_ROOM_CREATION_SUCCESS = "Unranked Room created successfully!",
+	NOT_GAIN_POINTS = "This game does not gain points to the ranking!",
 
-	THIS_IS_A_RANKED_ROOM = "Esta es una sala Ranked!",
-	THIS_IS_A_UN_RANKED_ROOM = "Esta es una sala Unranked!",
-	MUST_BE_LOGGED = "Debes hacer login para jugar en esta sala!",
+	THIS_IS_A_RANKED_ROOM = "This is a Ranked Room!",
+	THIS_IS_A_UN_RANKED_ROOM = "This is an Unranked Room!",
+	MUST_BE_LOGGED = "You must be logged in to play in this room!",
+
+	UNAVAILABLE_RANKING_SYSTEM = "At the moment, the ranking system is not available.",
+	HAS_ENTERED_AS_A_SPECTATOR = "has entered as a spectator",
+	HAS_ENTERED_TO_THE_DUEL = "has entered to the duel",
+	HAS_LEFT_THE_DUEL = "has left the duel",
+
+	PREPARING_DUEL = "Preparing duel",
+	STARTING_DUEL = "Starting duel",
+	IN_PROGRESS = "In progress",
+	FINISHED = "Finished",
 }

--- a/src/edopro/room/application/GameCreatorHandler.ts
+++ b/src/edopro/room/application/GameCreatorHandler.ts
@@ -106,9 +106,7 @@ export class GameCreatorHandler implements GameCreatorMessageHandler {
 		);
 		if (!config.ranking.enabled) {
 			this.socket.send(
-				ServerMessageClientMessage.create(
-					"En este momento, el sistema de clasificación no está disponible."
-				)
+				ServerMessageClientMessage.create(ServerInfoMessage.UNAVAILABLE_RANKING_SYSTEM)
 			);
 		}
 

--- a/src/edopro/room/application/JoinToDuelAsSpectator.ts
+++ b/src/edopro/room/application/JoinToDuelAsSpectator.ts
@@ -1,4 +1,5 @@
 import { ServerInfoMessage } from "@edopro/messages/domain/ServerInfoMessage";
+
 import { DuelStartClientMessage } from "../../../shared/messages/server-to-client/DuelStartClientMessage";
 import { PlayerEnterClientMessage } from "../../../shared/messages/server-to-client/PlayerEnterClientMessage";
 import { TypeChangeClientMessage } from "../../../shared/messages/server-to-client/TypeChangeClientMessage";

--- a/src/edopro/room/application/JoinToDuelAsSpectator.ts
+++ b/src/edopro/room/application/JoinToDuelAsSpectator.ts
@@ -1,3 +1,4 @@
+import { ServerInfoMessage } from "@edopro/messages/domain/ServerInfoMessage";
 import { DuelStartClientMessage } from "../../../shared/messages/server-to-client/DuelStartClientMessage";
 import { PlayerEnterClientMessage } from "../../../shared/messages/server-to-client/PlayerEnterClientMessage";
 import { TypeChangeClientMessage } from "../../../shared/messages/server-to-client/TypeChangeClientMessage";
@@ -48,7 +49,7 @@ export class JoinToDuelAsSpectator {
 			.map((item) => item.name.replace(/\0/g, "").trim());
 
 		socket.send(
-			ServerMessageClientMessage.create(`Bienvenido ${client.name.replace(/\0/g, "").trim()}`)
+			ServerMessageClientMessage.create(`Welcome ${client.name.replace(/\0/g, "").trim()}`)
 		);
 		socket.send(
 			ServerMessageClientMessage.create(
@@ -60,7 +61,9 @@ export class JoinToDuelAsSpectator {
 
 		[...room.clients, ...room.spectators].forEach((_client: Client) => {
 			_client.sendMessage(
-				ServerMessageClientMessage.create(`${client.name} ha ingresado como espectador`)
+				ServerMessageClientMessage.create(
+					`${client.name} ${ServerInfoMessage.HAS_ENTERED_AS_A_SPECTATOR}`
+				)
 			);
 		});
 	}

--- a/src/edopro/room/domain/states/dueling/DuelingState.ts
+++ b/src/edopro/room/domain/states/dueling/DuelingState.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 import BanListMemoryRepository from "@edopro/ban-list/infrastructure/BanListMemoryRepository";
+import { ServerInfoMessage } from "@edopro/messages/domain/ServerInfoMessage";
 import { spawn } from "child_process";
 import * as crypto from "crypto";
 import EventEmitter from "events";
@@ -31,7 +32,6 @@ import { Reconnect } from "../../../application/Reconnect";
 import { DuelFinishReason } from "../../DuelFinishReason";
 import { Room } from "../../Room";
 import { RoomState } from "../../RoomState";
-import { ServerInfoMessage } from "@edopro/messages/domain/ServerInfoMessage";
 
 interface Message {
 	type: string;
@@ -408,12 +408,18 @@ export class DuelingState extends RoomState {
 		player.clearReconnecting();
 
 		this.room.clients.forEach((client: Client) => {
-			client.sendMessage(ServerMessageClientMessage.create(`${player.name} ${ServerInfoMessage.HAS_ENTERED_TO_THE_DUEL}`));
+			client.sendMessage(
+				ServerMessageClientMessage.create(
+					`${player.name} ${ServerInfoMessage.HAS_ENTERED_TO_THE_DUEL}`
+				)
+			);
 		});
 
 		this.room.spectators.forEach((spectator: Client) => {
 			spectator.sendMessage(
-				ServerMessageClientMessage.create(`${player.name} ${ServerInfoMessage.HAS_ENTERED_TO_THE_DUEL}`)
+				ServerMessageClientMessage.create(
+					`${player.name} ${ServerInfoMessage.HAS_ENTERED_TO_THE_DUEL}`
+				)
 			);
 		});
 	}

--- a/src/edopro/room/domain/states/dueling/DuelingState.ts
+++ b/src/edopro/room/domain/states/dueling/DuelingState.ts
@@ -31,6 +31,7 @@ import { Reconnect } from "../../../application/Reconnect";
 import { DuelFinishReason } from "../../DuelFinishReason";
 import { Room } from "../../Room";
 import { RoomState } from "../../RoomState";
+import { ServerInfoMessage } from "@edopro/messages/domain/ServerInfoMessage";
 
 interface Message {
 	type: string;
@@ -207,7 +208,7 @@ export class DuelingState extends RoomState {
 
 	private handle(): void {
 		this.room.clients.forEach((item) => {
-			item.socket.send(ServerMessageClientMessage.create("Preparando el duelo"));
+			item.socket.send(ServerMessageClientMessage.create(ServerInfoMessage.PREPARING_DUEL));
 		});
 		this.room.prepareTurnOrder();
 
@@ -224,7 +225,7 @@ export class DuelingState extends RoomState {
 		this.logger.debug(`GAME: ${this.room.playerNames(0)} VS ${this.room.playerNames(1)}`);
 
 		this.room.clients.forEach((item) => {
-			item.socket.send(ServerMessageClientMessage.create("Iniciando duelo"));
+			item.socket.send(ServerMessageClientMessage.create(ServerInfoMessage.STARTING_DUEL));
 		});
 
 		const core = spawn(
@@ -407,12 +408,12 @@ export class DuelingState extends RoomState {
 		player.clearReconnecting();
 
 		this.room.clients.forEach((client: Client) => {
-			client.sendMessage(ServerMessageClientMessage.create(`${player.name} ha ingresado al duelo`));
+			client.sendMessage(ServerMessageClientMessage.create(`${player.name} ${ServerInfoMessage.HAS_ENTERED_TO_THE_DUEL}`));
 		});
 
 		this.room.spectators.forEach((spectator: Client) => {
 			spectator.sendMessage(
-				ServerMessageClientMessage.create(`${player.name} ha ingresado al duelo`)
+				ServerMessageClientMessage.create(`${player.name} ${ServerInfoMessage.HAS_ENTERED_TO_THE_DUEL}`)
 			);
 		});
 	}

--- a/src/shared/room/application/DisconnectHandler.ts
+++ b/src/shared/room/application/DisconnectHandler.ts
@@ -1,4 +1,5 @@
 import { ServerInfoMessage } from "@edopro/messages/domain/ServerInfoMessage";
+
 import { Client } from "../../../edopro/client/domain/Client";
 import { PlayerChangeClientMessage } from "../../../edopro/messages/server-to-client/PlayerChangeClientMessage";
 import { ServerMessageClientMessage } from "../../../edopro/messages/server-to-client/ServerMessageClientMessage";

--- a/src/shared/room/application/DisconnectHandler.ts
+++ b/src/shared/room/application/DisconnectHandler.ts
@@ -1,3 +1,4 @@
+import { ServerInfoMessage } from "@edopro/messages/domain/ServerInfoMessage";
 import { Client } from "../../../edopro/client/domain/Client";
 import { PlayerChangeClientMessage } from "../../../edopro/messages/server-to-client/PlayerChangeClientMessage";
 import { ServerMessageClientMessage } from "../../../edopro/messages/server-to-client/ServerMessageClientMessage";
@@ -87,7 +88,7 @@ export class DisconnectHandler {
 			room.clients.forEach((client: Client) => {
 				client.sendMessage(
 					ServerMessageClientMessage.create(
-						`${player.name.replace(/\0/g, "").trim()} ha salido del duelo`
+						`${player.name.replace(/\0/g, "").trim()} ${ServerInfoMessage.HAS_LEFT_THE_DUEL}`
 					)
 				);
 			});
@@ -95,7 +96,7 @@ export class DisconnectHandler {
 			room.spectators.forEach((spectator: Client) => {
 				spectator.sendMessage(
 					ServerMessageClientMessage.create(
-						`${player.name.replace(/\0/g, "").trim()} ha salido del duelo`
+						`${player.name.replace(/\0/g, "").trim()} ${ServerInfoMessage.HAS_LEFT_THE_DUEL}`
 					)
 				);
 			});


### PR DESCRIPTION
- Translated server messages from Spanish to English for better accessibility.
- Added new messages for game states including duel preparation, starting, and in-progress notifications.
- Refactored existing code to utilize the new message enum for consistency.