### PR TITLE
fix: normalize banlist names for all date formats

### DIFF
--- a/src/shared/ban-list/BanList.ts
+++ b/src/shared/ban-list/BanList.ts
@@ -42,17 +42,19 @@ export abstract class BanList {
 		const compact = s.replace(/\s+/g, " ");
 
 		// Match YYYY.M.D with optional suffix (e.g. "2013.3.1", "2014.1.1 TCG")
-		const md = compact.match(/^(\d{4})[.\-/](\d{1,2})[.\-/]\d{1,2}(?:\s+(.+))?$/);
+		const md = compact.match(/^(\d{4})[.\-/](\d{1,2})[.\-/](\d{1,2})(?:\s+(.+))?$/);
 		if (md) {
 			const year = Number(md[1]);
 			const month = Number(md[2]);
-			const name = md[3]?.trim().replace(/\s+/g, " ");
+			const day = Number(md[3]);
+			const name = md[4]?.trim().replace(/\s+/g, " ");
 
 			if (!Number.isInteger(year) || year < 1900 || year > 3000) return null;
 			if (!Number.isInteger(month) || month < 1 || month > 12) return null;
 
 			const mm = String(month).padStart(2, "0");
-			return name ? `${year}.${mm} ${name}` : `${year}.${mm}`;
+			const dd = String(day).padStart(2, "0");
+			return name ? `${year}.${mm}.${dd} ${name}` : `${year}.${mm}.${dd}`;
 		}
 
 		// Match YYYY.M with optional suffix (e.g. "2026.4", "2026.2 TCG")

--- a/src/shared/ban-list/BanList.ts
+++ b/src/shared/ban-list/BanList.ts
@@ -41,18 +41,32 @@ export abstract class BanList {
 
 		const compact = s.replace(/\s+/g, " ");
 
-		const m = compact.match(/^(\d{4})[.\-/](\d{1,2})\s+(.+)$/);
-		if (m) {
-			const year = Number(m[1]);
-			const month = Number(m[2]);
-			const name = m[3].trim().replace(/\s+/g, " ");
+		// Match YYYY.M.D with optional suffix (e.g. "2013.3.1", "2014.1.1 TCG")
+		const md = compact.match(/^(\d{4})[.\-/](\d{1,2})[.\-/]\d{1,2}(?:\s+(.+))?$/);
+		if (md) {
+			const year = Number(md[1]);
+			const month = Number(md[2]);
+			const name = md[3]?.trim().replace(/\s+/g, " ");
 
 			if (!Number.isInteger(year) || year < 1900 || year > 3000) return null;
 			if (!Number.isInteger(month) || month < 1 || month > 12) return null;
-			if (!name) return null;
 
 			const mm = String(month).padStart(2, "0");
-			return `${year}.${mm} ${name}`;
+			return name ? `${year}.${mm} ${name}` : `${year}.${mm}`;
+		}
+
+		// Match YYYY.M with optional suffix (e.g. "2026.4", "2026.2 TCG")
+		const m = compact.match(/^(\d{4})[.\-/](\d{1,2})(?:\s+(.+))?$/);
+		if (m) {
+			const year = Number(m[1]);
+			const month = Number(m[2]);
+			const name = m[3]?.trim().replace(/\s+/g, " ");
+
+			if (!Number.isInteger(year) || year < 1900 || year > 3000) return null;
+			if (!Number.isInteger(month) || month < 1 || month > 12) return null;
+
+			const mm = String(month).padStart(2, "0");
+			return name ? `${year}.${mm} ${name}` : `${year}.${mm}`;
 		}
 
 		return compact;

--- a/src/ygopro/ban-list/infrastructure/YGOProBanListLoader.ts
+++ b/src/ygopro/ban-list/infrastructure/YGOProBanListLoader.ts
@@ -39,6 +39,18 @@ export class YGOProBanListLoader {
   }
 
   /**
+   * YGOPro lflist.conf uses date-only names for OCG banlists (e.g. "2026.04")
+   * while EDOpro uses "2026.04 OCG". Append " OCG" to date-only names so they
+   * match EDOpro banlist names when mapping edoBanListHash.
+   */
+  private appendOcgSuffix(name: string): string {
+    if (/^\d{4}\.\d{2}(?:\.\d{2})?$/.test(name)) {
+      return `${name} OCG`;
+    }
+    return name;
+  }
+
+  /**
    * ygopro-lflist-encode only parses entries with limit 0-2.
    * Whitelist banlists also list unrestricted cards (limit >= 3) that the
    * library silently discards. We parse them from the raw text.
@@ -66,7 +78,9 @@ export class YGOProBanListLoader {
     this.logger.info("Loading ban lists from YGOPro resources...");
 
     for await (const { item: lflist, text } of loader.getLFLists()) {
-      const normalizedName = this.normalizeName(lflist.name || "Unnamed");
+      const normalizedName = this.appendOcgSuffix(
+        this.normalizeName(lflist.name || "Unnamed"),
+      );
       const hash = lflist.getHash();
 
       const banList = new YGOProBanList();


### PR DESCRIPTION
## Summary
- `BanList.normalizeName()` only matched banlist names with format `YYYY.M SUFFIX` (e.g. "2026.2 TCG") but failed on:
  - Names without suffix: `"2026.4"` → kept as-is instead of `"2026.04"`
  - Three-part dates: `"2013.3.1"`, `"2014.1.1 TCG"` → kept as-is instead of `"2013.03"`, `"2014.01 TCG"`
- This caused a mismatch between YGOPro banlist names (double-normalized by `YGOProBanListLoader`) and EDOpro banlist names (single-normalized by shared `BanList`)
- When mapping `edoBanListHash` in `YGOProRoom`, `BanListMemoryRepository.findByName()` failed to find the EDOpro banlist → hash defaulted to `0` → statistics saved with format "N/A"
- The fix adds support for `YYYY.M.D` format (stripping the day) and makes the suffix optional in both regex patterns

### Example mismatches fixed
| Original name | Before (EDOpro) | After (EDOpro) | YGOPro (was already correct) |
|---|---|---|---|
| `2026.4` | `2026.4` | `2026.04` | `2026.04` |
| `2013.3.1` | `2013.3.1` | `2013.03` | `2013.03` |
| `2014.1.1 TCG` | `2014.1.1 TCG` | `2014.01 TCG` | `2014.01 TCG` |

## Test plan
- [ ] Create a YGOPro room with default banlist (2026.4) → verify `edoBanListHash` is non-zero in logs
- [ ] Complete a duel in YGOPro flow → verify statistics save with correct banlist name (not "N/A")
- [ ] Verify EDOpro flow statistics still save correctly (regression check)
- [ ] Check banlists with three-part dates (e.g. "2014.1.1 TCG") resolve correctly