### PR TITLE
Codex/add side decking timeout and match loss

### DIFF
--- a/src/edopro/room/domain/states/side-decking/SideDeckingState.ts
+++ b/src/edopro/room/domain/states/side-decking/SideDeckingState.ts
@@ -23,13 +23,12 @@ import { Room } from "../../Room";
 import { DuelFinishReason } from "../../DuelFinishReason";
 import { RoomState } from "../../RoomState";
 
-const SIDE_DECK_TIMEOUT = 60000; // 60 seconds
-const SIDE_DECK_WARNING = 5000; // warn 5 seconds before timeout
+const SIDE_DECK_TIMEOUT = 60_000; // 60 seconds
+const SIDE_DECK_WARNING = 5_000; // warn 5 seconds before timeout
 
 export class SideDeckingState extends RoomState {
        private sideTimer: NodeJS.Timeout | null = null;
        private warningTimer: NodeJS.Timeout | null = null;
-       private timerWinner: number | null = null;
         constructor(
                 eventEmitter: EventEmitter,
                 private readonly logger: Logger,
@@ -54,7 +53,6 @@ export class SideDeckingState extends RoomState {
 
        private startSideTimer(room: Room, winnerTeam: number): void {
                this.clearSideTimer();
-               this.timerWinner = winnerTeam;
                this.logger.info("Side decking timer started for opposing team.");
                this.warningTimer = setTimeout(() => {
                        this.logger.warn("Side decking timer is about to expire.");
@@ -78,7 +76,6 @@ export class SideDeckingState extends RoomState {
                        clearTimeout(this.warningTimer);
                        this.warningTimer = null;
                }
-               this.timerWinner = null;
        }
 
 	async handle(message: ClientMessage, room: Room, socket: ISocket): Promise<void> {


### PR DESCRIPTION
This pull request introduces a new timeout mechanism for the side decking phase in the `SideDeckingState` class to ensure timely progression of the duel. The changes include adding timers to handle warnings and automatic duel termination, as well as logic to start and clear these timers based on player readiness.

### Timeout Mechanism for Side Decking Phase:

* **Added constants for timeout and warning durations**: Defined `SIDE_DECK_TIMEOUT` (60 seconds) and `SIDE_DECK_WARNING` (5 seconds before timeout) to configure the side decking phase timing. (`[src/edopro/room/domain/states/side-decking/SideDeckingState.tsR21-R31](diffhunk://#diff-ac1789717c5a2d383d0852c8f959252d51d22441a8d68c9cfdff12b61909c91aR21-R31)`)

* **Implemented timer management methods**: Added `startSideTimer` and `clearSideTimer` methods to manage the warning and timeout timers. These methods ensure the duel is terminated with a timeout reason if the opposing team fails to prepare in time. (`[src/edopro/room/domain/states/side-decking/SideDeckingState.tsR54-R80](diffhunk://#diff-ac1789717c5a2d383d0852c8f959252d51d22441a8d68c9cfdff12b61909c91aR54-R80)`)

### Player Readiness Logic:

* **Enhanced readiness checks**: Updated the `handle` method to check if both teams are ready and clear timers accordingly. If one team is ready but the other is not, the timeout mechanism is triggered. (`[src/edopro/room/domain/states/side-decking/SideDeckingState.tsR154-R180](diffhunk://#diff-ac1789717c5a2d383d0852c8f959252d51d22441a8d68c9cfdff12b61909c91aR154-R180)`)