### PR TITLE
fix: use OcgcoreScriptConstants for zone refresh location matching

### DIFF
--- a/src/ygopro/ocgcore-worker/ocgcore.ts
+++ b/src/ygopro/ocgcore-worker/ocgcore.ts
@@ -929,36 +929,36 @@ export class OCGCore {
   }
 
   private getZoneQueryFlag(location: number): number {
-    // Returns query flag for specific zone locations
-    switch (location) {
-      case 0x0080: // MZONE
-        return 0x881fff;
-      case 0x0100: // SZONE
-      case 0x1000: // EXTRA
-        return 0xe81fff;
-      case 0x0200: // HAND
-        return 0x681fff;
-      case 0x0400: // GRAVE
-      case 0x0800: // REMOVED
-        return 0x081fff;
-      default:
-        return 0xf81fff;
+    if (location === OcgcoreScriptConstants.LOCATION_MZONE) {
+      return 0x881fff;
     }
+    if (location === OcgcoreScriptConstants.LOCATION_SZONE) {
+      return 0xe81fff;
+    }
+    if (location === OcgcoreScriptConstants.LOCATION_HAND) {
+      return 0x681fff;
+    }
+    if (location === OcgcoreScriptConstants.LOCATION_GRAVE) {
+      return 0x081fff;
+    }
+    if (location === OcgcoreScriptConstants.LOCATION_EXTRA) {
+      return 0xe81fff;
+    }
+    return 0xf81fff;
   }
 
   private splitRefreshLocations(location: number): number[] {
-    // Split location flags into individual locations
     const locationFlags = [
-      0x0080, // MZONE
-      0x0100, // SZONE
-      0x0200, // HAND
-      0x0400, // GRAVE
-      0x0800, // REMOVED
-      0x1000, // EXTRA
-      0x2000, // DECK
-      0x4000, // OVERLAY
-      0x8000, // FZONE
-      0x10000, // PZONE
+      OcgcoreScriptConstants.LOCATION_MZONE,
+      OcgcoreScriptConstants.LOCATION_SZONE,
+      OcgcoreScriptConstants.LOCATION_HAND,
+      OcgcoreScriptConstants.LOCATION_GRAVE,
+      OcgcoreScriptConstants.LOCATION_REMOVED,
+      OcgcoreScriptConstants.LOCATION_EXTRA,
+      OcgcoreScriptConstants.LOCATION_DECK,
+      OcgcoreScriptConstants.LOCATION_OVERLAY,
+      OcgcoreScriptConstants.LOCATION_FZONE,
+      OcgcoreScriptConstants.LOCATION_PZONE,
     ];
 
     const locations = locationFlags.filter((flag) => (location & flag) !== 0);


### PR DESCRIPTION
## Summary
- **Zone refresh constants mismatch**: `splitRefreshLocations()` and `getZoneQueryFlag()` used YGOPro protocol constants (`0x0080`, `0x0100`, etc.) instead of `OcgcoreScriptConstants` (`LOCATION_MZONE=4`, `LOCATION_SZONE=8`, etc.). This caused `refreshForMessage()` to never match zones returned by `getRequireRefreshZones()`, so field state updates after phase changes (NewPhase, DamageStepEnd, ChainEnd) were silently skipped.
- **Tag duel position swap ignored**: `getPlayersAtIngamePosition()` and `getActivePlayer()` skipped position swap when `isTag` was true, using engine side directly as team index. When team 1 won the coin toss (`isPositionSwapped=true`), engine side 0 mapped to team 0 instead of team 1, causing hand cards to appear face-down for all players in turn.

### Symptoms fixed
- Cards with phase-specific ATK buffs (e.g. Blackwing - Kalut, Honest, Slifer) visually retaining buffed values after leaving the damage step
- Hand cards stuck face-down after tag swap in 2v2 duels
- ATK modifiers appearing to trigger only when a card is targeted/attacked

## Test plan
- [ ] Activate Blackwing - Kalut during damage step → verify ATK resets visually after damage step ends
- [ ] Activate Honest during damage step → verify ATK resets visually after damage step ends
- [ ] Slifer the Sky Dragon → verify ATK updates in real-time as hand size changes
- [ ] 2v2 Tag Duel where team 0 goes first → verify hand cards visible to active player
- [ ] 2v2 Tag Duel where team 1 goes first (coin toss) → verify hand cards visible to active player
- [ ] Tag swap mid-duel → verify new active player sees their hand face-up
- [ ] Verify reconnect still sends correct field state