### PR TITLE
fix(ygopro): broadcast slot change to all clients in movePlayerToAnotherCellUnsafe

### DIFF
--- a/src/ygopro/room/domain/YGOProRoom.ts
+++ b/src/ygopro/room/domain/YGOProRoom.ts
@@ -535,20 +535,21 @@ export class YGOProRoom extends YgoRoom {
     if (!nextPlace) {
       return;
     }
+    const oldPosition = player.position;
     player.notReady();
-    player.sendMessageToClient(
+    this.broadcastToAll(
       this._messageRepository.playerChangeMessage(
-        player.position,
+        oldPosition,
         nextPlace.position,
       ),
     );
-    player.sendMessageToClient(
+    player.playerPosition(nextPlace.position, nextPlace.team);
+    this.broadcastToAll(
       this._messageRepository.playerChangeMessage(
         player.position,
         PlayerChangeState.NOTREADY,
       ),
     );
-    player.playerPosition(nextPlace.position, nextPlace.team);
     player.sendMessageToClient(
       this._messageRepository.typeChangeMessage(player.position, player.host),
     );


### PR DESCRIPTION
## Summary
When a player changes cells in the waiting room (`to-duel`), the `playerChangeMessage` events were sent only to the moving player — every other client in the room never saw the slot change. In a tag room, when A3 moved from slot 2 to slot 3, A1 and A2 kept rendering A3 at the old slot.

This was inconsistent with `playerToSpectatorUnsafe` and `spectatorToPlayerUnsafe` in the same class, which both broadcast the same message type to everyone.

Also fixed a latent off-by-one: the second `playerChangeMessage` (the NOTREADY marker) was using the old `player.position` because `playerPosition()` had not been called yet. Reordered so the NOTREADY message carries the new slot.

`typeChangeMessage` remains a direct message to the moving player — that one carries personal type info the rest of the room does not need.

## Test plan
- [x] `npm test` — 282/282 passing
- [x] `npm run build` — clean
- [x] Manual: open a tag room, have A1/A2/A3 join, move A3 from slot 2 to slot 3 via `to-duel`, verify A1 and A2 see A3 at the new slot.
- [ ] Regression: spectator→player and player→spectator flows still broadcast correctly.