### PR TITLE
fix: allow OCG and TCG cards in pre-release and art room modes

### DIFF
--- a/src/ygopro/room/domain/RuleMappings.ts
+++ b/src/ygopro/room/domain/RuleMappings.ts
@@ -599,7 +599,7 @@ export const formatRuleMappings: RuleMappings = {
 	tcgpre: {
 		get: () => {
 			return {
-				rule: 1,
+				rule: 5,
 				duel_rule: 5,
 				time_limit: 450,
 			};
@@ -611,7 +611,7 @@ export const formatRuleMappings: RuleMappings = {
 	ocgpre: {
 		get: () => {
 			return {
-				rule: 0,
+				rule: 5,
 				duel_rule: 5,
 				lflist: 0,
 				time_limit: 450,
@@ -624,7 +624,7 @@ export const formatRuleMappings: RuleMappings = {
 	tcgart: {
 		get: () => {
 			return {
-				rule: 1,
+				rule: 5,
 				duel_rule: 5,
 				time_limit: 450,
 			};
@@ -636,7 +636,7 @@ export const formatRuleMappings: RuleMappings = {
 	ocgart: {
 		get: () => {
 			return {
-				rule: 0,
+				rule: 5,
 				duel_rule: 5,
 				lflist: 0,
 				time_limit: 450,

--- a/src/ygopro/room/domain/states/YGOProSideDeckingState.ts
+++ b/src/ygopro/room/domain/states/YGOProSideDeckingState.ts
@@ -207,7 +207,7 @@ export class YGOProSideDeckingState extends RoomState {
 		});
 
 		if (deckOrError instanceof DeckError) {
-			this.logger.warn(`Deck build error: type ${deckOrError.type}, code ${deckOrError.code}`);
+			this.logger.warn(`Deck build error: type=0x${deckOrError.type.toString(16)}, code=${deckOrError.code}, rule=${room.hostInfo.rule}, extendedPool=${room.useExtendedCardPool}`);
 			room.notReadyUnsafe(player);
 			player.sendMessageToClient(room.messageSender.errorMessage(ErrorMessageType.DECKERROR, deckOrError.type));
 			return;
@@ -216,7 +216,8 @@ export class YGOProSideDeckingState extends RoomState {
 		const deck = deckOrError;
 		const hasError = room.shouldValidateDeck() && this.deckValidator.validate(deck);
 		if (hasError) {
-			this.logger.warn(`Deck has an error: type ${hasError.type}, code ${hasError.code}`);
+			const failedCard = deck.allCards.find((c) => Number(c.code) === hasError.code);
+			this.logger.warn(`Deck validation error: type=0x${hasError.type.toString(16)}, code=${hasError.code}, cardOt=${failedCard?.variant ?? "N/A"}, rule=${room.hostInfo.rule}, extendedPool=${room.useExtendedCardPool}`);
 			room.notReadyUnsafe(player);
 			player.sendMessageToClient(room.messageSender.errorMessage(ErrorMessageType.DECKERROR, hasError.type));
 			return;

--- a/src/ygopro/room/domain/states/YGOProWaitingState.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.ts
@@ -209,7 +209,7 @@ export class YGOProWaitingState extends YGOProRoomState {
 		});
 
 		if (deckOrError instanceof DeckError) {
-			this.logger.warn(`Deck build error: type ${deckOrError.type}, code ${deckOrError.code}`);
+			this.logger.warn(`Deck build error: type=0x${deckOrError.type.toString(16)}, code=${deckOrError.code}, rule=${room.hostInfo.rule}, extendedPool=${room.useExtendedCardPool}`);
 			room.notReadyUnsafe(player);
 			player.sendMessageToClient(room.messageSender.errorMessage(ErrorMessageType.DECKERROR, deckOrError.type));
 			return;
@@ -218,7 +218,8 @@ export class YGOProWaitingState extends YGOProRoomState {
 		const deck = deckOrError;
 		const hasError = room.shouldValidateDeck() && this.deckValidator.validate(deck);
 		if (hasError) {
-			this.logger.warn(`Deck has an error: type ${hasError.type}, code ${hasError.code}`);
+			const failedCard = deck.allCards.find((c) => Number(c.code) === hasError.code);
+			this.logger.warn(`Deck validation error: type=0x${hasError.type.toString(16)}, code=${hasError.code}, cardOt=${failedCard?.variant ?? "N/A"}, rule=${room.hostInfo.rule}, extendedPool=${room.useExtendedCardPool}`);
 			room.notReadyUnsafe(player);
 			player.sendMessageToClient(room.messageSender.errorMessage(ErrorMessageType.DECKERROR, hasError.type));
 			return;

--- a/tests/modules/mercury/room/domain/YGOProRoom.test.ts
+++ b/tests/modules/mercury/room/domain/YGOProRoom.test.ts
@@ -342,33 +342,33 @@ describe("YGOProRoom", () => {
       expect(room.useExtendedCardPool).toBe(true);
     });
 
-    it("Should create a tcgpre room with rule 1 (TCG only) and extended card pool", () => {
+    it("Should create a tcgpre room with rule 5 (no scope restriction) and extended card pool", () => {
       const room = YGOProRoomMother.create({ command: "tcgpre,tm800#123" });
-      expect(room.hostInfo.rule).toBe(1);
+      expect(room.hostInfo.rule).toBe(5);
       expect(room.hostInfo.duel_rule).toBe(5);
       expect(room.hostInfo.time_limit).toBe(800);
       expect(room.useExtendedCardPool).toBe(true);
     });
 
-    it("Should create an ocgpre room with rule 0 (OCG only) and extended card pool", () => {
+    it("Should create an ocgpre room with rule 5 (no scope restriction) and extended card pool", () => {
       const room = YGOProRoomMother.create({ command: "ocgpre#123" });
-      expect(room.hostInfo.rule).toBe(0);
+      expect(room.hostInfo.rule).toBe(5);
       expect(room.hostInfo.lflist).toBe(0);
       expect(room.hostInfo.duel_rule).toBe(5);
       expect(room.useExtendedCardPool).toBe(true);
     });
 
-    it("Should create a tcgart room with rule 1 (TCG only) and extended card pool", () => {
+    it("Should create a tcgart room with rule 5 (no scope restriction) and extended card pool", () => {
       const room = YGOProRoomMother.create({ command: "tcgart,tm800#123" });
-      expect(room.hostInfo.rule).toBe(1);
+      expect(room.hostInfo.rule).toBe(5);
       expect(room.hostInfo.duel_rule).toBe(5);
       expect(room.hostInfo.time_limit).toBe(800);
       expect(room.useExtendedCardPool).toBe(true);
     });
 
-    it("Should create an ocgart room with rule 0 (OCG only) and extended card pool", () => {
+    it("Should create an ocgart room with rule 5 (no scope restriction) and extended card pool", () => {
       const room = YGOProRoomMother.create({ command: "ocgart#123" });
-      expect(room.hostInfo.rule).toBe(0);
+      expect(room.hostInfo.rule).toBe(5);
       expect(room.hostInfo.lflist).toBe(0);
       expect(room.hostInfo.duel_rule).toBe(5);
       expect(room.useExtendedCardPool).toBe(true);


### PR DESCRIPTION
## Summary
- OCGPRE/TCGPRE/OCGART/TCGART used `rule: 0` (OCG-only) or `rule: 1` (TCG-only) for card scope validation, rejecting cards that only had the opposite region bit set
- Changed all four modes to `rule: 5` (no scope restriction) so both OCG and TCG cards are allowed while still enforcing the appropriate regional banlist (OCG banlist for OCGPRE/OCGART, TCG banlist for TCGPRE/TCGART)
- Improved deck validation logging to include `cardOt`, `rule`, and `extendedPool` values for easier debugging

## Test plan
- [x] OCGPRE room: verify OCG-only cards (e.g. card 70088809 with ot=9) are accepted
- [x] OCGPRE room: verify TCG-only cards are also accepted
- [x] TCGPRE room: verify both OCG and TCG cards are accepted
- [x] OCGPRE room: verify OCG banlist restrictions still apply (e.g. Ash Blossom semi-limited)
- [x] TCGPRE room: verify TCG banlist restrictions still apply
- [x] OCGART/TCGART rooms: same behavior as their PRE counterparts