### PR TITLE
feat(tokens): add kind discriminator to TokenIndex

### DIFF
--- a/src/edopro/room/application/ExpressReconnectHandler.ts
+++ b/src/edopro/room/application/ExpressReconnectHandler.ts
@@ -24,7 +24,7 @@ export class ExpressReconnectHandler {
 		const token = message.data.toString("utf8");
 		this.logger.info(`Checking token: ${token}`);
 
-		const entry = TokenIndex.getInstance().find(token);
+		const entry = TokenIndex.getInstance().find(token, "reconnect");
 		if (entry && entry.client instanceof Client) {
 			const player = entry.client as Client;
 			this.logger.info(`MATCH! Found player ${player.name} in room ${entry.roomId}`);

--- a/src/edopro/room/domain/states/dueling/DuelingState.ts
+++ b/src/edopro/room/domain/states/dueling/DuelingState.ts
@@ -224,7 +224,7 @@ export class DuelingState extends RoomState {
 			item.socket.send(ServerMessageClientMessage.create(ServerInfoMessage.STARTING_DUEL));
 			const reconnectionToken = crypto.randomBytes(16).toString("hex");
 			item.setReconnectionToken(reconnectionToken);
-			TokenIndex.getInstance().register(reconnectionToken, item, this.room.id);
+			TokenIndex.getInstance().register(reconnectionToken, item, this.room.id, "reconnect");
 			item.socket.send(ReconnectionTokenClientMessage.create(reconnectionToken));
 		});
 
@@ -423,13 +423,13 @@ export class DuelingState extends RoomState {
 		player.clearReconnecting();
 		player.clearReconnectionToken();
 		if (oldToken) {
-			TokenIndex.getInstance().unregister(oldToken);
+			TokenIndex.getInstance().unregister(oldToken, "reconnect");
 		}
 
 		// Generate new token for future reconnections
 		const newToken = crypto.randomBytes(16).toString("hex");
 		player.setReconnectionToken(newToken);
-		TokenIndex.getInstance().register(newToken, player, this.room.id);
+		TokenIndex.getInstance().register(newToken, player, this.room.id, "reconnect");
 		player.sendMessage(ReconnectionTokenClientMessage.create(newToken));
 
 		if (player.cache) {
@@ -658,7 +658,7 @@ export class DuelingState extends RoomState {
 		const token = message.data.toString("utf8");
 		this.logger.info(`DUELING_STATE: Token received: ${token}`);
 
-		const entry = TokenIndex.getInstance().find(token);
+		const entry = TokenIndex.getInstance().find(token, "reconnect");
 		if (!entry || !(entry.client instanceof Client) || entry.roomId !== room.id) {
 			this.logger.info(`DUELING_STATE: Player not found for token ${token} or room mismatch`);
 			const type = Buffer.from([0xfd]);

--- a/src/edopro/room/domain/states/side-decking/SideDeckingState.ts
+++ b/src/edopro/room/domain/states/side-decking/SideDeckingState.ts
@@ -64,7 +64,7 @@ export class SideDeckingState extends RoomState {
 		this.logger.info("SIDE_DECKING: EXPRESS_RECONNECT - START");
 		const token = message.data.toString("utf8");
 
-		const entry = TokenIndex.getInstance().find(token);
+		const entry = TokenIndex.getInstance().find(token, "reconnect");
 		if (!entry || !(entry.client instanceof Client) || entry.roomId !== room.id) {
 			this.logger.info(`SIDE_DECKING: Player not found for token ${token} or room mismatch`);
 			const type = Buffer.from([0xfd]);
@@ -97,13 +97,13 @@ export class SideDeckingState extends RoomState {
 
 		const oldToken = player.reconnectionToken;
 		if (oldToken) {
-			TokenIndex.getInstance().unregister(oldToken);
+			TokenIndex.getInstance().unregister(oldToken, "reconnect");
 		}
 
 		// Renew token
 		const newToken = crypto.randomBytes(16).toString("hex");
 		player.setReconnectionToken(newToken);
-		TokenIndex.getInstance().register(newToken, player, room.id);
+		TokenIndex.getInstance().register(newToken, player, room.id, "reconnect");
 		player.sendMessage(ReconnectionTokenClientMessage.create(newToken));
 
 		player.clearReconnecting();

--- a/src/shared/room/domain/TokenIndex.test.ts
+++ b/src/shared/room/domain/TokenIndex.test.ts
@@ -1,0 +1,207 @@
+import { TokenIndex } from "./TokenIndex";
+import { YgoClient } from "../../client/domain/YgoClient";
+
+// Minimal stub for YgoClient (abstract class) — no socket needed for pure domain tests
+function makeClient(name = "player"): YgoClient {
+	return {
+		id: "1",
+		name,
+		position: 0,
+		team: 0,
+		host: false,
+		isSpectator: false,
+		isReady: false,
+		isReconnecting: false,
+		reconnectionToken: null,
+	} as unknown as YgoClient;
+}
+
+describe("TokenIndex", () => {
+	let index: TokenIndex;
+
+	beforeEach(() => {
+		// Create a fresh instance for each test — bypassing the singleton for isolation
+		index = TokenIndex.createForTests();
+	});
+
+	describe("register / find (back-compat reconnect path)", () => {
+		it("register without kind defaults to reconnect", () => {
+			const client = makeClient();
+			index.register("tok1", client, 10);
+			const entry = index.find("tok1", "reconnect");
+			expect(entry).toBeDefined();
+			expect(entry?.kind).toBe("reconnect");
+			expect(entry?.roomId).toBe(10);
+		});
+
+		it("register with explicit kind='reconnect' stores reconnect entry", () => {
+			const client = makeClient();
+			index.register("tok2", client, 20, "reconnect");
+			const entry = index.find("tok2", "reconnect");
+			expect(entry).toBeDefined();
+			expect(entry?.kind).toBe("reconnect");
+		});
+
+		it("find without kind returns entry regardless of kind", () => {
+			const client = makeClient();
+			index.register("tok3", client, 30);
+			const entry = index.find("tok3");
+			expect(entry).toBeDefined();
+		});
+
+		it("find with wrong kind returns undefined", () => {
+			const client = makeClient();
+			index.register("tok4", client, 40);
+			const entry = index.find("tok4", "windbot");
+			expect(entry).toBeUndefined();
+		});
+	});
+
+	describe("registerWindbot", () => {
+		it("stores botInfo and kind=windbot", () => {
+			index.registerWindbot("wtok1", 99, { name: "Anna", deck: "Anna.ydk" });
+			const entry = index.find("wtok1", "windbot");
+			expect(entry).toBeDefined();
+			expect(entry?.kind).toBe("windbot");
+			expect(entry?.roomId).toBe(99);
+			// Cast after the kind assertion above confirms the discriminant
+			const windBotEntry = entry as Extract<typeof entry, { kind: "windbot" }>;
+			expect(windBotEntry?.botInfo).toEqual({ name: "Anna", deck: "Anna.ydk" });
+			expect(windBotEntry?.client).toBeNull();
+		});
+
+		it("windbot token is NOT findable as reconnect", () => {
+			index.registerWindbot("wtok2", 99, { name: "Anna", deck: "Anna.ydk" });
+			const entry = index.find("wtok2", "reconnect");
+			expect(entry).toBeUndefined();
+		});
+
+		it("reconnect token is NOT findable as windbot", () => {
+			const client = makeClient();
+			index.register("rtok1", client, 50);
+			const entry = index.find("rtok1", "windbot");
+			expect(entry).toBeUndefined();
+		});
+	});
+
+	describe("consume (atomic find + delete)", () => {
+		it("consume with correct kind returns entry and removes it", () => {
+			index.registerWindbot("wtok3", 10, { name: "Bob", deck: "Bob.ydk" });
+			const result = index.consume("wtok3", "windbot");
+			expect(result).toBeDefined();
+			expect(result?.kind).toBe("windbot");
+			// Second consume must return undefined (one-shot)
+			const again = index.consume("wtok3", "windbot");
+			expect(again).toBeUndefined();
+		});
+
+		it("windbot token is not consumable as reconnect — entry remains", () => {
+			index.registerWindbot("wtok4", 11, { name: "Bob", deck: "Bob.ydk" });
+			const result = index.consume("wtok4", "reconnect");
+			expect(result).toBeUndefined();
+			// Entry still present
+			const stillThere = index.find("wtok4", "windbot");
+			expect(stillThere).toBeDefined();
+		});
+
+		it("reconnect token is not consumable as windbot — entry remains", () => {
+			const client = makeClient();
+			index.register("rtok2", client, 60);
+			const result = index.consume("rtok2", "windbot");
+			expect(result).toBeUndefined();
+			// Entry still present
+			const stillThere = index.find("rtok2", "reconnect");
+			expect(stillThere).toBeDefined();
+		});
+
+		it("consume on missing token returns undefined", () => {
+			const result = index.consume("nonexistent", "windbot");
+			expect(result).toBeUndefined();
+		});
+
+		it("reconnect token consumed with correct kind is removed (one-shot)", () => {
+			const client = makeClient();
+			index.register("rtok3", client, 70);
+			const result = index.consume("rtok3", "reconnect");
+			expect(result).toBeDefined();
+			expect(result?.kind).toBe("reconnect");
+			const again = index.consume("rtok3", "reconnect");
+			expect(again).toBeUndefined();
+		});
+	});
+
+	describe("clearByRoom", () => {
+		it("clears only windbot tokens for the given roomId", () => {
+			const client = makeClient();
+			index.register("rtok-room1", client, 1);
+			index.registerWindbot("wtok-room1a", 1, { name: "A", deck: "a.ydk" });
+			index.registerWindbot("wtok-room1b", 1, { name: "B", deck: "b.ydk" });
+			index.registerWindbot("wtok-room2", 2, { name: "C", deck: "c.ydk" });
+
+			const cleared = index.clearByRoom(1, "windbot");
+
+			expect(cleared).toBe(2);
+			// windbot tokens for room 1 gone
+			expect(index.find("wtok-room1a")).toBeUndefined();
+			expect(index.find("wtok-room1b")).toBeUndefined();
+			// windbot token for room 2 still present
+			expect(index.find("wtok-room2", "windbot")).toBeDefined();
+			// reconnect token for room 1 NOT touched
+			expect(index.find("rtok-room1", "reconnect")).toBeDefined();
+		});
+
+		it("clears only reconnect tokens for the given roomId when kind=reconnect", () => {
+			const c1 = makeClient("p1");
+			const c2 = makeClient("p2");
+			index.register("rtokA", c1, 5);
+			index.register("rtokB", c2, 5);
+			index.registerWindbot("wtokA", 5, { name: "A", deck: "a.ydk" });
+
+			const cleared = index.clearByRoom(5, "reconnect");
+
+			expect(cleared).toBe(2);
+			expect(index.find("rtokA")).toBeUndefined();
+			expect(index.find("rtokB")).toBeUndefined();
+			// windbot token untouched
+			expect(index.find("wtokA", "windbot")).toBeDefined();
+		});
+
+		it("returns 0 when no tokens match roomId+kind", () => {
+			index.registerWindbot("wtok-x", 99, { name: "X", deck: "x.ydk" });
+			const cleared = index.clearByRoom(42, "windbot");
+			expect(cleared).toBe(0);
+		});
+	});
+
+	describe("unregister", () => {
+		it("removes the token regardless of kind when no kind passed", () => {
+			const client = makeClient();
+			index.register("rtok-del", client, 1);
+			index.unregister("rtok-del");
+			expect(index.find("rtok-del")).toBeUndefined();
+		});
+
+		it("removes token when kind matches", () => {
+			index.registerWindbot("wtok-del", 1, { name: "X", deck: "x.ydk" });
+			index.unregister("wtok-del", "windbot");
+			expect(index.find("wtok-del")).toBeUndefined();
+		});
+
+		it("does NOT remove token when kind does not match", () => {
+			index.registerWindbot("wtok-nomatch", 1, { name: "X", deck: "x.ydk" });
+			index.unregister("wtok-nomatch", "reconnect");
+			expect(index.find("wtok-nomatch", "windbot")).toBeDefined();
+		});
+	});
+
+	describe("clear", () => {
+		it("removes all entries", () => {
+			const client = makeClient();
+			index.register("r1", client, 1);
+			index.registerWindbot("w1", 1, { name: "X", deck: "x.ydk" });
+			index.clear();
+			expect(index.find("r1")).toBeUndefined();
+			expect(index.find("w1")).toBeUndefined();
+		});
+	});
+});

--- a/src/shared/room/domain/TokenIndex.ts
+++ b/src/shared/room/domain/TokenIndex.ts
@@ -1,9 +1,26 @@
 import { YgoClient } from "../../client/domain/YgoClient";
 
-type TokenEntry = {
+export type TokenKind = "reconnect" | "windbot";
+
+type WindBotInfoSnapshot = {
+	name: string;
+	deck: string;
+};
+
+type ReconnectTokenEntry = {
+	kind: "reconnect";
 	client: YgoClient;
 	roomId: number;
 };
+
+type WindBotTokenEntry = {
+	kind: "windbot";
+	client: null;
+	roomId: number;
+	botInfo: WindBotInfoSnapshot;
+};
+
+export type TokenEntry = ReconnectTokenEntry | WindBotTokenEntry;
 
 export class TokenIndex {
 	private static instance: TokenIndex;
@@ -18,20 +35,90 @@ export class TokenIndex {
 		return TokenIndex.instance;
 	}
 
-	register(token: string, client: YgoClient, roomId: number): void {
+	/** Test seam: creates an isolated instance not bound to the singleton. */
+	static createForTests(): TokenIndex {
+		return new TokenIndex();
+	}
+
+	/**
+	 * Register a reconnect token.
+	 * Back-compat: when kind is omitted it defaults to 'reconnect'.
+	 */
+	register(token: string, client: YgoClient, roomId: number, kind: "reconnect" = "reconnect"): void {
 		if (token) {
-			this.tokens.set(token, { client, roomId });
+			this.tokens.set(token, { kind, client, roomId });
 		}
 	}
 
-	unregister(token: string): void {
+	/** Register a windbot token (no YgoClient until the bot connects back). */
+	registerWindbot(token: string, roomId: number, botInfo: WindBotInfoSnapshot): void {
 		if (token) {
+			this.tokens.set(token, { kind: "windbot", client: null, roomId, botInfo });
+		}
+	}
+
+	/**
+	 * Remove a token.
+	 * When kind is provided, the deletion is guarded — entry is only removed when kind matches.
+	 * When kind is omitted, any entry for the token is removed (legacy behavior).
+	 */
+	unregister(token: string, kind?: TokenKind): void {
+		if (!token) {
+			return;
+		}
+		if (kind === undefined) {
+			this.tokens.delete(token);
+			return;
+		}
+		const entry = this.tokens.get(token);
+		if (entry && entry.kind === kind) {
 			this.tokens.delete(token);
 		}
 	}
 
-	find(token: string): TokenEntry | undefined {
-		return this.tokens.get(token);
+	/**
+	 * Find a token entry.
+	 * When kind is provided, returns undefined on kind mismatch (REQ-TOKEN-202).
+	 * When kind is omitted, returns the entry regardless of kind (legacy behavior).
+	 */
+	find(token: string, kind?: TokenKind): TokenEntry | undefined {
+		const entry = this.tokens.get(token);
+		if (!entry) {
+			return undefined;
+		}
+		if (kind !== undefined && entry.kind !== kind) {
+			return undefined;
+		}
+		return entry;
+	}
+
+	/**
+	 * Atomic find + delete. Returns the entry only when it exists and the kind matches.
+	 * On mismatch the token is NOT removed (REQ-TOKEN-202).
+	 * On match the token is removed immediately (REQ-TOKEN-203 — one-shot).
+	 */
+	consume(token: string, kind: TokenKind): TokenEntry | undefined {
+		const entry = this.tokens.get(token);
+		if (!entry || entry.kind !== kind) {
+			return undefined;
+		}
+		this.tokens.delete(token);
+		return entry;
+	}
+
+	/**
+	 * Remove all tokens of a given kind for a specific room.
+	 * Returns the number of entries removed (REQ-TOKEN-204).
+	 */
+	clearByRoom(roomId: number, kind: TokenKind): number {
+		let count = 0;
+		for (const [token, entry] of this.tokens) {
+			if (entry.roomId === roomId && entry.kind === kind) {
+				this.tokens.delete(token);
+				count++;
+			}
+		}
+		return count;
 	}
 
 	clear(): void {


### PR DESCRIPTION
## Summary

Foundation slice (PR 1/8) for the windbot/AI bot integration chain. Adds a `kind: 'reconnect' | 'windbot'` discriminator to `TokenIndex` so reconnect tokens and windbot tokens share one Map without cross-consumption risk.

- New primitives: `registerWindbot(token, roomId, info)`, `consume(token, kind)`, `clearByRoom(roomId, kind)`
- 8 existing reconnect caller sites updated to pass `kind='reconnect'` explicitly (`DuelingState` x4, `SideDeckingState` x3, `ExpressReconnectHandler` x1)
- 19 new tests covering kind isolation, one-shot consume, scoped cleanup, and test seam factory

## Context

Part of the `windbot-port` SDD chain. Full spec: REQ-TOKEN-2xx requirements (`sdd/windbot-port/spec`).

Subsequent slices in the chain:
- PR-2: `YGOProClient.isInternal` flag + deck-check bypass
- PR-3a / PR-3b: `WindbotProvider` (application) + `HttpWindBotProvider` (infrastructure)
- PR-4: Join strategy chain refactor
- PR-5: Auto-RPS hook + `room.finalizing` field
- PR-6: Room flags + finalize cleanup hook
- PR-7: Bootstrap wiring + docker-compose service + sample botlist

No behaviour change for existing reconnect callers — discriminator is additive.

## Test plan

- [x] `npm run test` — 301/301 pass, 19 new TokenIndex tests
- [x] `npm run lint` — clean
- [x] `tsc` — clean (pre-push hook)
- [ ] Reviewer confirms no caller of `TokenIndex` exists outside the 8 updated sites (grep on `TokenIndex` shows only the touched files)