### PR TITLE
fix(ygopro): load lua scripts from extra pool folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The YGOPro engine uses srvpro2-compatible protocol. Players connect using Koishi
 - ✅ Card scripts and databases from ygopro-scripts
 - ✅ Ban lists and alternative format resources
 - ✅ The `YGOPRO_FOLDERS` environment variable pointing to your resource directories
-- ✅ (Optional) The `YGOPRO_EXTRA_DB_FOLDERS` environment variable for pre-release and art card databases
+- ✅ (Optional) The `YGOPRO_EXTRA_FOLDERS` environment variable for pre-release and art card resource folders (cdbs + scripts)
 
 **Minimum `.env` configuration:**
 
@@ -145,17 +145,17 @@ YGOPRO_FOLDERS=./resources/ygopro/base
 ├── 📜 base/               # Core scripts + lflist + cards.cdb (loaded by all modes)
 ├── 🌏 ocg/                # OCG-specific banlist
 ├── 🃏 alternatives/       # Format variants (Edison, GOAT, HAT, etc.)
-├── 🆕 prereleases-cdb/    # Pre-release card databases (extra DB)
-└── 🎨 cards-art/          # Custom card art databases (extra DB)
+├── 🆕 prereleases-cdb/    # Pre-release card databases + scripts (extra folder)
+└── 🎨 cards-art/          # Custom card art databases (extra folder)
 ```
 
-**Standard card pool** (`YGOPRO_FOLDERS`) is loaded for all rooms. **Extra databases** (`YGOPRO_EXTRA_DB_FOLDERS`) are only available in rooms that use PRE or ART formats — standard rooms cannot use those cards.
+**Standard card pool** (`YGOPRO_FOLDERS`) is loaded for all rooms. **Extra folders** (`YGOPRO_EXTRA_FOLDERS`) — which can contain cdbs, scripts, and other card assets — are only available in rooms that use PRE or ART formats. Standard rooms cannot use those cards.
 
 To enable all formats and pre-releases, set:
 
 ```env
 YGOPRO_FOLDERS=./resources/ygopro/base,./resources/ygopro/ocg,./resources/ygopro/alternatives
-YGOPRO_EXTRA_DB_FOLDERS=./resources/ygopro/prereleases-cdb,./resources/ygopro/cards-art
+YGOPRO_EXTRA_FOLDERS=./resources/ygopro/prereleases-cdb,./resources/ygopro/cards-art
 ```
 
 ```bash
@@ -176,7 +176,7 @@ YGOPRO_PORT=7711
 HTTP_PORT=7922
 WEBSOCKET_PORT=4000
 YGOPRO_FOLDERS=./resources/ygopro/base,./resources/ygopro/ocg,./resources/ygopro/alternatives
-YGOPRO_EXTRA_DB_FOLDERS=./resources/ygopro/prereleases-cdb,./resources/ygopro/cards-art
+YGOPRO_EXTRA_FOLDERS=./resources/ygopro/prereleases-cdb,./resources/ygopro/cards-art
 ```
 
 ```bash
@@ -194,7 +194,7 @@ The YGOPro engine maintains **two separate card pools** in memory:
 | Pool | Loaded from | Available to |
 |------|-------------|--------------|
 | **Standard** | `YGOPRO_FOLDERS` | All rooms |
-| **Extended** | `YGOPRO_FOLDERS` + `YGOPRO_EXTRA_DB_FOLDERS` | PRE/ART rooms only |
+| **Extended** | `YGOPRO_FOLDERS` + `YGOPRO_EXTRA_FOLDERS` | PRE/ART rooms only |
 
 When a player creates a room with a format like `PRE`, `TCGPRE`, `OCGPRE`, `TCGART`, or `OCGART`, the server uses the **extended** card pool for both deck validation and the duel engine. Standard rooms (`M`, `TCG`, `OT`, `GOAT`, etc.) use only the **standard** pool — any card not in that pool is rejected as unknown.
 
@@ -211,7 +211,7 @@ Both pools are loaded at startup and refreshed every 10 minutes if the underlyin
 | `HTTP_PORT` | HTTP API port | `7922` |
 | `WEBSOCKET_PORT` | WebSocket port | `4000` |
 | `YGOPRO_FOLDERS` | Comma-separated resource directories (standard card pool) | *(empty)* |
-| `YGOPRO_EXTRA_DB_FOLDERS` | Comma-separated extra DB directories (pre-releases, art cards) — only loaded for PRE/ART room formats | *(empty)* |
+| `YGOPRO_EXTRA_FOLDERS` | Comma-separated extra resource directories (cdbs + scripts for pre-releases, art cards) — only loaded for PRE/ART room formats | *(empty)* |
 | `RANK_ENABLED` | Enable ranking system (requires PostgreSQL) | `false` |
 | `POSTGRES_HOST` | PostgreSQL host | `localhost` |
 | `POSTGRES_PORT` | PostgreSQL port | `5432` |

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -58,7 +58,7 @@ services:
       HTTP_PORT: ${HTTP_PORT:-7922}
       WEBSOCKET_PORT: ${WEBSOCKET_PORT:-4000}
       YGOPRO_FOLDERS: ./resources/ygopro/base,./resources/ygopro/ocg,./resources/ygopro/alternatives
-      YGOPRO_EXTRA_DB_FOLDERS: ./resources/ygopro/prereleases-cdb,./resources/ygopro/cards-art
+      YGOPRO_EXTRA_FOLDERS: ./resources/ygopro/prereleases-cdb,./resources/ygopro/cards-art
     ports:
       - "${HOST_PORT:-7911}:${HOST_PORT:-7911}"
       - "${MERCURY_PORT:-7711}:${MERCURY_PORT:-7711}"

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -40,7 +40,7 @@ export const config = {
   resources: {
     ygopro: {
       folders: process.env?.YGOPRO_FOLDERS?.split(",") ?? [],
-      extraDbFolders: process.env?.YGOPRO_EXTRA_DB_FOLDERS?.split(",") ?? [],
+      extraFolders: process.env?.YGOPRO_EXTRA_FOLDERS?.split(",") ?? [],
       extraScripts: process.env?.YGOPRO_EXTRA_SCRIPTS?.split(",") ?? [],
     }
   },

--- a/src/ygopro/AGENTS.md
+++ b/src/ygopro/AGENTS.md
@@ -30,7 +30,7 @@ This module implements the srvpro2-compatible server for YGOPro clients (Koishi,
 
 - `YGOProResourceLoader` (singleton) loads two `CardStorage` instances at startup.
 - **Standard pool** (`YGOPRO_FOLDERS`): Available to all rooms.
-- **Extended pool** (`YGOPRO_FOLDERS` + `YGOPRO_EXTRA_DB_FOLDERS`): Only for PRE/ART formats.
+- **Extended pool** (`YGOPRO_FOLDERS` + `YGOPRO_EXTRA_FOLDERS`): Only for PRE/ART formats.
 - `CardYGOProRepository` resolves the correct pool based on the room's `useExtendedCardPool` flag.
 - Unknown cards return `UnknownCardError` — never silently ignored.
 

--- a/src/ygopro/ocgcore-worker/ocgcore.ts
+++ b/src/ygopro/ocgcore-worker/ocgcore.ts
@@ -150,6 +150,9 @@ export class OCGCore {
     const cardStorage = this.room.useExtendedCardPool
       ? await loader.getExtendedCardStorage()
       : await loader.getStandardCardStorage();
+    const scriptSearchPaths = this.room.useExtendedCardPool
+      ? [...loader.ygoproPaths, ...loader.extraFolderPaths]
+      : loader.ygoproPaths;
     const ocgcoreWasmBinary = await loader.getOcgcoreWasmBinary();
 
     const registry: Record<string, string> = {
@@ -179,7 +182,7 @@ export class OCGCore {
       this.ocgcore = await initWorker(OcgcoreWorker, {
         seed: duelRecord.seed,
         hostinfo: this.room.hostInfo,
-        ygoproPaths: YGOProResourceLoader.get().ygoproPaths,
+        ygoproPaths: scriptSearchPaths,
         extraScriptPaths,
         cardStorage,
         ocgcoreWasmBinary,

--- a/src/ygopro/ygopro/YGOProResourceLoader.ts
+++ b/src/ygopro/ygopro/YGOProResourceLoader.ts
@@ -50,7 +50,7 @@ export class YGOProResourceLoader {
 
   ygoproPaths = config.resources.ygopro.folders;
 
-  extraDbPaths = config.resources.ygopro.extraDbFolders;
+  extraFolderPaths = config.resources.ygopro.extraFolders;
 
   extraScriptPaths = config.resources.ygopro.extraScripts;
 
@@ -66,8 +66,8 @@ export class YGOProResourceLoader {
 
   private reloadTimerRegistered = false;
 
-  get hasExtraDbPaths(): boolean {
-    return this.extraDbPaths.length > 0;
+  get hasExtraFolderPaths(): boolean {
+    return this.extraFolderPaths.length > 0;
   }
 
   async getCardStorage() {
@@ -85,7 +85,7 @@ export class YGOProResourceLoader {
   }
 
   async getExtendedCardStorage(): Promise<CardStorage> {
-    if (!this.hasExtraDbPaths) {
+    if (!this.hasExtraFolderPaths) {
       return this.getStandardCardStorage();
     }
     if (this.extendedCardStorage) {
@@ -114,7 +114,7 @@ export class YGOProResourceLoader {
 
   async loadYGOProCdbs() {
     await this.loadStandardCdbs();
-    if (this.hasExtraDbPaths) {
+    if (this.hasExtraFolderPaths) {
       await this.loadExtendedCdbs();
     }
   }
@@ -144,7 +144,7 @@ export class YGOProResourceLoader {
       return this.extendedLoadingPromise;
     }
     const loading = this.loadingLock.acquire(async () => {
-      const allPaths = [...this.ygoproPaths, ...this.extraDbPaths];
+      const allPaths = [...this.ygoproPaths, ...this.extraFolderPaths];
       const { cardStorage, sha512 } = await this.loadCardStorageFromPaths(allPaths, "extended");
       this.extendedCardStorage = cardStorage;
       this.extendedSha512 = sha512;
@@ -185,8 +185,8 @@ export class YGOProResourceLoader {
       },
     );
 
-    if (this.hasExtraDbPaths) {
-      const allPaths = [...this.ygoproPaths, ...this.extraDbPaths];
+    if (this.hasExtraFolderPaths) {
+      const allPaths = [...this.ygoproPaths, ...this.extraFolderPaths];
       await this.reloadStorageIfChanged(
         allPaths,
         "extended",


### PR DESCRIPTION
## Summary
- Fixes a bug where `.lua` scripts inside extra-pool folders (e.g. `prereleases-cdb/script/`) were never loaded by the ocgcore. Cards from the extended pool showed up in decks but their effects failed silently because the core could not resolve their scripts.
- The ocgcore's `scriptReader` was built only from `YGOPRO_FOLDERS`, never including `extraDbFolders`. Now, whenever a room uses the extended card pool, the merged path list is passed to the worker.
- **Breaking change**: renames `YGOPRO_EXTRA_DB_FOLDERS` → `YGOPRO_EXTRA_FOLDERS`. The `DB` suffix was misleading — those folders contain scripts and other assets, not only card databases. The original name likely led the previous author to load only CDBs.

## Why no backwards-compat shim
We're not dual-reading the old env name. The rename is clean; users must update their `.env`. Deployments also need to update `docker-compose.prod.yaml` (already bumped here).

## Test plan
- [x] `npm test` — 282/282 passing
- [x] `npm run build` — clean
- [x] Manual: create a PRE-format room, draft a deck using a pre-release card, verify the card's effect resolves in-duel (was previously silent).
- [x] Update `.env` on running environments from `YGOPRO_EXTRA_DB_FOLDERS=` to `YGOPRO_EXTRA_FOLDERS=`.