### PR TITLE
feat(ygopro): add isInternal flag and deck-check bypass for bot clients

### DIFF
--- a/src/ygopro/client/domain/YGOProClient.ts
+++ b/src/ygopro/client/domain/YGOProClient.ts
@@ -12,6 +12,7 @@ export class YGOProClient extends YgoClient {
 	private readonly _roomMessageEmitter: SimpleRoomMessageEmitter;
 	private _rpsChosen: boolean;
 	private _captain: boolean = false;
+	private _isInternal: boolean = false;
 
 	constructor({
 		name,
@@ -102,5 +103,13 @@ export class YGOProClient extends YgoClient {
 
 	get isCaptain(): boolean {
 		return this._captain;
+	}
+
+	markInternal(): void {
+		this._isInternal = true;
+	}
+
+	get isInternal(): boolean {
+		return this._isInternal;
 	}
 }

--- a/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
@@ -1,0 +1,187 @@
+import { EventEmitter } from "stream";
+
+import { Commands } from "@shared/messages/Commands";
+import { ClientMessage } from "@shared/messages/MessageProcessor";
+import { Logger } from "@shared/logger/domain/Logger";
+
+import { YGOProClient } from "../../../client/domain/YGOProClient";
+import { YGOProRoom } from "../YGOProRoom";
+import { YGOProWaitingState } from "./YGOProWaitingState";
+import { YGOProDeckCreator } from "@ygopro/deck/application/YGOProDeckCreator";
+import { YGOProDeckValidator } from "@ygopro/deck/domain/YGOProDeckValidator";
+import { NotOfficialCardError } from "@shared/deck/domain/errors/NotOfficialCardError";
+import { UserAuth } from "@shared/user-auth/application/UserAuth";
+
+describe("YGOProWaitingState.handleUpdateDeck", () => {
+	let eventEmitter: EventEmitter;
+	let mockLogger: jest.Mocked<Logger>;
+	let mockUserAuth: jest.Mocked<UserAuth>;
+	let mockDeckCreator: jest.Mocked<YGOProDeckCreator>;
+	let mockDeckValidator: jest.Mocked<YGOProDeckValidator>;
+	let mockRoom: jest.Mocked<YGOProRoom>;
+	let mockPlayer: jest.Mocked<YGOProClient>;
+
+	const makeDeckPayload = (): Buffer => {
+		// Minimal valid YGOProCtosUpdateDeck payload (2 cards main, 0 side)
+		// Format: main_count (u32le) + side_count (u32le) + card codes (u32le each)
+		const main = [0x00000001, 0x00000002];
+		const side: number[] = [];
+		const buf = Buffer.alloc(4 + 4 + (main.length + side.length) * 4);
+		let offset = 0;
+		buf.writeUInt32LE(main.length, offset); offset += 4;
+		buf.writeUInt32LE(side.length, offset); offset += 4;
+		for (const code of [...main, ...side]) {
+			buf.writeUInt32LE(code, offset); offset += 4;
+		}
+		return buf;
+	};
+
+	const makeClientMessage = (data: Buffer): ClientMessage => ({
+		data,
+		previousMessage: Buffer.alloc(0),
+	} as unknown as ClientMessage);
+
+	beforeEach(() => {
+		eventEmitter = new EventEmitter();
+
+		mockLogger = {
+			child: jest.fn().mockReturnThis(),
+			info: jest.fn(),
+			warn: jest.fn(),
+			error: jest.fn(),
+			debug: jest.fn(),
+		} as unknown as jest.Mocked<Logger>;
+
+		mockUserAuth = {} as unknown as jest.Mocked<UserAuth>;
+
+		mockDeckCreator = {
+			build: jest.fn(),
+		} as unknown as jest.Mocked<YGOProDeckCreator>;
+
+		mockDeckValidator = {
+			validate: jest.fn().mockReturnValue(null),
+		} as unknown as jest.Mocked<YGOProDeckValidator>;
+
+		mockRoom = {
+			mutex: {
+				runExclusive: jest.fn().mockImplementation((fn: () => void) => fn()),
+			},
+			banListHash: 0,
+			shouldValidateDeck: jest.fn().mockReturnValue(true),
+			setDecksToPlayerUnsafe: jest.fn(),
+			notReadyUnsafe: jest.fn(),
+			messageSender: {
+				errorMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+			},
+			hostInfo: { rule: 0 },
+			useExtendedCardPool: false,
+		} as unknown as jest.Mocked<YGOProRoom>;
+
+		mockPlayer = {
+			isSpectator: false,
+			isInternal: false,
+			position: 0,
+			logger: {
+				child: jest.fn().mockReturnThis(),
+				info: jest.fn(),
+				warn: jest.fn(),
+				error: jest.fn(),
+				debug: jest.fn(),
+			},
+			sendMessageToClient: jest.fn(),
+		} as unknown as jest.Mocked<YGOProClient>;
+
+		new YGOProWaitingState(
+			mockUserAuth,
+			eventEmitter,
+			mockLogger,
+			mockDeckCreator,
+			mockDeckValidator,
+		);
+	});
+
+	const emitUpdateDeck = (player: jest.Mocked<YGOProClient>): Promise<void> => {
+		const data = makeDeckPayload();
+		const message = makeClientMessage(data);
+		return new Promise((resolve) => {
+			setImmediate(() => resolve());
+			eventEmitter.emit(Commands.UPDATE_DECK as unknown as string, message, mockRoom, player);
+		});
+	};
+
+	describe("when player.isInternal is false (human player)", () => {
+		it("should call the deck validator", async () => {
+			const fakeDeck = { allCards: [] };
+			mockDeckCreator.build.mockResolvedValue(fakeDeck as never);
+			mockDeckValidator.validate.mockReturnValue(null);
+
+			await emitUpdateDeck(mockPlayer);
+
+			expect(mockDeckValidator.validate).toHaveBeenCalledWith(fakeDeck);
+		});
+
+		it("should reject when the deck fails validation (regression test)", async () => {
+			const fakeDeck = { allCards: [{ code: 12345 }] };
+			const deckError = new NotOfficialCardError(12345);
+			mockDeckCreator.build.mockResolvedValue(fakeDeck as never);
+			mockDeckValidator.validate.mockReturnValue(deckError);
+
+			await emitUpdateDeck(mockPlayer);
+
+			expect(mockRoom.notReadyUnsafe).toHaveBeenCalled();
+			expect(mockPlayer.sendMessageToClient).toHaveBeenCalled();
+		});
+	});
+
+	describe("when player.isInternal is true (bot player)", () => {
+		beforeEach(() => {
+			(mockPlayer as unknown as Record<string, unknown>)["isInternal"] = true;
+		});
+
+		it("should NOT call the deck validator", async () => {
+			const fakeDeck = { allCards: [] };
+			mockDeckCreator.build.mockResolvedValue(fakeDeck as never);
+
+			await emitUpdateDeck(mockPlayer);
+
+			expect(mockDeckValidator.validate).not.toHaveBeenCalled();
+		});
+
+		it("should accept a deck that would normally fail validation", async () => {
+			const fakeDeck = { allCards: [{ code: 12345 }] };
+			// validator WOULD return an error — but it must not be called
+			mockDeckCreator.build.mockResolvedValue(fakeDeck as never);
+			mockDeckValidator.validate.mockReturnValue(new NotOfficialCardError(12345));
+
+			await emitUpdateDeck(mockPlayer);
+
+			expect(mockRoom.notReadyUnsafe).not.toHaveBeenCalled();
+			expect(mockPlayer.sendMessageToClient).not.toHaveBeenCalled();
+			expect(mockRoom.setDecksToPlayerUnsafe).toHaveBeenCalled();
+		});
+
+		it("should set the deck via setDecksToPlayerUnsafe", async () => {
+			const fakeDeck = { allCards: [] };
+			mockDeckCreator.build.mockResolvedValue(fakeDeck as never);
+
+			await emitUpdateDeck(mockPlayer);
+
+			expect(mockRoom.setDecksToPlayerUnsafe).toHaveBeenCalledWith(
+				mockPlayer.position,
+				fakeDeck,
+			);
+		});
+
+		it("isInternal check happens before validator — validator never invoked regardless of shouldValidateDeck()", async () => {
+			// Even if shouldValidateDeck returns true, validator must not run for internal clients
+			mockRoom.shouldValidateDeck.mockReturnValue(true);
+			const fakeDeck = { allCards: [] };
+			mockDeckCreator.build.mockResolvedValue(fakeDeck as never);
+
+			await emitUpdateDeck(mockPlayer);
+
+			expect(mockRoom.shouldValidateDeck).not.toHaveBeenCalled();
+			expect(mockDeckValidator.validate).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/ygopro/room/domain/states/YGOProWaitingState.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.ts
@@ -216,6 +216,14 @@ export class YGOProWaitingState extends YGOProRoomState {
 		}
 
 		const deck = deckOrError;
+
+		if (player.isInternal) {
+			room.mutex.runExclusive(() => {
+				room.setDecksToPlayerUnsafe(player.position, deck);
+			});
+			return;
+		}
+
 		const hasError = room.shouldValidateDeck() && this.deckValidator.validate(deck);
 		if (hasError) {
 			const failedCard = deck.allCards.find((c) => Number(c.code) === hasError.code);

--- a/tests/modules/mercury/client/domain/YGOProClient.test.ts
+++ b/tests/modules/mercury/client/domain/YGOProClient.test.ts
@@ -360,4 +360,47 @@ describe("YGOProClient", () => {
     });
   });
 
+  describe("isInternal", () => {
+    beforeEach(() => {
+      client = new YGOProClient({
+        name: "TestPlayer",
+        socket: mockSocket,
+        logger: mockLogger,
+        position: 0,
+        room: mockRoom,
+        host: true,
+        id: "player-id-1",
+        team: Team.PLAYER,
+      });
+    });
+
+    it("should default to false on a fresh client", () => {
+      expect(client.isInternal).toBe(false);
+    });
+
+    it("should return true after markInternal() is called", () => {
+      client.markInternal();
+
+      expect(client.isInternal).toBe(true);
+    });
+
+    it("should leave other client state unaffected after markInternal()", () => {
+      client.markInternal();
+
+      expect(client.name).toBe("TestPlayer");
+      expect(client.id).toBe("player-id-1");
+      expect(client.position).toBe(0);
+      expect(client.host).toBe(true);
+      expect(client.isCaptain).toBe(false);
+    });
+
+    it("should remain true after subsequent unrelated state changes (monotonic)", () => {
+      client.markInternal();
+      client.rpsChoose();
+      client.setNeedSpectatorMessages(true);
+
+      expect(client.isInternal).toBe(true);
+    });
+  });
+
 });


### PR DESCRIPTION
## Summary

Foundation slice (PR 2/8) for the windbot/AI bot integration. Marks bot clients with an `isInternal` flag and short-circuits the deck-check pipeline for them.

- `YGOProClient.isInternal: boolean` (default `false`)
- `YGOProClient.markInternal()` — monotonic setter, mirrors the existing `captain()` pattern
- `YGOProWaitingState.handleUpdateDeck` skips `shouldValidateDeck()` and the banlist/rules validator entirely when the player is internal

The bot deck still flows through `deckCreator.build()` for binary parsing — only the validator (which assumes a human-submitted deck) is bypassed.

## Why this shape

The design originally specified `setInternal(value: boolean)`, but `YGOProClient` already exposes monotonic flags via no-arg methods (e.g. `captain()` for captain assignment). `markInternal()` mirrors that idiom. Downstream consumers (PR-4 `AIJoinTokenStrategy`) will call `client.markInternal()`.

## Context

Part of the `windbot-port` SDD chain. Spec REQ-CLIENT-601 (flag exists, defaults false, set when bot attached) and REQ-CLIENT-602 (deck validator skipped for internal players).

Subsequent slices:
- PR-3a / PR-3b: `WindbotProvider` (application) + `HttpWindBotProvider` (infrastructure)
- PR-4: Join strategy chain refactor (this is where `markInternal()` will be called)
- PR-5: Auto-RPS hook + `room.finalizing` field
- PR-6: Room flags + finalize cleanup hook
- PR-7: Bootstrap wiring + docker-compose

## Test plan

- [x] `npm run test` — 303/303 pass (293 baseline + 10 new tests)
- [x] `npm run lint` — clean
- [x] `tsc` build — clean (pre-push hook)
- [x] Bypass placement test: `shouldValidateDeck` is never called for internal players
- [x] Regression guard: human players still go through the validator and get rejected on invalid decks
- [x] Monotonic flag: `markInternal()` keeps `isInternal=true` across subsequent state changes