### PR TITLE
fix: prevent memory leaks in OCGCore and room states

### DIFF
--- a/src/ygopro/ocgcore-worker/ocgcore.ts
+++ b/src/ygopro/ocgcore-worker/ocgcore.ts
@@ -23,6 +23,7 @@ import {
   ChatColor,
   YGOProStocChat,
 } from "ygopro-msg-encode";
+import { type Subscription } from "rxjs";
 import { MayBeArray } from "nfkit";
 
 import { YGOProClient } from "../client/domain/YGOProClient";
@@ -47,6 +48,7 @@ type Client = YGOProClient;
 
 export class OCGCore {
   private ocgcore: WorkerInstance<OcgcoreWorker> | null;
+  private messageSubscription: Subscription | null = null;
   // responseSide: the side (0 or 1) currently being prompted by the core
   private responseSide: number | null = null;
   private lastResponseRequestMsg: YGOProMsgBase | null = null;
@@ -185,7 +187,7 @@ export class OCGCore {
         decks,
       });
 
-      this.ocgcore.message$.subscribe((msg) => {
+      this.messageSubscription = this.ocgcore.message$.subscribe((msg) => {
         this.logger.info("Received message from OCGCoreWorker");
         this.logger.info({ message: msg.message, type: msg.type });
       });
@@ -334,6 +336,9 @@ export class OCGCore {
       return;
     }
     this.ocgcore = null;
+    this.messageSubscription?.unsubscribe();
+    this.messageSubscription = null;
+    this.timerState.clear();
 
     if (kill) {
       ocgcore.finalize().catch((error) => {

--- a/src/ygopro/room/domain/states/YGOProDuelingState.ts
+++ b/src/ygopro/room/domain/states/YGOProDuelingState.ts
@@ -494,6 +494,7 @@ export class YGOProDuelingState extends RoomState {
   }
 
   private transitionToSideDecking(winner: number): void {
+    this.disposeCore();
     this.room.sideDecking();
 
     this.room.players.forEach((client: YGOProClient) => {
@@ -528,6 +529,7 @@ export class YGOProDuelingState extends RoomState {
   private async finalizeWithReplays(): Promise<void> {
     this.logger.info("Finalizing match and sending replays");
 
+    this.removeAllListener();
     this.disposeCore();
     await this.sendAllReplays();
     this.sendDuelEndAndDisconnect();

--- a/src/ygopro/room/domain/states/YGOProSideDeckingState.ts
+++ b/src/ygopro/room/domain/states/YGOProSideDeckingState.ts
@@ -126,6 +126,11 @@ export class YGOProSideDeckingState extends RoomState {
 		}
 	}
 
+	override removeAllListener(): void {
+		this.clearAllTimeouts();
+		super.removeAllListener();
+	}
+
 	private sendChatToPlayer(player: YGOProClient, msg: string, color: ChatColor): void {
 		const chatMsg = new YGOProStocChat().fromPartial({
 			player_type: color,


### PR DESCRIPTION
## Summary
- **RxJS subscription leak**: `message$.subscribe()` in `OCGCore.init()` was never unsubscribed — now stored and cleaned up in `dispose()`
- **Timer leak**: `TimerState` timeout was not cleared on OCGCore disposal — now explicitly cleared
- **OCGCore worker not disposed on side deck transition**: worker stayed alive between games during side decking — now disposed before transitioning
- **Event listeners not removed on match end**: `YGOProDuelingState` listeners persisted after match finalization — now cleaned up via `removeAllListener()`
- **SideDeckingState player timers leak**: `setInterval` timers were not cleared when state was replaced — `removeAllListener()` override now calls `clearAllTimeouts()` first

## Test plan
- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] Jest tests pass (282/282)
- [ ] Manual test: play a full match (best of 3) and verify no orphaned subscriptions/timers
- [ ] Manual test: disconnect during side deck phase and verify timers are cleaned up
- [ ] Monitor memory usage with `--inspect` during sustained load


🤖 Generated with [Claude Code](https://claude.com/claude-code)