### PR TITLE
feat(api): add GET /api/rooms endpoint with display-ready DTO

### DIFF
--- a/docs/api/add-command-field.md
+++ b/docs/api/add-command-field.md
@@ -1,0 +1,53 @@
+# Add `command` field to `GET /api/rooms`
+
+## What
+
+Add a `command` string field to each room in the `GET /api/rooms` response.
+
+## Why
+
+The Evolution client needs the room's command string to join via WebSocket.
+The join protocol (`CTOS_JOIN_GAME`) requires the room name as the `pass` field.
+Without `command`, the client has no way to join a room from the browser.
+
+## Source
+
+```typescript
+// YGOProRoom already has this as a public readonly field:
+YGOProRoom.name  // e.g. "M,tcg,lp8000,tm5"
+```
+
+This is the command string that created the room, **without** the `#password` suffix.
+It's already stripped of the password during room creation.
+
+## Change
+
+In the `toRoomListDTO()` method (or wherever the room list response is built),
+add one field:
+
+```typescript
+{
+  id: this.id,
+  command: this.name,   // <-- ADD THIS LINE
+  status: ...,
+  // ... rest of fields
+}
+```
+
+## Response example (before → after)
+
+```diff
+ {
+   "id": 7659,
++  "command": "M,tcg,lp8000",
+   "status": "waiting",
+   "started": false,
+   ...
+ }
+```
+
+## Security
+
+`command` does NOT contain the password. The password portion after `#` is
+stripped during `YGOProRoom.create()` and stored separately in `YGOProRoom.password`
+(which is never exposed in any API response).

--- a/docs/api/room-list-spec.md
+++ b/docs/api/room-list-spec.md
@@ -1,0 +1,171 @@
+# Room List API — Specification
+
+## Context
+
+Evolution's client Room Browser needs to list Mercury rooms with all labels
+pre-resolved by the server. The client only renders — no mapping, no lookups.
+
+---
+
+## Endpoint
+
+```
+GET /api/rooms
+```
+
+### Query Parameters (all optional)
+
+| Param    | Type   | Default | Description |
+|----------|--------|---------|-------------|
+| `status` | `string` | —     | Comma-separated: `waiting`, `dueling`, `rps`, `choosingOrder`, `sideDecking` |
+| `open`   | `bool`   | —     | `true` = no password only, `false` = password only |
+| `mode`   | `number` | —     | `0` Single, `1` Match, `2` Tag |
+
+No params → all Mercury rooms.
+
+---
+
+### Response
+
+```jsonc
+{
+  "rooms": [
+    {
+      "id":         1234,
+      "command":    "M,tcg,lp8000",  // join key — pass this as CTOS_JOIN_GAME.pass (not displayed)
+      "status":     "waiting",       // DuelState value
+      "started":    false,           // false=waiting, true=any other state
+      "private":    false,
+      "canPlay":    true,            // waiting AND open slots
+      "canWatch":   true,            // always true
+
+      "banlist":    "2026.04 TCG",   // resolved name from BanList.name (via hash lookup)
+      "rule":       "TCG",           // resolved label: "OCG" | "TCG" | "OCG/TCG" | "Pre-release" | "Anything Goes"
+
+      "mode":       0,               // 0=Single, 1=Match, 2=Tag
+      "bestOf":     1,
+      "duelRule":   5,               // Master Rule 1-5
+      "startLp":    8000,
+      "timeLimit":  180,
+
+      "players": [
+        { "name": "DarkMagician", "position": 0, "team": 0 },
+        { "name": "BlueEyes99",  "position": 1, "team": 1 }
+      ],
+      "maxPlayers": 2,
+      "spectators": 0
+    }
+  ]
+}
+```
+
+---
+
+### Field Reference
+
+| Field       | Type      | Source | Description |
+|-------------|-----------|--------|-------------|
+| `id`        | `number`  | `YgoRoom.id` | Room ID |
+| `command`   | `string`  | `YGOProRoom.name` | Join key — client sends this as `CTOS_JOIN_GAME.pass`. Not displayed in UI. |
+| `status`    | `string`  | `YgoRoom.duelState` | Granular lifecycle state |
+| `started`   | `boolean` | computed | `duelState !== "waiting"` — quick filter for UI |
+| `private`   | `boolean` | `password.length > 0` | Password required |
+| `canPlay`   | `boolean` | computed | `!started && players.length < maxPlayers` |
+| `canWatch`  | `boolean` | computed | Always `true` |
+| `banlist`   | `string`  | `BanListRepo.findByHash(hash).name` | Human-readable banlist name |
+| `rule`      | `string`  | resolved from `HostInfo.rule` numeric | `"OCG"`, `"TCG"`, `"OCG/TCG"`, `"Pre-release"`, `"Anything Goes"` |
+| `mode`      | `number`  | `HostInfo.mode` | `0`=Single, `1`=Match, `2`=Tag |
+| `bestOf`    | `number`  | `YgoRoom.bestOf` | Match count |
+| `duelRule`  | `number`  | `HostInfo.duel_rule` | Master Rule version |
+| `startLp`   | `number`  | `HostInfo.start_lp` | Starting LP |
+| `timeLimit` | `number`  | `HostInfo.time_limit` | Seconds per turn |
+| `players`   | `array`   | `YgoRoom._players` | Player list |
+| `maxPlayers`| `number`  | `team0 + team1` | Total player slots |
+| `spectators`| `number`  | `YgoRoom._spectators.length` | Spectator count |
+
+#### `players[]`
+
+| Field      | Type     | Source |
+|------------|----------|--------|
+| `name`     | `string` | `YgoClient.name` (null bytes stripped) |
+| `position` | `number` | `YgoClient.position` |
+| `team`     | `number` | `YgoClient.team` (0 or 1) |
+
+#### Rule label resolution (server-side)
+
+```
+0 → "OCG"
+1 → "TCG"
+2 → "OCG/TCG"
+3 → "Pre-release"
+4 → "Anything Goes"
+5 → "Anything Goes"
+```
+
+#### Banlist name resolution (server-side)
+
+```typescript
+YGOProBanListMemoryRepository.findByHash(room.banListHash)?.name ?? "No banlist"
+```
+
+---
+
+## Implementation
+
+### Server
+
+1. **New controller**: `src/http-server/controllers/RoomListController.ts`
+   - `YGOProRoomList.getRooms()` → filter by query params → map `toRoomListDTO()`
+
+2. **New route**: `GET /api/rooms` in routes
+
+3. **`toRoomListDTO()` on `YGOProRoom`** — builds the response shape, resolves:
+   - `banlist`: lookup `BanListMemoryRepository.findByHash(hash).name`
+   - `rule`: map numeric → string label
+   - `started`: `duelState !== DuelState.WAITING`
+   - `canPlay`: `!started && players.length < maxPlayers`
+   - `canWatch`: `true`
+
+### Data available (no model changes)
+
+| Need | Source |
+|------|--------|
+| `duelState` | `YgoRoom.duelState` |
+| `team0/team1` | `YgoRoom.team0/team1` |
+| `players` with position, team | `YgoRoom._players` → `YgoClient` |
+| `spectators.length` | `YgoRoom._spectators` |
+| `password` | `YGOProRoom.password` |
+| `HostInfo` fields | `YGOProRoom._hostInfo` |
+| `banListHash` | `YGOProRoom._edoBanListHash ?? banListHash` |
+| BanList name lookup | `YGOProBanListMemoryRepository.findByHash()` |
+
+### Security
+
+- Passwords NEVER in response
+- Player IPs NEVER in response
+
+---
+
+## Client Usage
+
+1. `GET /api/rooms` — all rooms, or `?status=waiting` for joinable only
+2. Render room list — data is display-ready, no mapping needed
+3. User clicks room:
+   - `canPlay` → **Join** button
+   - `canWatch` (and `started`) → **Spectate** button
+   - `private` → prompt password first
+4. Connect WebSocket → `CTOS_PLAYER_INFO` + `CTOS_JOIN_GAME`
+
+---
+
+## DuelState Reference
+
+| Value            | `started` | `canPlay`        | `canWatch` |
+|------------------|-----------|------------------|------------|
+| `waiting`        | `false`   | if slots open    | Yes |
+| `rps`            | `true`    | No               | Yes |
+| `choosingOrder`  | `true`    | No               | Yes |
+| `dueling`        | `true`    | No               | Yes |
+| `sideDecking`    | `true`    | No               | Yes |
+
+Joining a `started` room → server assigns spectator role automatically.

--- a/src/http-server/controllers/RoomListController.ts
+++ b/src/http-server/controllers/RoomListController.ts
@@ -1,0 +1,34 @@
+import { Request, Response } from "express";
+
+import YGOProRoomList from "@ygopro/room/infrastructure/YGOProRoomList";
+
+export class RoomListController {
+	run(req: Request, res: Response): void {
+		let rooms = YGOProRoomList.getRooms();
+
+		const { status, open, mode } = req.query;
+
+		if (typeof status === "string") {
+			const allowed = new Set(status.split(",").map((s) => s.trim()));
+			rooms = rooms.filter((room) => allowed.has(room.duelState));
+		}
+
+		if (typeof open === "string") {
+			const isOpen = open === "true";
+			rooms = rooms.filter((room) =>
+				isOpen ? room.password.length === 0 : room.password.length > 0,
+			);
+		}
+
+		if (typeof mode === "string") {
+			const modeNum = Number(mode);
+			if (!Number.isNaN(modeNum)) {
+				rooms = rooms.filter((room) => room.hostInfo.mode === modeNum);
+			}
+		}
+
+		res.status(200).json({
+			rooms: rooms.map((room) => room.toRoomListDTO()),
+		});
+	}
+}

--- a/src/http-server/routes/index.ts
+++ b/src/http-server/routes/index.ts
@@ -5,11 +5,14 @@ import { Express } from "express";
 import { Logger } from "../../shared/logger/domain/Logger";
 import { CreateRoomController } from "../controllers/CreateRoomController";
 import { GetRoomListController } from "../controllers/GetRoomListController";
+import { RoomListController } from "../controllers/RoomListController";
 import { ServerMessagesController } from "../controllers/ServerMessagesController";
 import { AuthAdminMiddleware } from "../middlewares/AuthAdminMiddleware";
 
 export function loadRoutes(app: Express, logger: Logger): void {
 	app.get("/api/getrooms", (req, res) => new GetRoomListController().run(req, res));
+
+	app.get("/api/rooms", (req, res) => new RoomListController().run(req, res));
 
 	app.post("/api/room", (req, res) => new CreateRoomController(logger).run(req, res));
 

--- a/src/ygopro/room/domain/YGOProRoom.ts
+++ b/src/ygopro/room/domain/YGOProRoom.ts
@@ -717,6 +717,45 @@ export class YGOProRoom extends YgoRoom {
     };
   }
 
+  toRoomListDTO(): { [key: string]: unknown } {
+    const RULE_LABELS: Record<number, string> = {
+      0: "OCG",
+      1: "TCG",
+      2: "OCG/TCG",
+      3: "Pre-release",
+      4: "Anything Goes",
+      5: "Anything Goes",
+    };
+
+    const started = this.duelState !== DuelState.WAITING;
+    const maxPlayers = this.team0 + this.team1;
+    const banList = MercuryBanListMemoryRepository.findByHash(this.banListHash);
+
+    return {
+      id: this.id,
+      command: this.name,
+      status: this.duelState,
+      started,
+      private: this.password.length > 0,
+      canPlay: !started && this._players.length < maxPlayers,
+      canWatch: true,
+      banlist: banList?.name ?? "No banlist",
+      rule: RULE_LABELS[this._hostInfo.rule] ?? "Anything Goes",
+      mode: this._hostInfo.mode,
+      bestOf: this.bestOf,
+      duelRule: this._hostInfo.duel_rule,
+      startLp: this._hostInfo.start_lp,
+      timeLimit: this._hostInfo.time_limit,
+      players: this._players.map((player) => ({
+        name: player.name.replace(/\0/g, "").trim(),
+        position: player.position,
+        team: player.team,
+      })),
+      maxPlayers,
+      spectators: this._spectators.length,
+    };
+  }
+
   destroy(): void {
     this.emitter.removeAllListeners();
     this._roomState?.removeAllListener();


### PR DESCRIPTION
## Summary
- New `GET /api/rooms` endpoint returning Mercury rooms with all labels pre-resolved (banlist name, rule label, computed `started`/`canPlay`/`private` flags)
- Adds `toRoomListDTO()` on `YGOProRoom` — client Room Browser gets display-ready data, no mapping needed
- Query filters: `status`, `open`, `mode`
- Spec docs under `docs/api/`

## Test plan
- [x] `GET /api/rooms` returns array with expected fields
- [x] `?status=WAITING` filters by duel state
- [x] `?open=true` returns only rooms without password
- [x] `?mode=1` filters by game mode
- [x] Existing `GET /api/getrooms` still works (untouched)