### PR TITLE
fix: apply position swap in tag duel player resolution

### DIFF
--- a/src/ygopro/ocgcore-worker/ocgcore.ts
+++ b/src/ygopro/ocgcore-worker/ocgcore.ts
@@ -1211,29 +1211,24 @@ export class OCGCore {
 
   /**
    * Returns players at given side index (0 or 1 from core perspective).
-   * In Tag Duel, side already represents team index (0 or 1) - no swap needed.
+   * Applies position swap to map engine side to room team.
    */
   getPlayersAtIngamePosition(side: number): Client[] {
-    // In Tag Duel, the engine's positions 0/1 map directly to teams 0/1
-    // No swap should be applied in tag mode
-    const team = this.room.isTag ? side : this.getSideTeam(side);
+    const team = this.getSideTeam(side);
     return this.room.getTeamPlayers(team);
   }
 
   /**
    * Returns the active player (who must respond) for the given side.
    * Decides which teammate within the team should act based on turn rotation.
-   * In Tag Duel, side already represents team index - no swap needed.
    *
    * Formula from srvpro2 (tag_duel.cpp cur_player):
-   * - Team 0: idx = floor(max(0, tc - 1) / 2) % 2
-   * - Team 1: idx = 1 - (floor(tc / 2) % 2)
+   * - Side 0: idx = floor(max(0, tc - 1) / 2) % 2
+   * - Side 1: idx = 1 - (floor(tc / 2) % 2)
    * Where tc = turnCount (starts at 0, incremented at each new turn)
    */
   private getActivePlayer(side: number): Client | null {
-    // In Tag Duel, the engine's positions 0/1 map directly to teams 0/1
-    // No swap should be applied in tag mode
-    const team = this.room.isTag ? side : this.getSideTeam(side);
+    const team = this.getSideTeam(side);
     const teamPlayers = this.room.players.filter(
       (p) => p.team === team,
     ) as Client[];


### PR DESCRIPTION
## Summary
- `getPlayersAtIngamePosition()` and `getActivePlayer()` skipped position swap when `isTag` was true, using engine side directly as team index
- When team 1 won the coin toss (`isPositionSwapped=true`), engine side 0 mapped to team 0 instead of team 1, causing `deliverToTargets` to send `playerView()` to the wrong teammate and `teammateView()` (hidden cards) to the actual active player
- All hand cards appeared face-down for players in turn in 2v2 duels when team 1 went first

## Test plan
- [x] 2v2 Tag Duel where team 0 goes first → verify hand cards visible to active player
- [x] 2v2 Tag Duel where team 1 goes first (coin toss) → verify hand cards visible to active player
- [x] Tag swap mid-duel → verify new active player sees their hand face-up
- [x] Verify teammate sees partner's hand as face-down (correct behavior)
- [x] Verify response messages (select card, etc.) are sent to the correct player