### PR TITLE
feat(ygopro/windbot): add WindbotTokenStore for bot reverse-connection auth

### DIFF
--- a/src/ygopro/windbot/domain/WindbotTokenStore.test.ts
+++ b/src/ygopro/windbot/domain/WindbotTokenStore.test.ts
@@ -1,0 +1,120 @@
+import crypto from "crypto";
+import { WindbotTokenStore, WindbotTokenPayload } from "./WindbotTokenStore";
+
+describe("WindbotTokenStore", () => {
+	let store: WindbotTokenStore;
+
+	beforeEach(() => {
+		store = WindbotTokenStore.createForTests();
+	});
+
+	describe("register", () => {
+		it("issues a 12-char alphanumeric token", () => {
+			const token = store.register(1, "Anna", "Anna.ydk");
+			expect(token).toMatch(/^[A-Za-z0-9]{12}$/);
+		});
+
+		it("two consecutive register calls return different tokens", () => {
+			const token1 = store.register(1, "Anna", "Anna.ydk");
+			const token2 = store.register(2, "Gear", "Gear.ydk");
+			expect(token1).not.toBe(token2);
+		});
+
+		it("stores the payload for later consume", () => {
+			const token = store.register(42, "Jill", "Jill.ydk");
+			const payload = store.consume(token);
+			expect(payload).toEqual<WindbotTokenPayload>({
+				roomId: 42,
+				botName: "Jill",
+				deck: "Jill.ydk",
+			});
+		});
+	});
+
+	describe("consume", () => {
+		it("returns the exact payload that was registered", () => {
+			const token = store.register(99, "Bot", "bot.ydk");
+			const result = store.consume(token);
+			expect(result).toEqual<WindbotTokenPayload>({
+				roomId: 99,
+				botName: "Bot",
+				deck: "bot.ydk",
+			});
+		});
+
+		it("removes the entry (one-shot): second call with same token throws", () => {
+			const token = store.register(1, "Anna", "Anna.ydk");
+			store.consume(token);
+			expect(() => store.consume(token)).toThrow("Windbot token not found");
+		});
+
+		it("throws on unknown token", () => {
+			expect(() => store.consume("nonexistent01")).toThrow("Windbot token not found");
+		});
+	});
+
+	describe("clearByRoom", () => {
+		it("returns count of removed entries matching roomId", () => {
+			store.register(5, "Anna", "Anna.ydk");
+			store.register(5, "Gear", "Gear.ydk");
+			const count = store.clearByRoom(5);
+			expect(count).toBe(2);
+		});
+
+		it("does not affect entries for OTHER roomIds", () => {
+			const tokenOther = store.register(7, "Bob", "Bob.ydk");
+			store.register(5, "Anna", "Anna.ydk");
+			store.clearByRoom(5);
+			// tokenOther should still be consumable
+			expect(store.consume(tokenOther)).toEqual<WindbotTokenPayload>({
+				roomId: 7,
+				botName: "Bob",
+				deck: "Bob.ydk",
+			});
+		});
+
+		it("returns 0 when roomId has no matching entries", () => {
+			const count = store.clearByRoom(999);
+			expect(count).toBe(0);
+		});
+	});
+
+	describe("collision re-roll", () => {
+		it("re-rolls when first randomBytes returns a duplicate, returns second unique value", () => {
+			// Register a token first using real crypto (not spied yet).
+			// existingToken is a 12-char hex string produced by randomBytes(6).toString('hex').
+			const existingToken = store.register(1, "Anna", "Anna.ydk");
+
+			// Reconstruct the 6-byte buffer that would produce existingToken when hex-encoded.
+			const existingBytes = Buffer.from(existingToken, "hex");
+
+			// A clearly different 6-byte buffer for the second call (all-zeros → "000000000000").
+			const freshBytes = Buffer.from("000000000000", "hex");
+
+			const spy = jest
+				.spyOn(crypto, "randomBytes")
+				.mockImplementationOnce((() => existingBytes) as typeof crypto.randomBytes)
+				.mockImplementationOnce((() => freshBytes) as typeof crypto.randomBytes);
+
+			const newToken = store.register(2, "Gear", "Gear.ydk");
+
+			// The duplicate was re-rolled; the second value was used.
+			expect(newToken).toBe("000000000000");
+			// spy was called exactly twice (one duplicate hit, one fresh value).
+			expect(spy).toHaveBeenCalledTimes(2);
+
+			spy.mockRestore();
+		});
+	});
+
+	describe("createForTests", () => {
+		it("returns a fresh isolated instance independent from any other", () => {
+			const storeA = WindbotTokenStore.createForTests();
+			const storeB = WindbotTokenStore.createForTests();
+
+			const tokenA = storeA.register(1, "Anna", "Anna.ydk");
+			// storeB has no knowledge of tokenA
+			expect(() => storeB.consume(tokenA)).toThrow("Windbot token not found");
+		});
+	});
+});

--- a/src/ygopro/windbot/domain/WindbotTokenStore.ts
+++ b/src/ygopro/windbot/domain/WindbotTokenStore.ts
@@ -1,0 +1,54 @@
+import crypto from "crypto";
+
+export type WindbotTokenPayload = {
+	roomId: number;
+	botName: string;
+	deck: string;
+};
+
+export class WindbotTokenStore {
+	private readonly entries: Map<string, WindbotTokenPayload> = new Map();
+
+	constructor() {}
+
+	register(roomId: number, botName: string, deck: string): string {
+		const token = this._generateUniqueToken();
+		this.entries.set(token, { roomId, botName, deck });
+		return token;
+	}
+
+	consume(token: string): WindbotTokenPayload {
+		const payload = this.entries.get(token);
+		if (payload === undefined) {
+			throw new Error("Windbot token not found");
+		}
+		this.entries.delete(token);
+		return payload;
+	}
+
+	clearByRoom(roomId: number): number {
+		let count = 0;
+		for (const [token, payload] of this.entries) {
+			if (payload.roomId === roomId) {
+				this.entries.delete(token);
+				count++;
+			}
+		}
+		return count;
+	}
+
+	static createForTests(): WindbotTokenStore {
+		return new WindbotTokenStore();
+	}
+
+	private _generateUniqueToken(): string {
+		const MAX_ATTEMPTS = 10;
+		for (let i = 0; i < MAX_ATTEMPTS; i++) {
+			const token = crypto.randomBytes(6).toString("hex");
+			if (!this.entries.has(token)) {
+				return token;
+			}
+		}
+		throw new Error("WindbotTokenStore: failed to generate a unique token after 10 attempts");
+	}
+}


### PR DESCRIPTION
## Summary

Foundation slice (PR 1/8) for the windbot/AI bot integration. Introduces a ygopro-local token store that issues one-shot 12-char hex tokens. Bots use these tokens as the `AIJOIN#{token}` password when reverse-connecting to the server.

Lives under `src/ygopro/windbot/domain/` — isolated from the edopro reconnect flow and the shared `TokenIndex`. No cross-module coupling.

## API

```ts
register(roomId: number, botName: string, deck: string): string
consume(token: string): { roomId, botName, deck }    // one-shot, throws on miss
clearByRoom(roomId: number): number                  // finalize cleanup
static createForTests(): WindbotTokenStore           // test isolation
```

Token format: `crypto.randomBytes(6).toString('hex')` → 12-char `[0-9a-f]`, 48 bits entropy. Re-rolls on collision (max 10 attempts, fails loud).

## Context

Part of the `windbot-port` SDD chain. Spec REQ-TOKEN-201..204.

Subsequent slices:
- PR-2: `YGOProClient.isInternal` flag + deck-check bypass
- PR-3a / PR-3b: `WindbotProvider` (application) + `HttpWindBotProvider` (infrastructure)
- PR-4: Join strategy chain refactor (`YGOProJoinHandler` dispatch)
- PR-5: Auto-RPS hook + `room.finalizing` field
- PR-6: Room flags (`windbot`, `noHost`, `noReconnect`) + finalize cleanup hook
- PR-7: Bootstrap wiring + docker-compose windbot service + sample botlist

## Test plan

- [x] `npm run test` — 293/293 pass, 11 new WindbotTokenStore tests
- [x] `npm run lint` — clean
- [x] `tsc` build — clean (pre-push hook)
- [x] Negative paths covered: unknown token, double consume, unknown roomId
- [x] Collision re-roll: spied `crypto.randomBytes` returns duplicate first, fresh value second — store returns the fresh one