### PR TITLE
feat(ygopro): add WebSocket server for YGOPro clients

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -28,6 +28,7 @@ export const config = {
     },
     mercury: {
       port: Number(process.env.YGOPRO_PORT),
+      wsPort: Number(process.env.YGOPRO_WEBSOCKET_PORT) || 4002,
     },
     http: {
       port: Number(process.env.HTTP_PORT),

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { YGOProResourceLoader } from "./ygopro/ygopro/YGOProResourceLoader";
 import { HostServer } from "./socket-server/HostServer";
 import { WSHostServer } from "./socket-server/WSHostServer";
 import { YGOProServer } from "./socket-server/YGOProServer";
+import { WSYGOProServer } from "./socket-server/WSYGOProServer";
 import WebSocketSingleton from "./web-socket-server/WebSocketSingleton";
 
 void start();
@@ -23,6 +24,7 @@ async function start(): Promise<void> {
 
   const server = new Server(logger);
   const ygoproServer = new YGOProServer(logger);
+  const wsYgoproServer = new WSYGOProServer(logger);
 
   const hostServer = new HostServer(logger);
   const wsHostServer = new WSHostServer(logger);
@@ -50,4 +52,5 @@ async function start(): Promise<void> {
   hostServer.initialize();
   wsHostServer.initialize();
   ygoproServer.initialize();
+  wsYgoproServer.initialize();
 }

--- a/src/socket-server/WSYGOProServer.ts
+++ b/src/socket-server/WSYGOProServer.ts
@@ -1,0 +1,92 @@
+import { randomUUID as uuidv4 } from "crypto";
+import { createServer } from "http";
+import { WebSocketServer, WebSocket } from "ws";
+import { config } from "src/config";
+import { CheckIfUseCanJoin } from "src/shared/user-auth/application/CheckIfUserCanJoin";
+import { UserAuth } from "src/shared/user-auth/application/UserAuth";
+import { UserProfilePostgresRepository } from "src/shared/user-profile/infrastructure/postgres/UserProfilePostgresRepository";
+import { EventEmitter } from "stream";
+
+import { MessageEmitter } from "../edopro/MessageEmitter";
+import { Logger } from "../shared/logger/domain/Logger";
+import { DisconnectHandler } from "../shared/room/application/DisconnectHandler";
+import { RoomFinder } from "../shared/room/application/RoomFinder";
+import { WebSocketClientSocket } from "../shared/socket/domain/WebSocketClientSocket";
+import { YGOProGameCreatorHandler } from "@ygopro/room/application/YGOProGameCreatorHandler";
+import { YGOProJoinHandler } from "@ygopro/room/application/YGOProJoinHandler";
+import { YGOProMessageRepository } from "@ygopro/room/infrastructure/YGOProMessageRepository";
+
+export class WSYGOProServer {
+	private readonly wss: WebSocketServer;
+	private readonly logger: Logger;
+	private readonly roomFinder: RoomFinder;
+	private readonly userAuth: UserAuth;
+	private readonly checkIfUserCanJoin: CheckIfUseCanJoin;
+
+	constructor(logger: Logger) {
+		this.logger = logger;
+		this.roomFinder = new RoomFinder();
+		const server = createServer();
+		this.wss = new WebSocketServer({ server });
+		this.userAuth = new UserAuth(new UserProfilePostgresRepository());
+		this.checkIfUserCanJoin = new CheckIfUseCanJoin(this.userAuth);
+	}
+
+	initialize(): void {
+		const port = config.servers.mercury.wsPort;
+
+		this.wss.options.server?.listen(port, () => {
+			this.logger.info(`Mercury WebSocket Server listen in port ${port}`);
+		});
+
+		this.wss.on("connection", (socket: WebSocket) => {
+			const ygoClientSocket = new WebSocketClientSocket(socket);
+			const eventEmitter = new EventEmitter();
+			const messageRepository = new YGOProMessageRepository();
+			const address = ygoClientSocket.remoteAddress;
+
+			ygoClientSocket.id = uuidv4();
+
+			const connectionLogger = this.logger.child({
+				file: "MercuryWSServer",
+				socketId: ygoClientSocket.id,
+				remoteAddress: address,
+			});
+
+			connectionLogger.info("Client connected via WebSocket");
+
+			const createGameListener = () => {
+				new YGOProGameCreatorHandler(eventEmitter, connectionLogger, messageRepository);
+			};
+			const joinGameListener = () => {
+				new YGOProJoinHandler(
+					eventEmitter,
+					connectionLogger,
+					ygoClientSocket,
+					this.checkIfUserCanJoin,
+					messageRepository,
+				);
+			};
+
+			const messageEmitter = new MessageEmitter(
+				connectionLogger,
+				eventEmitter,
+				createGameListener,
+				joinGameListener,
+			);
+
+			ygoClientSocket.onMessage((data: Buffer) => {
+				connectionLogger.debug(
+					`Incoming message handle by Mercury WS Server: ${data.toString("hex")}`,
+				);
+				messageEmitter.handleMessage(data);
+			});
+
+			ygoClientSocket.onClose(() => {
+				connectionLogger.info("Client left via WebSocket close event");
+				const disconnectHandler = new DisconnectHandler(ygoClientSocket, this.roomFinder);
+				disconnectHandler.run(address);
+			});
+		});
+	}
+}


### PR DESCRIPTION
## Summary
- New `WSYGOProServer` that exposes YGOPro protocol over WebSocket (port from `YGOPRO_WEBSOCKET_PORT`, default `4002`)
- Reuses existing handlers (`YGOProJoinHandler`, `YGOProGameCreatorHandler`, `DisconnectHandler`) through `WebSocketClientSocket` adapter
- Wired up in `src/index.ts` alongside the existing TCP `YGOProServer`
- Adds `config.ygopro.mercury.wsPort`

## Test plan
- [x] Connect a WS client to `ws://host:4002` and send a JOIN message
- [x] Existing TCP YGOPro clients keep working on their port
- [x] Disconnect cleans up room state