### PR TITLE
fix(ygopro): sort players by position before mapping decks to ocgcore

### DIFF
--- a/src/ygopro/ocgcore-worker/ocgcore.ts
+++ b/src/ygopro/ocgcore-worker/ocgcore.ts
@@ -211,7 +211,11 @@ export class OCGCore {
   private generatePlayers(
     seed: number[],
   ): { name: string; deck: YGOProDeck }[] {
-    const decks = this.room.players.map((_client: YGOProClient) => {
+    const sortedPlayers = [...(this.room.players as YGOProClient[])].sort(
+      (a, b) => a.position - b.position,
+    );
+
+    const decks = sortedPlayers.map((_client) => {
       const deck = _client.deck!;
       const ygoproDeck = new YGOProDeck({
         main: deck.main.map((card) => parseInt(card.code, 10)),
@@ -225,12 +229,10 @@ export class OCGCore {
       ? shuffleDecksBySeed(decks, seed)
       : decks;
 
-    const players = this.room.players.map(
-      (_client: YGOProClient, index: number) => ({
-        name: _client.name,
-        deck: shuffledDecks[index]!,
-      }),
-    );
+    const players = sortedPlayers.map((_client, index) => ({
+      name: _client.name,
+      deck: shuffledDecks[index]!,
+    }));
 
     return players;
   }


### PR DESCRIPTION
## Summary
Fixes a tag-mode bug where players could not see their own hand and were unable to play — but only when someone had moved slots before the duel started.

Root cause: `_players` is an append-only array (ordered by join time). `movePlayerToAnotherCellUnsafe` updates `client.position` but never reorders the array. `generatePlayers()` was using the array index as the ocgcore slot index, so e.g. a client at `_players[1]` with `position=3` would have their deck loaded into ocgcore slot 1 — not slot 3 where they are actually sitting. Each affected player ended up seeing the opponent's hand.

Fix: sort `_players` by `position` before generating decks, so `shuffledDecks[index]` corresponds to the client at position `index`. Localized change in `generatePlayers()`; other consumers of `this.room.players` already use `.find()` / `.filter()` by client properties and are not affected.

## Why this only broke with slot changes
When no player moves, `_players[i].position === i` trivially holds and the bad index-based mapping happens to be correct. The bug is silent until the first slot change.

## Test plan
- [x] `npm test` — 282/282 passing
- [x] `npm run build` — clean
- [x] Manual: 4-player tag room, one player moves slot via `to-duel`, start the duel and verify each player sees their own hand and can play.
- [ ] Regression: single-mode duel still works (trivial since only one slot per team).