### PR TITLE
fix(ygopro): persist responses in DuelRecord and fix replay hint token format

### DIFF
--- a/src/ygopro/room/domain/states/YGOProDuelingState.ts
+++ b/src/ygopro/room/domain/states/YGOProDuelingState.ts
@@ -307,6 +307,8 @@ export class YGOProDuelingState extends RoomState {
     const responseRequestMsg = this.ocgCore.currentLastResponseRequestMsg;
     const responseBuffer = Buffer.from(message.data);
 
+    room.currentDuelRecord?.responses.push(responseBuffer);
+
     // Handle time limit compensation
     if (this.ocgCore.timeLimitEnabled) {
       this.ocgCore.clearResponseTimerState(true);
@@ -576,7 +578,7 @@ export class YGOProDuelingState extends RoomState {
   ): void {
     const hintMsg = new YGOProStocChat().fromPartial({
       player_type: 0,
-      msg: `#replay_hint_part1${index}#replay_hint_part2`,
+      msg: `#{replay_hint_part1}${index}#{replay_hint_part2}`,
     });
     const hintBuffer = Buffer.from(hintMsg.toFullPayload());
 


### PR DESCRIPTION
## Summary

Two bugs in YGOPro replay generation, confirmed by comparing against srvpro2 reference.

- **CRITICAL** — `YGOProDuelingState.handleResponse` never pushed `responseBuffer` into `room.currentDuelRecord.responses`. `DuelRecord.toYrp` serialized an empty responses array, so emitted YRP files had zero player decisions and were unplayable. Added the push before `setResponse`, mirroring srvpro2 `Room.onResponse` (`src/room/room.ts:2084`). Position chosen so the existing retry `pop()` at `ocgcore.ts:1173` stays balanced.
- **Hint format** — chat hint used bare `#replay_hint_part1${index}#replay_hint_part2`. Client localization parser expects `#{key}` with curly braces (verified across srvpro2 — `room.ts:510`, `cloud-replay-service`, `room-death-service`, `windbot-provider`, etc.). Without braces the token cannot resolve. Updated to `#{replay_hint_part1}${index}#{replay_hint_part2}`.

Index is already 1-based (caller at `:552` passes `i + 1`), so no off-by-one introduced.

## Out of scope

- srvpro2 sends the hint with `BABYBLUE` color via `client.sendChat`. Our `YGOProStocChat` doesn't set `player_type` for color — needs protocol verification before changing.

## Test plan

- [ ] Play a full duel through a YGOPro client, finish it, request replay
- [ ] Verify the YRP file plays back deterministically in the client
- [ ] Verify the hint chat shows localized "Sending the replay of the duel number N." (or the matching localization) instead of the literal `#replay_hint_part1...` string
- [ ] Verify retry flow still works (timed-out / retry response) — `pop()` should remove the last pushed response cleanly