### PR TITLE
fix(ygopro): reject join with wrong password instead of creating duplicate room

### DIFF
--- a/src/ygopro/room/application/YGOProJoinHandler.ts
+++ b/src/ygopro/room/application/YGOProJoinHandler.ts
@@ -49,11 +49,22 @@ export class YGOProJoinHandler implements JoinMessageHandler {
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
 		const joinMessage = new YGOProCtosJoinGame().fromPayload(message.data);
 
-		const room = this.createRoomIfNotExists(
+		const [command, password = ""] = joinMessage.pass.split("#");
+
+		const room = this.findOrCreateRoom(
+			command,
+			password,
 			joinMessage.pass,
 			playerInfoMessage,
 			this.socket.id as string
 		);
+
+		if (!room) {
+			this.logger.info("JOIN_GAME rejected: wrong password");
+			this.socket.destroy();
+
+			return;
+		}
 
 		if (room.ranked && !(await this.checkIfUserCanJoin.check(playerInfoMessage, this.socket))) {
 			return;
@@ -62,28 +73,34 @@ export class YGOProJoinHandler implements JoinMessageHandler {
 		room.emit("JOIN", message, this.socket);
 	}
 
-	private createRoomIfNotExists(
-		name: string,
+	private findOrCreateRoom(
+		command: string,
+		password: string,
+		fullPass: string,
 		playerInfo: PlayerInfoMessage,
 		socketId: string
-	): YGOProRoom {
-		const existingRoom = YGOProRoomList.findByName(name);
-		if (!existingRoom) {
-			const room = YGOProRoom.create(
-				generateUniqueId(),
-				name,
-				this.logger,
-				this.eventEmitter,
-				playerInfo,
-				socketId,
-				this.messageRepository,
-			);
-			YGOProRoomList.addRoom(room);
-			room.waiting();
+	): YGOProRoom | null {
+		const existingRoom = YGOProRoomList.findByName(command);
+		if (existingRoom) {
+			if (existingRoom.password !== password) {
+				return null;
+			}
 
-			return room;
+			return existingRoom;
 		}
 
-		return existingRoom;
+		const room = YGOProRoom.create(
+			generateUniqueId(),
+			fullPass,
+			this.logger,
+			this.eventEmitter,
+			playerInfo,
+			socketId,
+			this.messageRepository,
+		);
+		YGOProRoomList.addRoom(room);
+		room.waiting();
+
+		return room;
 	}
 }

--- a/src/ygopro/room/domain/YGOProRoom.ts
+++ b/src/ygopro/room/domain/YGOProRoom.ts
@@ -156,7 +156,7 @@ export class YGOProRoom extends YgoRoom {
       best_of: BEST_OF[GameMode.SINGLE],
     };
 
-    const [configuration, password] = command.split("#");
+    const [configuration, password = ""] = command.split("#");
     const options = configuration
       .toLowerCase()
       .split(",")
@@ -221,7 +221,7 @@ export class YGOProRoom extends YgoRoom {
     const room = new YGOProRoom({
       id,
       hostInfo,
-      name: command,
+      name: configuration,
       password,
       team0: teamCount,
       team1: teamCount,


### PR DESCRIPTION
## Summary
Before this fix, the room name was stored as the full join command (`config#password`), so `YGOProRoomList.findByName(joinMessage.pass)` only matched when the joining client typed the exact same password. A wrong password would miss the lookup and silently **create a brand new room** with the bad password as its name.

Now:
- `YGOProRoom.name` stores only the configuration part (no `#password`)
- `YGOProJoinHandler` splits `command#password`, finds the room by `command`, and:
  - if password doesn't match → destroys the socket (rejects join)
  - if room doesn't exist → creates it
- `password = ""` default makes rooms without `#` behave correctly

## Test plan
- [x] Join existing room with correct password → works
- [x] Join existing room with wrong password → socket disconnected, no new room created
- [x] Join non-existent room → new room created as today
- [x] Room name in lobby UI no longer leaks the password