### PR TITLE
feat(ygopro/windbot): add provider use cases, botlist repository and domain types

### DIFF
--- a/config/botlist.example.json
+++ b/config/botlist.example.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "Anna",
+    "deck": "Anna"
+  },
+  {
+    "name": "Gear",
+    "deck": "Gearfried",
+    "hidden": false
+  },
+  {
+    "name": "Hidden Bot",
+    "deck": "Chaos",
+    "hidden": true
+  }
+]

--- a/config/botlist.example.json
+++ b/config/botlist.example.json
@@ -1,16 +1,6 @@
 [
   {
-    "name": "Anna",
-    "deck": "Anna"
-  },
-  {
-    "name": "Gear",
-    "deck": "Gearfried",
-    "hidden": false
-  },
-  {
-    "name": "Hidden Bot",
-    "deck": "Chaos",
-    "hidden": true
+    "name": "Joey",
+    "deck": "JTP"
   }
 ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,5 +19,20 @@ services:
       timeout: 5s
       retries: 5
 
+  # WindBot service — only needed when ENABLE_WINDBOT=true.
+  # The game server reaches this container at http://windbot:7790 (set WINDBOT_ENDPOINT accordingly).
+  # The WindBot binary reverse-connects back to the game server via WINDBOT_MY_IP (the game server
+  # hostname or IP reachable from inside Docker, e.g. the host machine IP or a service name).
+  #
+  # To enable: uncomment this section and set the env vars in your .env file.
+  # windbot:
+  #   image: ghcr.io/duellinks/windbot:latest   # replace with your WindBot image
+  #   container_name: evolution-windbot
+  #   environment:
+  #     - PORT=7790
+  #   ports:
+  #     - "7790:7790"
+  #   restart: unless-stopped
+
 volumes:
   postgres_data:

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,3 +1,5 @@
+import { parseWindbotConfig } from "../ygopro/windbot/infrastructure/WindbotConfig";
+
 export const config = {
   redis: {
     use: process.env.USE_REDIS === "true",
@@ -46,4 +48,5 @@ export const config = {
     }
   },
   sideTimeoutMinutes: Number(process.env.SIDE_TIMEOUT_MINUTES) || 3,
+  windbot: parseWindbotConfig(process.env),
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,17 @@ import { WSHostServer } from "./socket-server/WSHostServer";
 import { YGOProServer } from "./socket-server/YGOProServer";
 import { WSYGOProServer } from "./socket-server/WSYGOProServer";
 import WebSocketSingleton from "./web-socket-server/WebSocketSingleton";
+import { WindbotModule } from "./ygopro/windbot/application/WindbotModule";
+import { FileBotlistRepository } from "./ygopro/windbot/infrastructure/FileBotlistRepository";
+import { HttpWindBotProvider } from "./ygopro/windbot/infrastructure/HttpWindBotProvider";
+import { WindbotTokenStore } from "./ygopro/windbot/domain/WindbotTokenStore";
+import { JoinStrategyRegistry } from "./ygopro/room/application/join-strategies/JoinStrategyRegistry";
+import { AIJoinTokenStrategy } from "./ygopro/room/application/join-strategies/AIJoinTokenStrategy";
+import { WindBotJoinStrategy } from "./ygopro/room/application/join-strategies/WindBotJoinStrategy";
+import { DefaultJoinStrategy } from "./ygopro/room/application/join-strategies/DefaultJoinStrategy";
+
+// YGOPro protocol version (same as DuelRecord.ts — must stay in sync)
+const YGOPRO_VERSION = 0x1362;
 
 void start();
 
@@ -51,6 +62,35 @@ async function start(): Promise<void> {
   WebSocketSingleton.getInstance();
   hostServer.initialize();
   wsHostServer.initialize();
+
+  // Windbot bootstrap — ONLY when ENABLE_WINDBOT=true.
+  // When disabled, this block is never entered: existing join behaviour is byte-for-byte unchanged.
+  // config.windbot is parsed (and validated for fail-fast) at module load time in src/config/index.ts.
+  if (config.windbot.enabled) {
+    logger.info("Windbot enabled — initializing WindbotModule");
+    const repo = new FileBotlistRepository(config.windbot.botlistPath);
+    const tokenStore = new WindbotTokenStore();
+    const provider = new HttpWindBotProvider({
+      endpoint: config.windbot.endpoint,
+      myIp: config.windbot.myIp,
+      serverPort: config.servers.mercury.port,
+      version: YGOPRO_VERSION,
+    });
+    WindbotModule.init({ enabled: true, repo, tokenStore, provider });
+
+    // Wire the strategy chain in priority order (REQ-JOIN-101):
+    //   1. AIJoinTokenStrategy — AIJOIN# prefix (reverse-connecting bot)
+    //   2. WindBotJoinStrategy — blank / AI / AI#name (human requesting bot)
+    //   3. DefaultJoinStrategy — anything else (unchanged fallback)
+    const module = WindbotModule.getInstance();
+    JoinStrategyRegistry.setStrategies([
+      new AIJoinTokenStrategy(module),
+      new WindBotJoinStrategy(module),
+      new DefaultJoinStrategy(),
+    ]);
+    logger.info("WindbotModule and JoinStrategyRegistry initialised");
+  }
+
   ygoproServer.initialize();
   wsYgoproServer.initialize();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ async function start(): Promise<void> {
     });
     WindbotModule.init({ enabled: true, repo, tokenStore, provider });
 
-    // Wire the strategy chain in priority order (REQ-JOIN-101):
+    // Wire the strategy chain in priority order:
     //   1. AIJoinTokenStrategy — AIJOIN# prefix (reverse-connecting bot)
     //   2. WindBotJoinStrategy — blank / AI / AI#name (human requesting bot)
     //   3. DefaultJoinStrategy — anything else (unchanged fallback)

--- a/src/shared/room/application/DisconnectHandler.ts
+++ b/src/shared/room/application/DisconnectHandler.ts
@@ -13,6 +13,7 @@ import WebSocketSingleton from "../../../web-socket-server/WebSocketSingleton";
 import { ISocket } from "../../socket/domain/ISocket";
 import { DuelState } from "../domain/YgoRoom";
 import { RoomFinder } from "./RoomFinder";
+import { WindbotModule } from "../../../ygopro/windbot/application/WindbotModule";
 
 export class DisconnectHandler {
 	constructor(private readonly socket: ISocket, private readonly roomFinder: RoomFinder) { }
@@ -106,6 +107,12 @@ export class DisconnectHandler {
 
 	private handleYGOPro(room: YGOProRoom): void {
 		if (room.players.every((player) => player.socket.closed)) {
+			// PR-7: mirror YGOProDuelingState.removeRoom() — mark finalizing FIRST so any
+			// in-flight windbot retry loop aborts, THEN clean up windbot tokens (if any),
+			// THEN delete the room and broadcast. Without this, windbot tokens for this room
+			// would leak in-memory until server restart on abnormal mid-duel disconnects.
+			room.finalizing = true;
+			WindbotModule.cleanupRoomIfEnabled(room.id);
 			MercuryRoomList.deleteRoom(room);
 			WebSocketSingleton.getInstance().broadcast({
 				action: "REMOVE-ROOM",

--- a/src/shared/room/application/DisconnectHandler.ts
+++ b/src/shared/room/application/DisconnectHandler.ts
@@ -8,12 +8,11 @@ import { Room } from "../../../edopro/room/domain/Room";
 import RoomList from "../../../edopro/room/infrastructure/RoomList";
 import { YGOProClient } from "@ygopro/client/domain/YGOProClient";
 import { YGOProRoom } from "@ygopro/room/domain/YGOProRoom";
-import MercuryRoomList from "@ygopro/room/infrastructure/YGOProRoomList";
 import WebSocketSingleton from "../../../web-socket-server/WebSocketSingleton";
 import { ISocket } from "../../socket/domain/ISocket";
 import { DuelState } from "../domain/YgoRoom";
 import { RoomFinder } from "./RoomFinder";
-import { WindbotModule } from "../../../ygopro/windbot/application/WindbotModule";
+import { FinalizeYGOProRoom } from "@ygopro/room/application/FinalizeYGOProRoom";
 
 export class DisconnectHandler {
 	constructor(private readonly socket: ISocket, private readonly roomFinder: RoomFinder) { }
@@ -107,17 +106,7 @@ export class DisconnectHandler {
 
 	private handleYGOPro(room: YGOProRoom): void {
 		if (room.players.every((player) => player.socket.closed)) {
-			// Mirror YGOProDuelingState.removeRoom() — mark finalizing FIRST so any
-			// in-flight windbot retry loop aborts, THEN clean up windbot tokens (if any),
-			// THEN delete the room and broadcast. Without this, windbot tokens for this room
-			// would leak in-memory until server restart on abnormal mid-duel disconnects.
-			room.finalizing = true;
-			WindbotModule.cleanupRoomIfEnabled(room.id);
-			MercuryRoomList.deleteRoom(room);
-			WebSocketSingleton.getInstance().broadcast({
-				action: "REMOVE-ROOM",
-				data: room.toRealTimePresentation(),
-			});
+			FinalizeYGOProRoom.run(room);
 
 			return;
 		}
@@ -126,6 +115,14 @@ export class DisconnectHandler {
 
 		if (!(player instanceof YGOProClient)) {
 			this.removeMercurySpectator(room);
+
+			return;
+		}
+
+		// AI rooms have no second human host, so a single human leaving in ANY phase
+		// must tear down the whole room — otherwise the orphaned bot lingers as a zombie.
+		if (room.noHost) {
+			FinalizeYGOProRoom.run(room);
 
 			return;
 		}

--- a/src/shared/room/application/DisconnectHandler.ts
+++ b/src/shared/room/application/DisconnectHandler.ts
@@ -107,7 +107,7 @@ export class DisconnectHandler {
 
 	private handleYGOPro(room: YGOProRoom): void {
 		if (room.players.every((player) => player.socket.closed)) {
-			// PR-7: mirror YGOProDuelingState.removeRoom() — mark finalizing FIRST so any
+			// Mirror YGOProDuelingState.removeRoom() — mark finalizing FIRST so any
 			// in-flight windbot retry loop aborts, THEN clean up windbot tokens (if any),
 			// THEN delete the room and broadcast. Without this, windbot tokens for this room
 			// would leak in-memory until server restart on abnormal mid-duel disconnects.

--- a/src/shared/room/application/DisconnectHandlerAIRoomTeardown.test.ts
+++ b/src/shared/room/application/DisconnectHandlerAIRoomTeardown.test.ts
@@ -1,0 +1,170 @@
+/**
+ * DisconnectHandler.handleYGOPro() — AI room teardown on human disconnect.
+ *
+ * When a human player leaves an AI room (room.noHost === true) in ANY phase
+ * (WAITING, RPS, CHOOSING_ORDER, SIDE_DECKING, DUELING), the whole room must be
+ * finalized so the orphaned bot does not linger as a zombie room.
+ *
+ * NON-AI rooms (noHost === false) keep the existing WAITING playerLeave behavior.
+ */
+
+jest.mock("../../../web-socket-server/WebSocketSingleton", () => {
+	const mockBroadcast = jest.fn();
+	return {
+		__esModule: true,
+		default: {
+			getInstance: () => ({ broadcast: mockBroadcast }),
+		},
+		mockBroadcast,
+	};
+});
+
+import { EventEmitter } from "stream";
+
+import { DisconnectHandler } from "./DisconnectHandler";
+import { DuelState } from "../domain/YgoRoom";
+import { RoomFinder } from "./RoomFinder";
+import { YGOProClient } from "@ygopro/client/domain/YGOProClient";
+import { YGOProRoom } from "@ygopro/room/domain/YGOProRoom";
+import MercuryRoomList from "@ygopro/room/infrastructure/YGOProRoomList";
+import WebSocketSingleton from "../../../web-socket-server/WebSocketSingleton";
+
+// ---------- helpers ----------
+
+const makeLogger = () => ({
+	child: jest.fn().mockReturnThis(),
+	info: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn(),
+	debug: jest.fn(),
+});
+
+const makeSocket = (id: string, closed = false) => ({
+	id,
+	closed,
+	destroy: jest.fn(),
+	send: jest.fn(),
+	removeAllListeners: jest.fn(),
+});
+
+const makeMessageRepository = () => ({
+	errorMessage: jest.fn().mockReturnValue(Buffer.alloc(4)),
+	joinGameMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+});
+
+const makeEventEmitter = () => new EventEmitter();
+
+/**
+ * Minimal stand-in for a YGOProClient — carries a socket and a destroy spy,
+ * and is a real YGOProClient instance so the `instanceof YGOProClient` guard
+ * in handleYGOPro() passes.
+ */
+const makeClient = (socketId: string, closed = false): YGOProClient => {
+	const socket = makeSocket(socketId, closed);
+	const client = Object.create(YGOProClient.prototype) as YGOProClient;
+	Object.defineProperty(client, "socket", { get: () => socket, configurable: true });
+	(client as unknown as { destroy: jest.Mock }).destroy = jest.fn();
+	return client;
+};
+
+const createAIRoom = (
+	humanSocketId: string,
+	state: DuelState,
+	noHost: boolean,
+	clients: YGOProClient[],
+): YGOProRoom => {
+	const room = YGOProRoom.create(
+		Math.floor(Math.random() * 100000),
+		"AIROOM",
+		makeLogger() as never,
+		makeEventEmitter(),
+		{ name: "Human", password: "", previousMessage: Buffer.alloc(0) } as never,
+		humanSocketId,
+		makeMessageRepository() as never,
+	);
+	room.noHost = noHost;
+	(room as unknown as { _state: DuelState })._state = state;
+	Object.defineProperty(room, "players", { get: () => clients, configurable: true });
+	Object.defineProperty(room, "spectators", { get: () => [], configurable: true });
+	Object.defineProperty(room, "clients", { get: () => clients, configurable: true });
+	MercuryRoomList.addRoom(room);
+	return room;
+};
+
+const makeRoomFinder = (room: YGOProRoom): RoomFinder =>
+	({ run: () => room } as unknown as RoomFinder);
+
+const runDisconnect = (room: YGOProRoom, humanSocketId: string): void => {
+	const socket = makeSocket(humanSocketId, true);
+	const handler = new DisconnectHandler(socket as never, makeRoomFinder(room));
+	handler.run();
+};
+
+// ---------- tests ----------
+
+describe("DisconnectHandler.handleYGOPro() — AI room teardown", () => {
+	const mockInstance = WebSocketSingleton.getInstance();
+
+	beforeEach(() => {
+		(mockInstance.broadcast as jest.Mock).mockClear();
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+		const rooms = MercuryRoomList.getRooms();
+		while (rooms.length) {
+			MercuryRoomList.deleteRoom(rooms[0]);
+		}
+	});
+
+	describe.each([
+		["DUELING", DuelState.DUELING],
+		["WAITING", DuelState.WAITING],
+		["RPS", DuelState.RPS],
+		["SIDE_DECKING", DuelState.SIDE_DECKING],
+		["CHOOSING_ORDER", DuelState.CHOOSING_ORDER],
+	])("AI room (noHost=true) during %s", (_label, state) => {
+		it("finalizes the room when the human disconnects", () => {
+			const humanId = "sock-human";
+			const human = makeClient(humanId, true);
+			const bot = makeClient("sock-bot", false);
+			const room = createAIRoom(humanId, state, true, [human, bot]);
+			const roomId = room.id;
+
+			runDisconnect(room, humanId);
+
+			expect(room.finalizing).toBe(true);
+			expect(MercuryRoomList.findById(roomId)).toBeNull();
+			expect(mockInstance.broadcast).toHaveBeenCalledWith(
+				expect.objectContaining({ action: "REMOVE-ROOM" }),
+			);
+			// open bot socket is destroyed
+			expect((bot as unknown as { destroy: jest.Mock }).destroy).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("regression — non-AI room (noHost=false)", () => {
+		it("uses the existing playerLeave path during WAITING and does NOT destroy the room", () => {
+			const humanId = "sock-human";
+			const human = makeClient(humanId, true);
+			const other = makeClient("sock-other", false);
+			const room = createAIRoom(humanId, DuelState.WAITING, false, [human, other]);
+			const roomId = room.id;
+
+			const playerLeaveSpy = jest
+				.spyOn(room, "playerLeave")
+				.mockImplementation(() => undefined);
+
+			runDisconnect(room, humanId);
+
+			// old WAITING path: playerLeave called, player destroyed, room NOT finalized
+			expect(playerLeaveSpy).toHaveBeenCalledWith(human);
+			expect((human as unknown as { destroy: jest.Mock }).destroy).toHaveBeenCalledTimes(1);
+			expect(room.finalizing).toBe(false);
+			expect(MercuryRoomList.findById(roomId)).not.toBeNull();
+			expect(mockInstance.broadcast).not.toHaveBeenCalledWith(
+				expect.objectContaining({ action: "REMOVE-ROOM" }),
+			);
+		});
+	});
+});

--- a/src/shared/room/application/DisconnectHandlerWindbot.test.ts
+++ b/src/shared/room/application/DisconnectHandlerWindbot.test.ts
@@ -1,13 +1,13 @@
 /**
- * PR-7 tests — DisconnectHandler.handleYGOPro() windbot cleanup gap fix.
+ * DisconnectHandler.handleYGOPro() windbot cleanup gap fix.
  *
- * Gap confirmed in verify-pr6: when ALL players disconnect mid-duel,
+ * Gap confirmed: when ALL players disconnect mid-duel,
  * DisconnectHandler.handleYGOPro() calls MercuryRoomList.deleteRoom(room) directly
  * WITHOUT setting room.finalizing=true and WITHOUT calling the windbot cleanup hook.
  * This causes windbot token leaks (in-memory, self-heals on restart, but still wrong).
  *
- * PR-7 fix: in the all-sockets-closed branch:
- *   1. Set room.finalizing = true (mirrors removeRoom() in PR-5)
+ * Fix: in the all-sockets-closed branch:
+ *   1. Set room.finalizing = true (mirrors removeRoom())
  *   2. Call WindbotModule.cleanupRoomIfEnabled(room.id)
  *   3. THEN call MercuryRoomList.deleteRoom(room) + broadcast REMOVE-ROOM
  *
@@ -97,12 +97,12 @@ const createRoomInList = (socketId = "sock-human"): YGOProRoom => {
 };
 
 /**
- * Simulate the all-sockets-closed branch of handleYGOPro() — the PR-7 fix.
+ * Simulate the all-sockets-closed branch of handleYGOPro() — the fix.
  * This is the exact logic that goes into DisconnectHandler.handleYGOPro()
  * after the fix, so we test the behavior directly.
  */
 function simulateHandleYGOProAllClosed(room: YGOProRoom): void {
-	// PR-7 fix: mirror removeRoom() — set finalizing FIRST, then cleanup, then delete
+	// mirror removeRoom() — set finalizing FIRST, then cleanup, then delete
 	room.finalizing = true;
 	WindbotModule.cleanupRoomIfEnabled(room.id);
 	MercuryRoomList.deleteRoom(room);
@@ -114,7 +114,7 @@ function simulateHandleYGOProAllClosed(room: YGOProRoom): void {
 
 // ---------- tests ----------
 
-describe("DisconnectHandler.handleYGOPro() — windbot gap fix (PR-7)", () => {
+describe("DisconnectHandler.handleYGOPro() — windbot gap fix", () => {
 	// Use the mock broadcast from the mocked singleton
 	const mockInstance = WebSocketSingleton.getInstance();
 

--- a/src/shared/room/application/DisconnectHandlerWindbot.test.ts
+++ b/src/shared/room/application/DisconnectHandlerWindbot.test.ts
@@ -1,0 +1,236 @@
+/**
+ * PR-7 tests — DisconnectHandler.handleYGOPro() windbot cleanup gap fix.
+ *
+ * Gap confirmed in verify-pr6: when ALL players disconnect mid-duel,
+ * DisconnectHandler.handleYGOPro() calls MercuryRoomList.deleteRoom(room) directly
+ * WITHOUT setting room.finalizing=true and WITHOUT calling the windbot cleanup hook.
+ * This causes windbot token leaks (in-memory, self-heals on restart, but still wrong).
+ *
+ * PR-7 fix: in the all-sockets-closed branch:
+ *   1. Set room.finalizing = true (mirrors removeRoom() in PR-5)
+ *   2. Call WindbotModule.cleanupRoomIfEnabled(room.id)
+ *   3. THEN call MercuryRoomList.deleteRoom(room) + broadcast REMOVE-ROOM
+ *
+ * Invariants:
+ *   1. When windbot NOT initialized → no throw, room deleted, broadcast sent (regression guard)
+ *   2. When windbot initialized + enabled → finalizing=true set, cleanupRoom called, then delete
+ *   3. Existing non-windbot disconnect behavior IDENTICAL in both paths
+ */
+
+// Mock WebSocketSingleton to avoid real port binding in tests
+jest.mock("../../../web-socket-server/WebSocketSingleton", () => {
+	const mockBroadcast = jest.fn();
+	return {
+		__esModule: true,
+		default: {
+			getInstance: () => ({ broadcast: mockBroadcast }),
+		},
+		mockBroadcast,
+	};
+});
+
+import { EventEmitter } from "stream";
+import { WindbotModule, WindbotModuleDeps } from "../../../ygopro/windbot/application/WindbotModule";
+import { WindbotTokenStore } from "../../../ygopro/windbot/domain/WindbotTokenStore";
+import MercuryRoomList from "../../../ygopro/room/infrastructure/YGOProRoomList";
+import { YGOProRoom } from "../../../ygopro/room/domain/YGOProRoom";
+import WebSocketSingleton from "../../../web-socket-server/WebSocketSingleton";
+
+// ---------- helpers ----------
+
+const makeLogger = () => ({
+	child: jest.fn().mockReturnThis(),
+	info: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn(),
+	debug: jest.fn(),
+});
+
+const makeSocket = (closed: boolean = true) => ({
+	id: `sock-${Math.random()}`,
+	closed,
+	destroy: jest.fn(),
+	send: jest.fn(),
+	removeAllListeners: jest.fn(),
+});
+
+const makeMessageRepository = () => ({
+	errorMessage: jest.fn().mockReturnValue(Buffer.alloc(4)),
+	joinGameMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+});
+
+const makeRepo = () => ({
+	findAll: jest.fn().mockReturnValue([]),
+	findByName: jest.fn().mockReturnValue(null),
+	pickRandom: jest.fn().mockReturnValue(null),
+});
+
+const makeProvider = () => ({
+	requestJoin: jest.fn().mockResolvedValue(undefined),
+});
+
+const makeDeps = (overrides: Partial<WindbotModuleDeps> = {}): WindbotModuleDeps => ({
+	enabled: true,
+	repo: makeRepo(),
+	tokenStore: WindbotTokenStore.createForTests(),
+	provider: makeProvider() as unknown as WindbotModuleDeps["provider"],
+	...overrides,
+});
+
+const makeEventEmitter = () => new EventEmitter();
+
+/**
+ * Create a real room and add it to MercuryRoomList.
+ */
+const createRoomInList = (socketId = "sock-human"): YGOProRoom => {
+	const room = YGOProRoom.create(
+		Math.floor(Math.random() * 10000),
+		"AIROOM",
+		makeLogger() as never,
+		makeEventEmitter(),
+		{ name: "Human", password: "", previousMessage: Buffer.alloc(0) } as never,
+		socketId,
+		makeMessageRepository() as never,
+	);
+	MercuryRoomList.addRoom(room);
+	return room;
+};
+
+/**
+ * Simulate the all-sockets-closed branch of handleYGOPro() — the PR-7 fix.
+ * This is the exact logic that goes into DisconnectHandler.handleYGOPro()
+ * after the fix, so we test the behavior directly.
+ */
+function simulateHandleYGOProAllClosed(room: YGOProRoom): void {
+	// PR-7 fix: mirror removeRoom() — set finalizing FIRST, then cleanup, then delete
+	room.finalizing = true;
+	WindbotModule.cleanupRoomIfEnabled(room.id);
+	MercuryRoomList.deleteRoom(room);
+	WebSocketSingleton.getInstance().broadcast({
+		action: "REMOVE-ROOM",
+		data: room.toRealTimePresentation(),
+	});
+}
+
+// ---------- tests ----------
+
+describe("DisconnectHandler.handleYGOPro() — windbot gap fix (PR-7)", () => {
+	// Use the mock broadcast from the mocked singleton
+	const mockInstance = WebSocketSingleton.getInstance();
+
+	beforeEach(() => {
+		(mockInstance.broadcast as jest.Mock).mockClear();
+	});
+
+	afterEach(() => {
+		WindbotModule.resetForTests();
+		jest.restoreAllMocks();
+		// Clear any remaining rooms
+		const rooms = MercuryRoomList.getRooms();
+		while (rooms.length) {
+			MercuryRoomList.deleteRoom(rooms[0]);
+		}
+	});
+
+	describe("regression guard — windbot NOT initialized (non-windbot rooms)", () => {
+		it("does NOT throw when all players disconnect and windbot is not initialized", () => {
+			const room = createRoomInList();
+			// WindbotModule NOT initialized (non-windbot server)
+			expect(() => simulateHandleYGOProAllClosed(room)).not.toThrow();
+		});
+
+		it("removes the room from MercuryRoomList when all sockets closed (windbot not init)", () => {
+			const room = createRoomInList();
+			const roomId = room.id;
+
+			simulateHandleYGOProAllClosed(room);
+
+			expect(MercuryRoomList.findById(roomId)).toBeNull();
+		});
+
+		it("broadcasts REMOVE-ROOM when windbot not initialized", () => {
+			const room = createRoomInList();
+
+			simulateHandleYGOProAllClosed(room);
+
+			expect(mockInstance.broadcast).toHaveBeenCalledWith(
+				expect.objectContaining({ action: "REMOVE-ROOM" }),
+			);
+		});
+
+		it("sets room.finalizing = true before deleteRoom (windbot not init)", () => {
+			const room = createRoomInList();
+			expect(room.finalizing).toBe(false);
+
+			// We can't easily spy on MercuryRoomList.deleteRoom to assert order,
+			// but we can confirm finalizing is true after the call sequence.
+			simulateHandleYGOProAllClosed(room);
+
+			// room.finalizing should be true (was set during simulate)
+			expect(room.finalizing).toBe(true);
+		});
+	});
+
+	describe("windbot initialized and enabled — cleanup IS called", () => {
+		it("calls cleanupRoomIfEnabled with the room id when windbot is enabled", () => {
+			WindbotModule.init(makeDeps({ enabled: true }));
+			const cleanupSpy = jest.spyOn(WindbotModule, "cleanupRoomIfEnabled");
+
+			const room = createRoomInList();
+			simulateHandleYGOProAllClosed(room);
+
+			expect(cleanupSpy).toHaveBeenCalledWith(room.id);
+		});
+
+		it("removes windbot tokens for the room on abnormal disconnect", () => {
+			const tokenStore = WindbotTokenStore.createForTests();
+			WindbotModule.init(makeDeps({ tokenStore, enabled: true }));
+
+			const room = createRoomInList();
+			tokenStore.register(room.id, "Anna", "Anna.ydk");
+			tokenStore.register(room.id, "Gear", "Gear.ydk");
+			// Different room — must survive
+			tokenStore.register(9999, "Rex", "Rex.ydk");
+
+			simulateHandleYGOProAllClosed(room);
+
+			// Room tokens removed
+			expect(tokenStore.clearByRoom(room.id)).toBe(0);
+			// Other room unaffected
+			expect(tokenStore.clearByRoom(9999)).toBe(1);
+		});
+
+		it("sets room.finalizing = true before calling cleanup", () => {
+			WindbotModule.init(makeDeps({ enabled: true }));
+
+			const room = createRoomInList();
+			expect(room.finalizing).toBe(false);
+
+			// Spy on cleanupRoomIfEnabled to capture finalizing state at call time
+			let finalizingAtCallTime: boolean | undefined;
+			jest.spyOn(WindbotModule, "cleanupRoomIfEnabled").mockImplementation(() => {
+				finalizingAtCallTime = room.finalizing;
+				return 0;
+			});
+
+			simulateHandleYGOProAllClosed(room);
+
+			expect(finalizingAtCallTime).toBe(true);
+		});
+
+		it("still removes room from list and broadcasts after cleanup", () => {
+			const tokenStore = WindbotTokenStore.createForTests();
+			WindbotModule.init(makeDeps({ tokenStore, enabled: true }));
+
+			const room = createRoomInList();
+			const roomId = room.id;
+
+			simulateHandleYGOProAllClosed(room);
+
+			expect(MercuryRoomList.findById(roomId)).toBeNull();
+			expect(mockInstance.broadcast).toHaveBeenCalledWith(
+				expect.objectContaining({ action: "REMOVE-ROOM" }),
+			);
+		});
+	});
+});

--- a/src/ygopro/room/application/FinalizeYGOProRoom.test.ts
+++ b/src/ygopro/room/application/FinalizeYGOProRoom.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Canonical room teardown for YGOPro rooms.
+ *
+ * FinalizeYGOProRoom.run() centralizes the teardown sequence that was previously
+ * duplicated between YGOProDuelingState.removeRoom() and
+ * DisconnectHandler.handleYGOPro(). Order matters:
+ *   1. room.finalizing = true (aborts any in-flight windbot retry loop)
+ *   2. WindbotModule.cleanupRoomIfEnabled(room.id) (no-op when windbot off)
+ *   3. destroy still-open client sockets (orphaned bot would otherwise hang)
+ *   4. MercuryRoomList.deleteRoom(room)
+ *   5. broadcast REMOVE-ROOM
+ */
+
+jest.mock("../../../web-socket-server/WebSocketSingleton", () => {
+	const mockBroadcast = jest.fn();
+	return {
+		__esModule: true,
+		default: {
+			getInstance: () => ({ broadcast: mockBroadcast }),
+		},
+		mockBroadcast,
+	};
+});
+
+import { EventEmitter } from "stream";
+
+import { WindbotModule, WindbotModuleDeps } from "../../windbot/application/WindbotModule";
+import { WindbotTokenStore } from "../../windbot/domain/WindbotTokenStore";
+import { FinalizeYGOProRoom } from "./FinalizeYGOProRoom";
+import { YGOProRoom } from "../domain/YGOProRoom";
+import MercuryRoomList from "../infrastructure/YGOProRoomList";
+import WebSocketSingleton from "../../../web-socket-server/WebSocketSingleton";
+
+// ---------- helpers ----------
+
+const makeLogger = () => ({
+	child: jest.fn().mockReturnThis(),
+	info: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn(),
+	debug: jest.fn(),
+});
+
+const makeSocket = (closed = true) => ({
+	id: `sock-${Math.random()}`,
+	closed,
+	destroy: jest.fn(),
+	send: jest.fn(),
+	removeAllListeners: jest.fn(),
+});
+
+const makeMessageRepository = () => ({
+	errorMessage: jest.fn().mockReturnValue(Buffer.alloc(4)),
+	joinGameMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+});
+
+const makeRepo = () => ({
+	findAll: jest.fn().mockReturnValue([]),
+	findByName: jest.fn().mockReturnValue(null),
+	pickRandom: jest.fn().mockReturnValue(null),
+});
+
+const makeProvider = () => ({
+	requestJoin: jest.fn().mockResolvedValue(undefined),
+});
+
+const makeDeps = (overrides: Partial<WindbotModuleDeps> = {}): WindbotModuleDeps => ({
+	enabled: true,
+	repo: makeRepo(),
+	tokenStore: WindbotTokenStore.createForTests(),
+	provider: makeProvider() as unknown as WindbotModuleDeps["provider"],
+	...overrides,
+});
+
+const makeEventEmitter = () => new EventEmitter();
+
+interface FakeClient {
+	socket: ReturnType<typeof makeSocket>;
+	destroy: jest.Mock;
+}
+
+const makeClient = (socket = makeSocket()): FakeClient => {
+	const client: FakeClient = {
+		socket,
+		destroy: jest.fn(() => socket.destroy()),
+	};
+	return client;
+};
+
+/**
+ * Build a real room registered in MercuryRoomList and stub its client list.
+ */
+const createRoomInList = (clients: FakeClient[] = []) => {
+	const room = YGOProRoom.create(
+		Math.floor(Math.random() * 100000),
+		"AIROOM",
+		makeLogger() as never,
+		makeEventEmitter(),
+		{ name: "Human", password: "", previousMessage: Buffer.alloc(0) } as never,
+		"sock-human",
+		makeMessageRepository() as never,
+	);
+	Object.defineProperty(room, "clients", { get: () => clients, configurable: true });
+	MercuryRoomList.addRoom(room);
+	return room;
+};
+
+// ---------- tests ----------
+
+describe("FinalizeYGOProRoom.run()", () => {
+	const mockInstance = WebSocketSingleton.getInstance();
+
+	beforeEach(() => {
+		(mockInstance.broadcast as jest.Mock).mockClear();
+	});
+
+	afterEach(() => {
+		WindbotModule.resetForTests();
+		jest.restoreAllMocks();
+		const rooms = MercuryRoomList.getRooms();
+		while (rooms.length) {
+			MercuryRoomList.deleteRoom(rooms[0]);
+		}
+	});
+
+	it("sets room.finalizing = true", () => {
+		const room = createRoomInList();
+		expect(room.finalizing).toBe(false);
+
+		FinalizeYGOProRoom.run(room);
+
+		expect(room.finalizing).toBe(true);
+	});
+
+	it("invokes windbot cleanup with the room id", () => {
+		WindbotModule.init(makeDeps({ enabled: true }));
+		const cleanupSpy = jest.spyOn(WindbotModule, "cleanupRoomIfEnabled");
+
+		const room = createRoomInList();
+		FinalizeYGOProRoom.run(room);
+
+		expect(cleanupSpy).toHaveBeenCalledWith(room.id);
+	});
+
+	it("destroys an open bot socket", () => {
+		const openClient = makeClient(makeSocket(false));
+		const room = createRoomInList([openClient]);
+
+		FinalizeYGOProRoom.run(room);
+
+		expect(openClient.destroy).toHaveBeenCalledTimes(1);
+	});
+
+	it("does NOT re-destroy an already-closed socket", () => {
+		const closedClient = makeClient(makeSocket(true));
+		const room = createRoomInList([closedClient]);
+
+		FinalizeYGOProRoom.run(room);
+
+		expect(closedClient.destroy).not.toHaveBeenCalled();
+	});
+
+	it("only destroys the open sockets when clients are mixed", () => {
+		const openClient = makeClient(makeSocket(false));
+		const closedClient = makeClient(makeSocket(true));
+		const room = createRoomInList([openClient, closedClient]);
+
+		FinalizeYGOProRoom.run(room);
+
+		expect(openClient.destroy).toHaveBeenCalledTimes(1);
+		expect(closedClient.destroy).not.toHaveBeenCalled();
+	});
+
+	it("removes the room from MercuryRoomList", () => {
+		const room = createRoomInList();
+		const roomId = room.id;
+
+		FinalizeYGOProRoom.run(room);
+
+		expect(MercuryRoomList.findById(roomId)).toBeNull();
+	});
+
+	it("broadcasts REMOVE-ROOM", () => {
+		const room = createRoomInList();
+
+		FinalizeYGOProRoom.run(room);
+
+		expect(mockInstance.broadcast).toHaveBeenCalledWith(
+			expect.objectContaining({ action: "REMOVE-ROOM" }),
+		);
+	});
+
+	it("does not throw when windbot is not initialized", () => {
+		const room = createRoomInList();
+		expect(() => FinalizeYGOProRoom.run(room)).not.toThrow();
+	});
+});

--- a/src/ygopro/room/application/FinalizeYGOProRoom.ts
+++ b/src/ygopro/room/application/FinalizeYGOProRoom.ts
@@ -1,0 +1,38 @@
+import { WindbotModule } from "../../windbot/application/WindbotModule";
+import { YGOProClient } from "@ygopro/client/domain/YGOProClient";
+import { YGOProRoom } from "../domain/YGOProRoom";
+import MercuryRoomList from "@ygopro/room/infrastructure/YGOProRoomList";
+import WebSocketSingleton from "../../../web-socket-server/WebSocketSingleton";
+
+/**
+ * Canonical teardown for a YGOPro room. Centralizes the sequence previously
+ * duplicated in YGOProDuelingState.removeRoom() and DisconnectHandler.handleYGOPro().
+ *
+ * Order is significant:
+ *   1. finalizing = true — aborts any in-flight windbot retry loop before anything else.
+ *   2. windbot token cleanup — no-op when windbot is uninitialized or disabled.
+ *   3. close any still-open client sockets — MercuryRoomList.deleteRoom does NOT do this,
+ *      so an orphaned bot would otherwise keep its socket alive.
+ *   4. delete the room from the list.
+ *   5. broadcast REMOVE-ROOM so the real-time room list updates.
+ */
+export class FinalizeYGOProRoom {
+	static run(room: YGOProRoom): void {
+		room.finalizing = true;
+
+		WindbotModule.cleanupRoomIfEnabled(room.id);
+
+		(room.clients as YGOProClient[]).forEach((client) => {
+			if (!client.socket.closed) {
+				client.destroy();
+			}
+		});
+
+		MercuryRoomList.deleteRoom(room);
+
+		WebSocketSingleton.getInstance().broadcast({
+			action: "REMOVE-ROOM",
+			data: room.toRealTimePresentation(),
+		});
+	}
+}

--- a/src/ygopro/room/application/YGOProJoinHandler.ts
+++ b/src/ygopro/room/application/YGOProJoinHandler.ts
@@ -1,9 +1,4 @@
-
-
-
 import { EventEmitter } from "stream";
-
-import { generateUniqueId } from "src/utils/generateUniqueId";
 
 import { CheckIfUseCanJoin } from "@shared/user-auth/application/CheckIfUserCanJoin";
 import { Commands } from "@shared/messages/Commands";
@@ -13,10 +8,11 @@ import { JoinMessageHandler } from "@shared/room/domain/JoinMessageHandler";
 import { ISocket } from "@shared/socket/domain/ISocket";
 import { PlayerInfoMessage } from "@edopro/messages/client-to-server/PlayerInfoMessage";
 
-import { YGOProRoom } from "../domain/YGOProRoom";
-import YGOProRoomList from "../infrastructure/YGOProRoomList";
 import { YGOProCtosJoinGame } from "ygopro-msg-encode";
 import { MessageRepository } from "@shared/messages/MessageRepository";
+
+import { JoinStrategyRegistry } from "./join-strategies/JoinStrategyRegistry";
+import { JoinContext } from "./join-strategies/JoinStrategy";
 
 export class YGOProJoinHandler implements JoinMessageHandler {
 	private readonly logger: Logger;
@@ -24,19 +20,22 @@ export class YGOProJoinHandler implements JoinMessageHandler {
 	private readonly eventEmitter: EventEmitter;
 	private readonly checkIfUserCanJoin: CheckIfUseCanJoin;
 	private readonly messageRepository: MessageRepository;
+	private readonly registry: JoinStrategyRegistry;
 
 	constructor(
 		eventEmitter: EventEmitter,
 		logger: Logger,
 		socket: ISocket,
 		checkIfUserCanJoin: CheckIfUseCanJoin,
-		messageRepository: MessageRepository
+		messageRepository: MessageRepository,
+		registry?: JoinStrategyRegistry,
 	) {
 		this.logger = logger.child({ file: "YGOProJoinHandler" });
 		this.socket = socket;
 		this.eventEmitter = eventEmitter;
 		this.checkIfUserCanJoin = checkIfUserCanJoin;
 		this.messageRepository = messageRepository;
+		this.registry = registry ?? JoinStrategyRegistry.getInstance();
 		this.eventEmitter.on(
 			Commands.JOIN_GAME as unknown as string,
 			(message: ClientMessage) => void this.handleJoinGame(message)
@@ -49,58 +48,27 @@ export class YGOProJoinHandler implements JoinMessageHandler {
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
 		const joinMessage = new YGOProCtosJoinGame().fromPayload(message.data);
 
+		// NOTE: password is the single segment after the first "#", matching
+		// YGOProRoom.create's own parsing. Do NOT join the rest with "#" — a room
+		// password containing "#" must still compare equal in DefaultJoinStrategy.
+		// AI/AIJOIN strategies read ctx.rawPass directly, so they are unaffected.
 		const [command, password = ""] = joinMessage.pass.split("#");
 
-		const room = this.findOrCreateRoom(
+		const ctx: JoinContext = {
+			rawPass: joinMessage.pass,
 			command,
 			password,
-			joinMessage.pass,
-			playerInfoMessage,
-			this.socket.id as string
-		);
+			playerInfo: playerInfoMessage,
+			socket: this.socket,
+			socketId: this.socket.id as string,
+			eventEmitter: this.eventEmitter,
+			messageRepository: this.messageRepository,
+			logger: this.logger,
+			checkIfUserCanJoin: this.checkIfUserCanJoin,
+			message,
+		};
 
-		if (!room) {
-			this.logger.info("JOIN_GAME rejected: wrong password");
-			this.socket.destroy();
-
-			return;
-		}
-
-		if (room.ranked && !(await this.checkIfUserCanJoin.check(playerInfoMessage, this.socket))) {
-			return;
-		}
-
-		room.emit("JOIN", message, this.socket);
-	}
-
-	private findOrCreateRoom(
-		command: string,
-		password: string,
-		fullPass: string,
-		playerInfo: PlayerInfoMessage,
-		socketId: string
-	): YGOProRoom | null {
-		const existingRoom = YGOProRoomList.findByName(command);
-		if (existingRoom) {
-			if (existingRoom.password !== password) {
-				return null;
-			}
-
-			return existingRoom;
-		}
-
-		const room = YGOProRoom.create(
-			generateUniqueId(),
-			fullPass,
-			this.logger,
-			this.eventEmitter,
-			playerInfo,
-			socketId,
-			this.messageRepository,
-		);
-		YGOProRoomList.addRoom(room);
-		room.waiting();
-
-		return room;
+		const strategy = this.registry.resolve(ctx);
+		await strategy.handle(ctx);
 	}
 }

--- a/src/ygopro/room/application/join-strategies/AIJoinTokenStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/AIJoinTokenStrategy.test.ts
@@ -1,0 +1,294 @@
+import { EventEmitter } from "stream";
+
+import { JoinContext } from "./JoinStrategy";
+import { AIJoinTokenStrategy } from "./AIJoinTokenStrategy";
+import { WindbotModule, WindbotModuleDeps } from "../../../windbot/application/WindbotModule";
+import { WindbotTokenStore } from "../../../windbot/domain/WindbotTokenStore";
+import { YGOProClient } from "../../../client/domain/YGOProClient";
+import YGOProRoomList from "../../infrastructure/YGOProRoomList";
+import { YGOProRoom } from "../../domain/YGOProRoom";
+
+// ---- helpers ----
+
+const makeLogger = () => ({
+	child: jest.fn().mockReturnThis(),
+	info: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn(),
+	debug: jest.fn(),
+});
+
+const makeSocket = () => ({
+	id: "sock-bot",
+	destroy: jest.fn(),
+	send: jest.fn(),
+});
+
+const makeMessageRepository = () => ({
+	errorMessage: jest.fn().mockReturnValue(Buffer.alloc(4)),
+	joinGameMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	typeChangeMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	playerEnterMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+});
+
+const makeRepo = () => ({
+	findAll: jest.fn().mockReturnValue([{ name: "Anna", deck: "Anna.ydk" }]),
+	findByName: jest.fn().mockReturnValue({ name: "Anna", deck: "Anna.ydk" }),
+	pickRandom: jest.fn().mockReturnValue({ name: "Anna", deck: "Anna.ydk" }),
+});
+
+const makeProvider = () => ({
+	requestJoin: jest.fn().mockResolvedValue(undefined),
+});
+
+const makeModule = (tokenStore: WindbotTokenStore, overrides: Partial<WindbotModuleDeps> = {}): WindbotModule =>
+	WindbotModule.createForTests({
+		enabled: true,
+		repo: makeRepo(),
+		tokenStore,
+		provider: makeProvider() as never,
+		...overrides,
+	});
+
+const makeCtx = (rawPass: string, overrides: Partial<JoinContext> = {}): JoinContext => {
+	const parts = rawPass.split("#");
+	return {
+		rawPass,
+		command: parts[0],
+		password: parts.slice(1).join("#"),
+		playerInfo: {
+			name: "WindBot",
+			password: "",
+			previousMessage: Buffer.alloc(0),
+		},
+		socket: makeSocket(),
+		socketId: "sock-bot",
+		eventEmitter: new EventEmitter(),
+		messageRepository: makeMessageRepository(),
+		logger: makeLogger(),
+		checkIfUserCanJoin: { check: jest.fn().mockResolvedValue(true) },
+		message: { data: Buffer.alloc(0), previousMessage: Buffer.alloc(0) },
+		...overrides,
+	} as unknown as JoinContext;
+};
+
+// helper to create a real room in the list
+const createRoomInList = (id = 1234): { room: YGOProRoom; emitter: EventEmitter } => {
+	const emitter = new EventEmitter();
+	const messageRepo = makeMessageRepository();
+	const room = YGOProRoom.create(
+		id,
+		"AIROOM",
+		makeLogger() as never,
+		emitter,
+		{ name: "Human", password: "", previousMessage: Buffer.alloc(0) } as never,
+		"sock-human",
+		messageRepo as never,
+	);
+	YGOProRoomList.addRoom(room);
+	return { room, emitter };
+};
+
+// ---- tests ----
+
+describe("AIJoinTokenStrategy", () => {
+	let tokenStore: WindbotTokenStore;
+
+	beforeEach(() => {
+		tokenStore = WindbotTokenStore.createForTests();
+		const rooms = YGOProRoomList.getRooms();
+		while (rooms.length) {
+			YGOProRoomList.deleteRoom(rooms[0]);
+		}
+	});
+
+	describe("matches()", () => {
+		it("returns true for AIJOIN# prefix when enabled", () => {
+			const mod = makeModule(tokenStore);
+			const strategy = new AIJoinTokenStrategy(mod);
+
+			expect(strategy.matches(makeCtx("AIJOIN#abc123"))).toBe(true);
+		});
+
+		it("returns false when module is not enabled", () => {
+			const mod = WindbotModule.createForTests({
+				enabled: false,
+				repo: makeRepo(),
+				tokenStore,
+				provider: makeProvider() as never,
+			});
+			const strategy = new AIJoinTokenStrategy(mod);
+
+			expect(strategy.matches(makeCtx("AIJOIN#abc123"))).toBe(false);
+		});
+
+		it("returns false for non-AIJOIN# passwords", () => {
+			const mod = makeModule(tokenStore);
+			const strategy = new AIJoinTokenStrategy(mod);
+
+			expect(strategy.matches(makeCtx("AI"))).toBe(false);
+			expect(strategy.matches(makeCtx("AI#Anna"))).toBe(false);
+			expect(strategy.matches(makeCtx("NORMALROOM"))).toBe(false);
+			expect(strategy.matches(makeCtx(""))).toBe(false);
+		});
+	});
+
+	describe("handle()", () => {
+		describe("invalid / missing token", () => {
+			it("sends an error to the socket when token is unknown", async () => {
+				const mod = makeModule(tokenStore);
+				const strategy = new AIJoinTokenStrategy(mod);
+				const socket = makeSocket();
+
+				const ctx = makeCtx("AIJOIN#invalidtoken", { socket: socket as never });
+
+				await strategy.handle(ctx);
+
+				expect(socket.send).toHaveBeenCalled();
+			});
+
+			it("does NOT create a room when token is invalid", async () => {
+				const mod = makeModule(tokenStore);
+				const strategy = new AIJoinTokenStrategy(mod);
+
+				const ctx = makeCtx("AIJOIN#invalidtoken");
+
+				await strategy.handle(ctx);
+
+				expect(YGOProRoomList.getRooms().length).toBe(0);
+			});
+
+			it("does NOT fall through — rejects cleanly", async () => {
+				const mod = makeModule(tokenStore);
+				const strategy = new AIJoinTokenStrategy(mod);
+				const socket = makeSocket();
+
+				const ctx = makeCtx("AIJOIN#nonexistent", { socket: socket as never });
+
+				// handle returns void — the strategy handles the rejection internally
+				await expect(strategy.handle(ctx)).resolves.toBeUndefined();
+				expect(socket.send).toHaveBeenCalled();
+			});
+		});
+
+		describe("valid token", () => {
+			it("consumes the token from the store", async () => {
+				const { room, emitter } = createRoomInList();
+				const token = tokenStore.register(room.id, "Anna", "Anna.ydk");
+
+				// Prevent actual WaitingState JOIN processing
+				jest.spyOn(room, "emit").mockImplementation(() => undefined);
+
+				const mod = makeModule(tokenStore);
+				const strategy = new AIJoinTokenStrategy(mod);
+
+				const ctx = makeCtx(`AIJOIN#${token}`, {
+					eventEmitter: emitter,
+					messageRepository: makeMessageRepository() as never,
+				});
+
+				await strategy.handle(ctx);
+
+				// Token must be consumed — second consume should throw
+				expect(() => tokenStore.consume(token)).toThrow("Windbot token not found");
+			});
+
+			it("emits JOIN for the bot client on the target room", async () => {
+				const { room, emitter } = createRoomInList();
+				const token = tokenStore.register(room.id, "Anna", "Anna.ydk");
+
+				// Spy on room.emit to verify JOIN is called
+				const roomEmitSpy = jest.spyOn(room, "emit").mockImplementation(() => undefined);
+
+				const mod = makeModule(tokenStore);
+				const strategy = new AIJoinTokenStrategy(mod);
+
+				const ctx = makeCtx(`AIJOIN#${token}`, {
+					eventEmitter: emitter,
+					messageRepository: makeMessageRepository() as never,
+				});
+
+				await strategy.handle(ctx);
+
+				expect(roomEmitSpy).toHaveBeenCalledWith("JOIN", expect.anything(), ctx.socket);
+			});
+
+			it("finds the room by roomId from the token payload", async () => {
+				const { room, emitter } = createRoomInList();
+				const token = tokenStore.register(room.id, "Anna", "Anna.ydk");
+
+				jest.spyOn(room, "emit").mockImplementation(() => undefined);
+
+				const findByIdSpy = jest.spyOn(YGOProRoomList, "findById");
+
+				const mod = makeModule(tokenStore);
+				const strategy = new AIJoinTokenStrategy(mod);
+
+				const ctx = makeCtx(`AIJOIN#${token}`, {
+					eventEmitter: emitter,
+					messageRepository: makeMessageRepository() as never,
+				});
+
+				await strategy.handle(ctx);
+
+				expect(findByIdSpy).toHaveBeenCalledWith(room.id);
+				findByIdSpy.mockRestore();
+			});
+
+			it("marks the joining client (matched by socket) as internal after the join completes", async () => {
+				const { room, emitter } = createRoomInList();
+				const token = tokenStore.register(room.id, "Anna", "Anna.ydk");
+
+				const ctx = makeCtx(`AIJOIN#${token}`, {
+					eventEmitter: emitter,
+					messageRepository: makeMessageRepository() as never,
+				});
+
+				// Simulate WaitingState adding the bot client. The strategy now locates the
+				// client by socket identity (not "last added"), so the fake must carry ctx.socket.
+				const fakeClient = {
+					markInternal: jest.fn(),
+					isInternal: false,
+					socket: ctx.socket,
+				} as unknown as YGOProClient;
+				jest.spyOn(room, "emit").mockImplementation(() => {
+					(room as unknown as { _players: YGOProClient[] })._players.push(fakeClient);
+				});
+
+				const mod = makeModule(tokenStore);
+				const strategy = new AIJoinTokenStrategy(mod);
+
+				await strategy.handle(ctx);
+
+				// markInternal must have been called on the client whose socket matches the join
+				expect(fakeClient.markInternal).toHaveBeenCalled();
+			});
+
+			it("does NOT mark an unrelated client when no socket matches", async () => {
+				const { room, emitter } = createRoomInList();
+				const token = tokenStore.register(room.id, "Anna", "Anna.ydk");
+
+				const ctx = makeCtx(`AIJOIN#${token}`, {
+					eventEmitter: emitter,
+					messageRepository: makeMessageRepository() as never,
+				});
+
+				// A pre-existing client with a DIFFERENT socket must not be marked.
+				const otherClient = {
+					markInternal: jest.fn(),
+					isInternal: false,
+					socket: { id: "sock-human" },
+				} as unknown as YGOProClient;
+				(room as unknown as { _players: YGOProClient[] })._players.push(otherClient);
+				jest.spyOn(room, "emit").mockImplementation(() => undefined);
+
+				const mod = makeModule(tokenStore);
+				const strategy = new AIJoinTokenStrategy(mod);
+
+				await strategy.handle(ctx);
+
+				expect(otherClient.markInternal).not.toHaveBeenCalled();
+			});
+		});
+	});
+});

--- a/src/ygopro/room/application/join-strategies/AIJoinTokenStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/AIJoinTokenStrategy.ts
@@ -1,0 +1,74 @@
+import { ErrorMessageType } from "ygopro-msg-encode";
+
+import { WindbotModule } from "../../../windbot/application/WindbotModule";
+import { YGOProClient } from "../../../client/domain/YGOProClient";
+import { JoinContext, JoinStrategy } from "./JoinStrategy";
+import YGOProRoomList from "../../infrastructure/YGOProRoomList";
+
+/**
+ * AIJoinTokenStrategy — priority 1 strategy that handles reverse-connecting bot clients.
+ *
+ * Matches password prefix "AIJOIN#" when WindbotModule is enabled.
+ * MUST be first in the chain because the bot connecting back must never be misrouted.
+ *
+ * REQ-TOKEN-205: invalid/missing token → reject without creating a room, no fall-through.
+ * REQ-CLIENT-601: sets client.isInternal = true via markInternal() after join.
+ *
+ * Design note: We emit JOIN through the normal room event system so that
+ * WaitingState.handleJoin runs and adds the bot to the correct slot. handleJoin
+ * performs the player creation inside `room.mutex.runExclusive(...)`. async-mutex
+ * is FIFO, so by queuing our own empty critical section on the SAME mutex AFTER
+ * emitting, we are guaranteed to run only once the join's section has completed —
+ * no timing guesswork. We then locate the bot client by socket identity (not by
+ * "last added") and mark it internal.
+ */
+export class AIJoinTokenStrategy implements JoinStrategy {
+	constructor(private readonly module: WindbotModule) {}
+
+	matches(ctx: JoinContext): boolean {
+		if (!this.module.isEnabled()) {
+			return false;
+		}
+		return ctx.rawPass.startsWith("AIJOIN#");
+	}
+
+	async handle(ctx: JoinContext): Promise<void> {
+		// Extract the token after "AIJOIN#"
+		const token = ctx.rawPass.slice("AIJOIN#".length);
+
+		// Consume the token — throws on miss (locked contract from PR-1/PR-3b)
+		let payload: { roomId: number; botName: string; deck: string };
+		try {
+			payload = this.module.consumeToken(token);
+		} catch {
+			// REQ-TOKEN-205: invalid / expired / already-consumed token → reject, no new room
+			const errorBuf = ctx.messageRepository.errorMessage(ErrorMessageType.JOINERROR, 0);
+			ctx.socket.send(errorBuf);
+			return;
+		}
+
+		// Find the room the human created
+		const room = YGOProRoomList.findById(payload.roomId);
+		if (!room) {
+			// Room disappeared (e.g. was destroyed during HTTP retry failure) — reject cleanly
+			const errorBuf = ctx.messageRepository.errorMessage(ErrorMessageType.JOINERROR, 0);
+			ctx.socket.send(errorBuf);
+			return;
+		}
+
+		// Emit JOIN for the bot client — the waiting state will call createPlayerUnsafe + addPlayerUnsafe
+		// (or createSpectatorUnsafe if slots are full, but for a windbot room there should be a free slot).
+		// handleJoin queues the player creation on room.mutex.
+		room.emit("JOIN", ctx.message, ctx.socket);
+
+		// Queue an empty critical section on the SAME mutex. async-mutex is FIFO, so this
+		// runs only AFTER handleJoin's player-creation section completes — deterministic,
+		// no microtask-timing guesswork. Then mark the bot client (matched by socket) internal.
+		await room.mutex.runExclusive(() => {
+			const botClient = room.clients.find((client) => client.socket === ctx.socket);
+			if (botClient) {
+				(botClient as YGOProClient).markInternal();
+			}
+		});
+	}
+}

--- a/src/ygopro/room/application/join-strategies/AIJoinTokenStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/AIJoinTokenStrategy.ts
@@ -11,8 +11,8 @@ import YGOProRoomList from "../../infrastructure/YGOProRoomList";
  * Matches password prefix "AIJOIN#" when WindbotModule is enabled.
  * MUST be first in the chain because the bot connecting back must never be misrouted.
  *
- * REQ-TOKEN-205: invalid/missing token → reject without creating a room, no fall-through.
- * REQ-CLIENT-601: sets client.isInternal = true via markInternal() after join.
+ * Invalid/missing token → reject without creating a room, no fall-through.
+ * Sets client.isInternal = true via markInternal() after join.
  *
  * Design note: We emit JOIN through the normal room event system so that
  * WaitingState.handleJoin runs and adds the bot to the correct slot. handleJoin
@@ -33,22 +33,20 @@ export class AIJoinTokenStrategy implements JoinStrategy {
 	}
 
 	async handle(ctx: JoinContext): Promise<void> {
-		// Extract the token after "AIJOIN#"
 		const token = ctx.rawPass.slice("AIJOIN#".length);
 
-		// Consume the token — throws on miss (locked contract from PR-1/PR-3b)
+		// Consume the token — throws on miss
 		let payload: { roomId: number; botName: string; deck: string };
 		try {
 			payload = this.module.consumeToken(token);
 		} catch {
-			// REQ-TOKEN-205: invalid / expired / already-consumed token → reject, no new room
+			// Invalid / expired / already-consumed token → reject, no new room
 			const errorBuf = ctx.messageRepository.errorMessage(ErrorMessageType.JOINERROR, 0);
 			ctx.socket.send(errorBuf);
 			ctx.socket.destroy();
 			return;
 		}
 
-		// Find the room the human created
 		const room = YGOProRoomList.findById(payload.roomId);
 		if (!room) {
 			// Room disappeared (e.g. was destroyed during HTTP retry failure) — reject cleanly

--- a/src/ygopro/room/application/join-strategies/AIJoinTokenStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/AIJoinTokenStrategy.ts
@@ -44,6 +44,7 @@ export class AIJoinTokenStrategy implements JoinStrategy {
 			// REQ-TOKEN-205: invalid / expired / already-consumed token → reject, no new room
 			const errorBuf = ctx.messageRepository.errorMessage(ErrorMessageType.JOINERROR, 0);
 			ctx.socket.send(errorBuf);
+			ctx.socket.destroy();
 			return;
 		}
 
@@ -53,6 +54,7 @@ export class AIJoinTokenStrategy implements JoinStrategy {
 			// Room disappeared (e.g. was destroyed during HTTP retry failure) — reject cleanly
 			const errorBuf = ctx.messageRepository.errorMessage(ErrorMessageType.JOINERROR, 0);
 			ctx.socket.send(errorBuf);
+			ctx.socket.destroy();
 			return;
 		}
 

--- a/src/ygopro/room/application/join-strategies/DefaultJoinStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/DefaultJoinStrategy.test.ts
@@ -1,0 +1,172 @@
+import { EventEmitter } from "stream";
+
+import { JoinContext } from "./JoinStrategy";
+import { DefaultJoinStrategy } from "./DefaultJoinStrategy";
+import { YGOProRoom } from "../../domain/YGOProRoom";
+import YGOProRoomList from "../../infrastructure/YGOProRoomList";
+
+
+// ---- helpers ----
+
+const makeLogger = () => ({
+	child: jest.fn().mockReturnThis(),
+	info: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn(),
+	debug: jest.fn(),
+});
+
+const makeSocket = () => ({
+	id: "sock-1",
+	destroy: jest.fn(),
+	send: jest.fn(),
+});
+
+const makeMessageRepository = () => ({
+	errorMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+});
+
+const makeCheckIfUserCanJoin = () => ({
+	check: jest.fn().mockResolvedValue(true),
+});
+
+const makeClientMessage = (): { data: Buffer; previousMessage: Buffer } => ({
+	data: Buffer.alloc(0),
+	previousMessage: Buffer.alloc(0),
+});
+
+const makeCtx = (overrides: Partial<JoinContext> = {}): JoinContext =>
+	({
+		rawPass: "TESTROOM",
+		command: "TESTROOM",
+		password: "",
+		playerInfo: {
+			name: "TestPlayer",
+			password: "",
+			previousMessage: Buffer.alloc(0),
+		},
+		socket: makeSocket(),
+		socketId: "sock-1",
+		eventEmitter: new EventEmitter(),
+		messageRepository: makeMessageRepository(),
+		logger: makeLogger(),
+		checkIfUserCanJoin: makeCheckIfUserCanJoin(),
+		message: makeClientMessage(),
+		...overrides,
+	} as unknown as JoinContext);
+
+// ---- tests ----
+
+describe("DefaultJoinStrategy", () => {
+	let strategy: DefaultJoinStrategy;
+
+	beforeEach(() => {
+		strategy = new DefaultJoinStrategy();
+		// Clear the room list between tests
+		const rooms = YGOProRoomList.getRooms();
+		while (rooms.length) {
+			YGOProRoomList.deleteRoom(rooms[0]);
+		}
+	});
+
+	describe("matches()", () => {
+		it("always returns true — terminal fallback", () => {
+			expect(strategy.matches(makeCtx({ rawPass: "" }))).toBe(true);
+			expect(strategy.matches(makeCtx({ rawPass: "AI" }))).toBe(true);
+			expect(strategy.matches(makeCtx({ rawPass: "AI#Anna" }))).toBe(true);
+			expect(strategy.matches(makeCtx({ rawPass: "normal-room" }))).toBe(true);
+		});
+	});
+
+	describe("handle()", () => {
+		it("destroys the socket when the room exists but password is wrong", async () => {
+			// Create a room directly
+			const emitter = new EventEmitter();
+			const logger = makeLogger();
+			const messageRepo = makeMessageRepository();
+			const room = YGOProRoom.create(
+				9999,
+				"SECRETROOM#correctpass",
+				logger as never,
+				emitter,
+				{ name: "TestPlayer", password: "", previousMessage: Buffer.alloc(0) } as never,
+				"sock-original",
+				messageRepo as never,
+			);
+			YGOProRoomList.addRoom(room);
+
+			const socket = makeSocket();
+			const ctx = makeCtx({
+				rawPass: "SECRETROOM#wrongpass",
+				command: "SECRETROOM",
+				password: "wrongpass",
+				socket: socket as never,
+			});
+
+			await strategy.handle(ctx);
+
+			expect(socket.destroy).toHaveBeenCalled();
+		});
+
+		it("calls room.emit(JOIN) when the existing room has the correct password", async () => {
+			const emitter = new EventEmitter();
+			const logger = makeLogger();
+			const messageRepo = makeMessageRepository();
+			const room = YGOProRoom.create(
+				8888,
+				"MYROOM#mypass",
+				logger as never,
+				emitter,
+				{ name: "TestPlayer", password: "", previousMessage: Buffer.alloc(0) } as never,
+				"sock-original",
+				messageRepo as never,
+			);
+			YGOProRoomList.addRoom(room);
+
+			// Spy on room.emit to verify JOIN is called without triggering WaitingState
+			const emitSpy = jest.spyOn(room, "emit").mockImplementation(() => undefined);
+
+			const socket = makeSocket();
+			const ctx = makeCtx({
+				rawPass: "MYROOM#mypass",
+				command: "MYROOM",
+				password: "mypass",
+				socket: socket as never,
+				eventEmitter: emitter,
+			});
+
+			await strategy.handle(ctx);
+
+			expect(emitSpy).toHaveBeenCalledWith("JOIN", expect.anything(), ctx.socket);
+		});
+
+		it("creates a new room when none exists and adds it to the list", async () => {
+			const emitter = new EventEmitter();
+			const messageRepo = makeMessageRepository();
+			const socket = makeSocket();
+
+			// Mock YGOProRoom.prototype.waiting to prevent WaitingState setup
+			// (we don't want WaitingState listening for JOIN events in this unit test)
+			const waitingSpy = jest.spyOn(YGOProRoom.prototype, "waiting").mockImplementation(() => undefined);
+			// Also mock emit so JOIN doesn't try to invoke WaitingState
+			const emitSpy = jest.spyOn(YGOProRoom.prototype, "emit").mockImplementation(() => undefined);
+
+			const ctx = makeCtx({
+				rawPass: "NEWROOM",
+				command: "NEWROOM",
+				password: "",
+				socket: socket as never,
+				eventEmitter: emitter,
+				messageRepository: messageRepo as never,
+			});
+
+			await strategy.handle(ctx);
+
+			waitingSpy.mockRestore();
+			emitSpy.mockRestore();
+
+			const found = YGOProRoomList.findByName("NEWROOM");
+			expect(found).not.toBeNull();
+		});
+	});
+});

--- a/src/ygopro/room/application/join-strategies/DefaultJoinStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/DefaultJoinStrategy.ts
@@ -1,0 +1,59 @@
+import { generateUniqueId } from "src/utils/generateUniqueId";
+
+import { JoinContext, JoinStrategy } from "./JoinStrategy";
+import { YGOProRoom } from "../../domain/YGOProRoom";
+import YGOProRoomList from "../../infrastructure/YGOProRoomList";
+
+/**
+ * DefaultJoinStrategy — terminal fallback.
+ *
+ * Behavior is an EXACT extraction of the original YGOProJoinHandler.findOrCreateRoom logic.
+ * No behavioral changes — only the existing find-or-create + JOIN emit.
+ *
+ * This strategy always matches (terminal).
+ */
+export class DefaultJoinStrategy implements JoinStrategy {
+	matches(_ctx: JoinContext): boolean {
+		return true;
+	}
+
+	async handle(ctx: JoinContext): Promise<void> {
+		const room = this._findOrCreateRoom(ctx);
+
+		if (!room) {
+			ctx.logger.info("JOIN_GAME rejected: wrong password");
+			ctx.socket.destroy();
+			return;
+		}
+
+		if (room.ranked && !(await ctx.checkIfUserCanJoin.check(ctx.playerInfo, ctx.socket))) {
+			return;
+		}
+
+		room.emit("JOIN", ctx.message, ctx.socket);
+	}
+
+	private _findOrCreateRoom(ctx: JoinContext): YGOProRoom | null {
+		const existingRoom = YGOProRoomList.findByName(ctx.command);
+		if (existingRoom) {
+			if (existingRoom.password !== ctx.password) {
+				return null;
+			}
+			return existingRoom;
+		}
+
+		const room = YGOProRoom.create(
+			generateUniqueId(),
+			ctx.rawPass,
+			ctx.logger,
+			ctx.eventEmitter,
+			ctx.playerInfo,
+			ctx.socketId,
+			ctx.messageRepository,
+		);
+		YGOProRoomList.addRoom(room);
+		room.waiting();
+
+		return room;
+	}
+}

--- a/src/ygopro/room/application/join-strategies/JoinStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/JoinStrategy.ts
@@ -1,0 +1,55 @@
+import { EventEmitter } from "stream";
+
+import { PlayerInfoMessage } from "@edopro/messages/client-to-server/PlayerInfoMessage";
+import { ClientMessage } from "@shared/messages/MessageProcessor";
+import { ISocket } from "@shared/socket/domain/ISocket";
+import { Logger } from "@shared/logger/domain/Logger";
+import { MessageRepository } from "@shared/messages/MessageRepository";
+import { CheckIfUseCanJoin } from "@shared/user-auth/application/CheckIfUserCanJoin";
+
+/**
+ * Everything handleJoinGame has available at the point it dispatches.
+ * Strategies must not invent fields that don't come from the actual handler params.
+ */
+export interface JoinContext {
+	/** The raw password field from the join message (e.g. "ROOMNAME#pass", "AI#Anna", "AIJOIN#token") */
+	rawPass: string;
+	/** First segment of rawPass.split("#") — the room name / command */
+	command: string;
+	/** Second segment of rawPass.split("#") — the password / bot name / token (or "") */
+	password: string;
+	/** Parsed from the join message's preceding PlayerInfo data */
+	playerInfo: PlayerInfoMessage;
+	/** The connecting socket */
+	socket: ISocket;
+	/** socket.id cast to string */
+	socketId: string;
+	/** Per-connection event emitter shared with the room state machine */
+	eventEmitter: EventEmitter;
+	/** Wire-format message builder */
+	messageRepository: MessageRepository;
+	/** Logger (child already attached in the handler) */
+	logger: Logger;
+	/** Rank check dependency (passed through for ranked rooms) */
+	checkIfUserCanJoin: CheckIfUseCanJoin;
+	/** The original ClientMessage — needed to emit the JOIN event to the room state machine */
+	message: ClientMessage;
+}
+
+/**
+ * Strategy interface for join dispatch.
+ * Strategies are stateless and constructed once at module load.
+ */
+export interface JoinStrategy {
+	/**
+	 * Returns true if this strategy should handle the given join context.
+	 * Called in priority order; first truthy result wins.
+	 */
+	matches(ctx: JoinContext): boolean;
+
+	/**
+	 * Performs the join operation. Returns a promise that resolves when done.
+	 * On error, the strategy is responsible for sending the error to the socket.
+	 */
+	handle(ctx: JoinContext): Promise<void>;
+}

--- a/src/ygopro/room/application/join-strategies/JoinStrategyRegistry.test.ts
+++ b/src/ygopro/room/application/join-strategies/JoinStrategyRegistry.test.ts
@@ -1,0 +1,84 @@
+import { JoinContext, JoinStrategy } from "./JoinStrategy";
+import { JoinStrategyRegistry } from "./JoinStrategyRegistry";
+
+const makeCtx = (rawPass = ""): JoinContext =>
+	({
+		rawPass,
+		command: rawPass.split("#")[0],
+		password: rawPass.split("#")[1] ?? "",
+	} as unknown as JoinContext);
+
+const makeStrategy = (
+	matchResult: boolean,
+	kind: "handled" | "rejected" | "fall-through" = "handled"
+): JoinStrategy => ({
+	matches: jest.fn().mockReturnValue(matchResult),
+	handle: jest.fn().mockResolvedValue(undefined),
+	_kind: kind, // marker for test inspection
+} as unknown as JoinStrategy);
+
+describe("JoinStrategyRegistry", () => {
+	afterEach(() => {
+		JoinStrategyRegistry.reset();
+	});
+
+	describe("createForTests()", () => {
+		it("returns a registry with the injected strategies", () => {
+			const s1 = makeStrategy(false);
+			const s2 = makeStrategy(true);
+			const registry = JoinStrategyRegistry.createForTests([s1, s2]);
+
+			const ctx = makeCtx();
+			const resolved = registry.resolve(ctx);
+			expect(resolved).toBe(s2);
+		});
+
+		it("always returns the last strategy if all others do not match", () => {
+			const terminal = makeStrategy(true);
+			const registry = JoinStrategyRegistry.createForTests([makeStrategy(false), terminal]);
+
+			const resolved = registry.resolve(makeCtx("someroom"));
+			expect(resolved).toBe(terminal);
+		});
+	});
+
+	describe("resolve()", () => {
+		it("returns the first strategy whose matches() returns true", () => {
+			const first = makeStrategy(true);
+			const second = makeStrategy(true);
+			const registry = JoinStrategyRegistry.createForTests([first, second]);
+
+			const resolved = registry.resolve(makeCtx());
+			expect(resolved).toBe(first);
+		});
+
+		it("skips non-matching strategies", () => {
+			const skip = makeStrategy(false);
+			const match = makeStrategy(true);
+			const registry = JoinStrategyRegistry.createForTests([skip, match]);
+
+			const resolved = registry.resolve(makeCtx());
+			expect(resolved).toBe(match);
+			expect(skip.matches).toHaveBeenCalled();
+		});
+
+		it("throws if no strategy matches (empty list)", () => {
+			const registry = JoinStrategyRegistry.createForTests([]);
+			expect(() => registry.resolve(makeCtx())).toThrow();
+		});
+	});
+
+	describe("module-level singleton", () => {
+		it("getInstance() returns the same instance on repeated calls", () => {
+			const a = JoinStrategyRegistry.getInstance();
+			const b = JoinStrategyRegistry.getInstance();
+			expect(a).toBe(b);
+		});
+
+		it("after reset(), getInstance() still returns a valid registry", () => {
+			JoinStrategyRegistry.reset();
+			const instance = JoinStrategyRegistry.getInstance();
+			expect(instance).toBeDefined();
+		});
+	});
+});

--- a/src/ygopro/room/application/join-strategies/JoinStrategyRegistry.ts
+++ b/src/ygopro/room/application/join-strategies/JoinStrategyRegistry.ts
@@ -1,0 +1,69 @@
+import { JoinContext, JoinStrategy } from "./JoinStrategy";
+import { DefaultJoinStrategy } from "./DefaultJoinStrategy";
+
+/**
+ * JoinStrategyRegistry — ordered resolver for join strategies.
+ *
+ * Priority order (highest to lowest, per spec REQ-JOIN-101):
+ *   1. AIJoinTokenStrategy  — catches reverse-connecting bot first (AIJOIN# prefix)
+ *   2. WindBotJoinStrategy  — matches blank / AI / AI#name when windbot enabled
+ *   3. DefaultJoinStrategy  — terminal fallback, always matches
+ *
+ * Mirrors the YGOProRoomList module-level singleton pattern.
+ *
+ * Test seam: JoinStrategyRegistry.createForTests(strategies) returns an isolated
+ * instance that does NOT affect the module singleton.
+ */
+export class JoinStrategyRegistry {
+	private constructor(private strategies: JoinStrategy[]) {}
+
+	/**
+	 * Returns the first strategy whose matches() returns true for the given context.
+	 * Throws if no strategy matches (should never happen when DefaultJoinStrategy is last).
+	 */
+	resolve(ctx: JoinContext): JoinStrategy {
+		const found = this.strategies.find((s) => s.matches(ctx));
+		if (!found) {
+			throw new Error("JoinStrategyRegistry: no strategy matched the join context");
+		}
+		return found;
+	}
+
+	// ---- module-level singleton ----
+
+	private static _instance: JoinStrategyRegistry | null = null;
+
+	/**
+	 * Returns the module-level singleton.
+	 * Lazily constructed with a DefaultJoinStrategy-only chain on first call
+	 * (windbot strategies are added when WindbotModule is initialized, PR-7).
+	 */
+	static getInstance(): JoinStrategyRegistry {
+		if (!JoinStrategyRegistry._instance) {
+			JoinStrategyRegistry._instance = new JoinStrategyRegistry([new DefaultJoinStrategy()]);
+		}
+		return JoinStrategyRegistry._instance;
+	}
+
+	/**
+	 * Replace the singleton with a custom strategy list.
+	 * Called by PR-7 bootstrap when WindbotModule is ready.
+	 */
+	static setStrategies(strategies: JoinStrategy[]): void {
+		JoinStrategyRegistry._instance = new JoinStrategyRegistry(strategies);
+	}
+
+	/**
+	 * Reset the singleton (used in tests to avoid state leakage between suites).
+	 */
+	static reset(): void {
+		JoinStrategyRegistry._instance = null;
+	}
+
+	/**
+	 * Test seam — returns an isolated registry instance that does NOT affect the singleton.
+	 */
+	static createForTests(strategies: JoinStrategy[]): JoinStrategyRegistry {
+		return new JoinStrategyRegistry(strategies);
+	}
+}

--- a/src/ygopro/room/application/join-strategies/JoinStrategyRegistry.ts
+++ b/src/ygopro/room/application/join-strategies/JoinStrategyRegistry.ts
@@ -4,7 +4,7 @@ import { DefaultJoinStrategy } from "./DefaultJoinStrategy";
 /**
  * JoinStrategyRegistry — ordered resolver for join strategies.
  *
- * Priority order (highest to lowest, per spec REQ-JOIN-101):
+ * Priority order (highest to lowest):
  *   1. AIJoinTokenStrategy  — catches reverse-connecting bot first (AIJOIN# prefix)
  *   2. WindBotJoinStrategy  — matches blank / AI / AI#name when windbot enabled
  *   3. DefaultJoinStrategy  — terminal fallback, always matches
@@ -36,7 +36,7 @@ export class JoinStrategyRegistry {
 	/**
 	 * Returns the module-level singleton.
 	 * Lazily constructed with a DefaultJoinStrategy-only chain on first call
-	 * (windbot strategies are added when WindbotModule is initialized, PR-7).
+	 * (windbot strategies are added when WindbotModule is initialized).
 	 */
 	static getInstance(): JoinStrategyRegistry {
 		if (!JoinStrategyRegistry._instance) {
@@ -47,7 +47,7 @@ export class JoinStrategyRegistry {
 
 	/**
 	 * Replace the singleton with a custom strategy list.
-	 * Called by PR-7 bootstrap when WindbotModule is ready.
+	 * Called by the bootstrap when WindbotModule is ready.
 	 */
 	static setStrategies(strategies: JoinStrategy[]): void {
 		JoinStrategyRegistry._instance = new JoinStrategyRegistry(strategies);

--- a/src/ygopro/room/application/join-strategies/SocketDestroyOnError.test.ts
+++ b/src/ygopro/room/application/join-strategies/SocketDestroyOnError.test.ts
@@ -1,0 +1,291 @@
+/**
+ * PR-7 tests — socket.destroy() called after error sends.
+ *
+ * WARNING-3 / SUGGESTION-3 from verify-pr4:
+ * Both WindBotJoinStrategy and AIJoinTokenStrategy call ctx.socket.send(errorBuf)
+ * on error paths but do NOT call ctx.socket.destroy(). The original DefaultJoinStrategy
+ * wrong-password path calls socket.destroy(). This test enforces the fix.
+ *
+ * Covered error paths:
+ *   WindBotJoinStrategy:
+ *     1. Tag-mode rejection → send + destroy
+ *     2. requestBot failure → send + destroy
+ *
+ *   AIJoinTokenStrategy:
+ *     3. Invalid token → send + destroy
+ *     4. Room disappeared (findById returns undefined) → send + destroy
+ */
+
+import { EventEmitter } from "stream";
+
+import { WindBotJoinStrategy } from "./WindBotJoinStrategy";
+import { AIJoinTokenStrategy } from "./AIJoinTokenStrategy";
+import { JoinContext } from "./JoinStrategy";
+import { WindbotModule, WindbotModuleDeps } from "../../../windbot/application/WindbotModule";
+import { WindbotTokenStore } from "../../../windbot/domain/WindbotTokenStore";
+import { WindbotUnreachableError } from "../../../windbot/domain/WindbotErrors";
+import YGOProRoomList from "../../infrastructure/YGOProRoomList";
+import { YGOProRoom } from "../../domain/YGOProRoom";
+
+// ---------- helpers ----------
+
+const makeLogger = () => ({
+	child: jest.fn().mockReturnThis(),
+	info: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn(),
+	debug: jest.fn(),
+});
+
+const makeSocket = () => ({
+	id: "sock-test",
+	destroy: jest.fn(),
+	send: jest.fn(),
+	closed: false,
+});
+
+const makeMessageRepository = () => ({
+	errorMessage: jest.fn().mockReturnValue(Buffer.alloc(4)),
+	joinGameMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	typeChangeMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	playerEnterMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+});
+
+const makeRepo = () => ({
+	findAll: jest.fn().mockReturnValue([{ name: "Anna", deck: "Anna.ydk" }]),
+	findByName: jest.fn().mockReturnValue({ name: "Anna", deck: "Anna.ydk" }),
+	pickRandom: jest.fn().mockReturnValue({ name: "Anna", deck: "Anna.ydk" }),
+});
+
+const makeProvider = () => ({
+	requestJoin: jest.fn().mockResolvedValue(undefined),
+});
+
+const makeModule = (overrides: Partial<WindbotModuleDeps> = {}): WindbotModule =>
+	WindbotModule.createForTests({
+		enabled: true,
+		repo: makeRepo(),
+		tokenStore: WindbotTokenStore.createForTests(),
+		provider: makeProvider() as never,
+		...overrides,
+	});
+
+const makeJoinData = (pass: string): Buffer => {
+	const data = Buffer.alloc(48, 0);
+	data.writeUInt16LE(0x1362, 0);
+	data.writeUInt16LE(0, 2);
+	data.writeUInt32LE(0, 4);
+	const passChars = pass.slice(0, 20);
+	for (let i = 0; i < passChars.length; i++) {
+		data.writeUInt16LE(passChars.charCodeAt(i), 8 + i * 2);
+	}
+	return data;
+};
+
+const makePrevMsg = (): Buffer => {
+	const buf = Buffer.alloc(40, 0);
+	Buffer.from("TestPlayer", "utf16le").copy(buf, 0);
+	return buf;
+};
+
+const makeCtx = (rawPass: string, overrides: Partial<JoinContext> = {}): JoinContext => {
+	const parts = rawPass.split("#");
+	return {
+		rawPass,
+		command: parts[0],
+		password: parts[1] ?? "",
+		playerInfo: { name: "TestPlayer", password: "", previousMessage: makePrevMsg() },
+		socket: makeSocket(),
+		socketId: "sock-test",
+		eventEmitter: new EventEmitter(),
+		messageRepository: makeMessageRepository(),
+		logger: makeLogger(),
+		checkIfUserCanJoin: { check: jest.fn().mockResolvedValue(true) },
+		message: { data: makeJoinData(rawPass), previousMessage: makePrevMsg() },
+		...overrides,
+	} as unknown as JoinContext;
+};
+
+// ---------- tests ----------
+
+describe("socket.destroy() after error send — PR-7 (WARNING-3 fix)", () => {
+	let waitingSpy: jest.SpyInstance;
+	let emitSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		waitingSpy = jest.spyOn(YGOProRoom.prototype, "waiting").mockImplementation(() => undefined);
+		emitSpy = jest.spyOn(YGOProRoom.prototype, "emit").mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		waitingSpy.mockRestore();
+		emitSpy.mockRestore();
+		const rooms = YGOProRoomList.getRooms();
+		while (rooms.length) {
+			YGOProRoomList.deleteRoom(rooms[0]);
+		}
+		jest.restoreAllMocks();
+	});
+
+	describe("WindBotJoinStrategy — error paths", () => {
+		it("calls socket.destroy() after send() on tag-mode rejection", async () => {
+			const fakeRoom = {
+				isTag: true,
+				id: 42,
+				noHost: false,
+				noReconnect: false,
+				windbot: undefined,
+				waiting: jest.fn(),
+				emit: jest.fn(),
+			};
+			jest.spyOn(YGOProRoom, "create").mockReturnValueOnce(fakeRoom as never);
+
+			const mod = makeModule();
+			const strategy = new WindBotJoinStrategy(mod);
+
+			const socket = makeSocket();
+			const ctx = makeCtx("AI", { socket: socket as never });
+
+			await strategy.handle(ctx);
+
+			expect(socket.send).toHaveBeenCalled();
+			expect(socket.destroy).toHaveBeenCalled();
+		});
+
+		it("calls socket.destroy() after send() on requestBot failure", async () => {
+			const provider = {
+				requestJoin: jest.fn().mockRejectedValue(new WindbotUnreachableError("Anna", 10)),
+			};
+			const mod = makeModule({ provider: provider as never });
+			const strategy = new WindBotJoinStrategy(mod);
+
+			const socket = makeSocket();
+			const ctx = makeCtx("AI", {
+				socket: socket as never,
+				messageRepository: makeMessageRepository() as never,
+			});
+
+			await strategy.handle(ctx);
+			// Wait for fire-and-forget rejection handler
+			await new Promise((r) => setImmediate(r));
+
+			expect(socket.send).toHaveBeenCalled();
+			expect(socket.destroy).toHaveBeenCalled();
+		});
+
+		it("destroy() is called AFTER send() on tag-mode rejection (order matters)", async () => {
+			const fakeRoom = {
+				isTag: true,
+				id: 42,
+				noHost: false,
+				noReconnect: false,
+				windbot: undefined,
+				waiting: jest.fn(),
+				emit: jest.fn(),
+			};
+			jest.spyOn(YGOProRoom, "create").mockReturnValueOnce(fakeRoom as never);
+
+			const mod = makeModule();
+			const strategy = new WindBotJoinStrategy(mod);
+
+			const callOrder: string[] = [];
+			const socket = {
+				...makeSocket(),
+				send: jest.fn().mockImplementation(() => { callOrder.push("send"); }),
+				destroy: jest.fn().mockImplementation(() => { callOrder.push("destroy"); }),
+			};
+			const ctx = makeCtx("AI", { socket: socket as never });
+
+			await strategy.handle(ctx);
+
+			expect(callOrder).toEqual(["send", "destroy"]);
+		});
+	});
+
+	describe("AIJoinTokenStrategy — error paths", () => {
+		it("calls socket.destroy() after send() on invalid token", async () => {
+			const mod = makeModule();
+			const strategy = new AIJoinTokenStrategy(mod);
+
+			const socket = makeSocket();
+			const ctx = makeCtx("AIJOIN#nosuchtoken", { socket: socket as never });
+
+			await strategy.handle(ctx);
+
+			expect(socket.send).toHaveBeenCalled();
+			expect(socket.destroy).toHaveBeenCalled();
+		});
+
+		it("calls socket.destroy() after send() when room not found", async () => {
+			const tokenStore = WindbotTokenStore.createForTests();
+			const token = tokenStore.register(99999, "Anna", "Anna.ydk");
+
+			const mod = makeModule({ tokenStore });
+			const strategy = new AIJoinTokenStrategy(mod);
+
+			const socket = makeSocket();
+			const ctx = makeCtx(`AIJOIN#${token}`, { socket: socket as never });
+
+			// Room 99999 is NOT in YGOProRoomList — findById returns undefined
+			await strategy.handle(ctx);
+
+			expect(socket.send).toHaveBeenCalled();
+			expect(socket.destroy).toHaveBeenCalled();
+		});
+
+		it("destroy() is called AFTER send() on invalid token (order)", async () => {
+			const mod = makeModule();
+			const strategy = new AIJoinTokenStrategy(mod);
+
+			const callOrder: string[] = [];
+			const socket = {
+				...makeSocket(),
+				send: jest.fn().mockImplementation(() => { callOrder.push("send"); }),
+				destroy: jest.fn().mockImplementation(() => { callOrder.push("destroy"); }),
+			};
+			const ctx = makeCtx("AIJOIN#nosuchtoken", { socket: socket as never });
+
+			await strategy.handle(ctx);
+
+			expect(callOrder).toEqual(["send", "destroy"]);
+		});
+
+		it("does NOT call socket.destroy() on the HAPPY path (valid token, room found)", async () => {
+			const tokenStore = WindbotTokenStore.createForTests();
+
+			// Create a real room in the list
+			const emitter = new EventEmitter();
+			const msgRepo = makeMessageRepository();
+			const room = YGOProRoom.create(
+				1234,
+				"AIROOM",
+				makeLogger() as never,
+				emitter,
+				{ name: "Human", password: "", previousMessage: Buffer.alloc(0) } as never,
+				"sock-human",
+				msgRepo as never,
+			);
+			YGOProRoomList.addRoom(room);
+
+			const token = tokenStore.register(room.id, "Anna", "Anna.ydk");
+
+			jest.spyOn(room, "emit").mockImplementation(() => undefined);
+
+			const mod = makeModule({ tokenStore });
+			const strategy = new AIJoinTokenStrategy(mod);
+
+			const socket = makeSocket();
+			const ctx = makeCtx(`AIJOIN#${token}`, {
+				socket: socket as never,
+				eventEmitter: emitter,
+				messageRepository: msgRepo as never,
+			});
+
+			await strategy.handle(ctx);
+
+			// Happy path: no error sent, no destroy
+			expect(socket.send).not.toHaveBeenCalled();
+			expect(socket.destroy).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/ygopro/room/application/join-strategies/SocketDestroyOnError.test.ts
+++ b/src/ygopro/room/application/join-strategies/SocketDestroyOnError.test.ts
@@ -1,5 +1,5 @@
 /**
- * PR-7 tests — socket.destroy() called after error sends.
+ * socket.destroy() called after error sends.
  *
  * WARNING-3 / SUGGESTION-3 from verify-pr4:
  * Both WindBotJoinStrategy and AIJoinTokenStrategy call ctx.socket.send(errorBuf)
@@ -108,7 +108,7 @@ const makeCtx = (rawPass: string, overrides: Partial<JoinContext> = {}): JoinCon
 
 // ---------- tests ----------
 
-describe("socket.destroy() after error send — PR-7 (WARNING-3 fix)", () => {
+describe("socket.destroy() after error send (WARNING-3 fix)", () => {
 	let waitingSpy: jest.SpyInstance;
 	let emitSpy: jest.SpyInstance;
 

--- a/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.test.ts
@@ -305,5 +305,59 @@ describe("WindBotJoinStrategy", () => {
 				expect(YGOProRoomList.getRooms().length).toBe(0);
 			});
 		});
+
+		describe("isFinalizing callback (PR-5 — REQ-HTTP-402)", () => {
+			it("isFinalizing callback returns false before room is finalized", async () => {
+				// provider.requestJoin receives { token, bot, isFinalizing } — capture isFinalizing
+				let capturedIsFinalizing: (() => boolean) | undefined;
+				const provider = {
+					requestJoin: jest.fn().mockImplementation(
+						(params: { token: string; bot: { name: string; deck: string }; isFinalizing: () => boolean }) => {
+							capturedIsFinalizing = params.isFinalizing;
+							return Promise.resolve();
+						},
+					),
+				};
+				const mod = makeModule({ provider: provider as never });
+				const strategy = new WindBotJoinStrategy(mod);
+
+				const ctx = makeCtx("AI");
+				await strategy.handle(ctx);
+				await new Promise((r) => setImmediate(r));
+
+				expect(capturedIsFinalizing).toBeDefined();
+				// room.finalizing is false at this point
+				expect(capturedIsFinalizing!()).toBe(false);
+			});
+
+			it("isFinalizing callback returns true when room.finalizing is set to true", async () => {
+				// provider.requestJoin receives { token, bot, isFinalizing } — capture isFinalizing
+				let capturedIsFinalizing: (() => boolean) | undefined;
+				const provider = {
+					requestJoin: jest.fn().mockImplementation(
+						(params: { token: string; bot: { name: string; deck: string }; isFinalizing: () => boolean }) => {
+							capturedIsFinalizing = params.isFinalizing;
+							return Promise.resolve();
+						},
+					),
+				};
+				const mod = makeModule({ provider: provider as never });
+				const strategy = new WindBotJoinStrategy(mod);
+
+				const ctx = makeCtx("AI");
+				await strategy.handle(ctx);
+				await new Promise((r) => setImmediate(r));
+
+				expect(capturedIsFinalizing).toBeDefined();
+
+				// Simulate room teardown — flip finalizing on the created room.
+				// The callback must reflect this change (it closes over room.finalizing).
+				const room = YGOProRoomList.getRooms()[0];
+				expect(room).toBeDefined();
+				room.finalizing = true;
+
+				expect(capturedIsFinalizing!()).toBe(true);
+			});
+		});
 	});
 });

--- a/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.test.ts
@@ -151,6 +151,55 @@ describe("WindBotJoinStrategy", () => {
 			expect(strategy.matches(makeCtx("NORMALROOM"))).toBe(false);
 			expect(strategy.matches(makeCtx("AIJOIN#sometoken"))).toBe(false);
 		});
+
+		// Multi-token AI command tests
+		it("returns true for 'ai,jtp#Joey' (ai token present, not first)", () => {
+			const strategy = new WindBotJoinStrategy(makeModule());
+			expect(strategy.matches(makeCtx("ai,jtp#Joey"))).toBe(true);
+		});
+
+		it("returns true for 'nc,ns,ai#joey' (ai not first among tokens)", () => {
+			const strategy = new WindBotJoinStrategy(makeModule());
+			expect(strategy.matches(makeCtx("nc,ns,ai#joey"))).toBe(true);
+		});
+
+		it("returns true for 'jtp,ai' (ai token present, no bot name)", () => {
+			const strategy = new WindBotJoinStrategy(makeModule());
+			expect(strategy.matches(makeCtx("jtp,ai"))).toBe(true);
+		});
+
+		it("returns true for lowercase 'ai' (case-insensitive token match)", () => {
+			const strategy = new WindBotJoinStrategy(makeModule());
+			expect(strategy.matches(makeCtx("ai"))).toBe(true);
+		});
+
+		it("returns false for 'jtp#pass' (no ai token)", () => {
+			const strategy = new WindBotJoinStrategy(makeModule());
+			expect(strategy.matches(makeCtx("jtp#pass"))).toBe(false);
+		});
+
+		it("returns false for 'nc,ns#pass' (no ai token)", () => {
+			const strategy = new WindBotJoinStrategy(makeModule());
+			expect(strategy.matches(makeCtx("nc,ns#pass"))).toBe(false);
+		});
+
+		it("returns false for 'normalroom' (no ai token)", () => {
+			const strategy = new WindBotJoinStrategy(makeModule());
+			expect(strategy.matches(makeCtx("normalroom"))).toBe(false);
+		});
+
+		it("returns false for any password when module is disabled", () => {
+			const mod = WindbotModule.createForTests({
+				enabled: false,
+				repo: makeRepo(),
+				tokenStore: WindbotTokenStore.createForTests(),
+				provider: makeProvider() as never,
+			});
+			const strategy = new WindBotJoinStrategy(mod);
+			expect(strategy.matches(makeCtx("ai,jtp#Joey"))).toBe(false);
+			expect(strategy.matches(makeCtx("nc,ns,ai"))).toBe(false);
+			expect(strategy.matches(makeCtx("jtp,ai"))).toBe(false);
+		});
 	});
 
 	describe("handle()", () => {
@@ -264,6 +313,57 @@ describe("WindBotJoinStrategy", () => {
 
 				// pickRandom called because no name specified
 				expect(repo.pickRandom).toHaveBeenCalled();
+			});
+
+			// Multi-token bot-name parsing tests
+			it("parses bot name from 'ai,jtp#Joey' → findByName('Joey')", async () => {
+				const repo = makeRepo();
+				const mod = makeModule({ repo });
+				const strategy = new WindBotJoinStrategy(mod);
+
+				const ctx = makeCtx("ai,jtp#Joey");
+
+				await strategy.handle(ctx);
+
+				expect(repo.findByName).toHaveBeenCalledWith("Joey");
+			});
+
+			it("parses bot name from 'nc,ns,ai#joey' → findByName('joey')", async () => {
+				const repo = makeRepo();
+				const mod = makeModule({ repo });
+				const strategy = new WindBotJoinStrategy(mod);
+
+				const ctx = makeCtx("nc,ns,ai#joey");
+
+				await strategy.handle(ctx);
+
+				expect(repo.findByName).toHaveBeenCalledWith("joey");
+			});
+
+			it("uses pickRandom when 'ai' has no '#' segment (no bot name)", async () => {
+				const repo = makeRepo();
+				const mod = makeModule({ repo });
+				const strategy = new WindBotJoinStrategy(mod);
+
+				const ctx = makeCtx("ai");
+
+				await strategy.handle(ctx);
+
+				expect(repo.pickRandom).toHaveBeenCalled();
+				expect(repo.findByName).not.toHaveBeenCalled();
+			});
+
+			it("uses pickRandom when 'nc,ai' has no '#' segment (no bot name)", async () => {
+				const repo = makeRepo();
+				const mod = makeModule({ repo });
+				const strategy = new WindBotJoinStrategy(mod);
+
+				const ctx = makeCtx("nc,ai");
+
+				await strategy.handle(ctx);
+
+				expect(repo.pickRandom).toHaveBeenCalled();
+				expect(repo.findByName).not.toHaveBeenCalled();
 			});
 		});
 

--- a/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.test.ts
@@ -406,7 +406,7 @@ describe("WindBotJoinStrategy", () => {
 			});
 		});
 
-		describe("isFinalizing callback (PR-5 — REQ-HTTP-402)", () => {
+		describe("isFinalizing callback (REQ-HTTP-402)", () => {
 			it("isFinalizing callback returns false before room is finalized", async () => {
 				// provider.requestJoin receives { token, bot, isFinalizing } — capture isFinalizing
 				let capturedIsFinalizing: (() => boolean) | undefined;

--- a/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.test.ts
@@ -1,0 +1,309 @@
+import { EventEmitter } from "stream";
+
+import { JoinContext } from "./JoinStrategy";
+import { WindBotJoinStrategy } from "./WindBotJoinStrategy";
+import { WindbotModule, WindbotModuleDeps } from "../../../windbot/application/WindbotModule";
+import { WindbotTokenStore } from "../../../windbot/domain/WindbotTokenStore";
+import { WindbotUnreachableError } from "../../../windbot/domain/WindbotErrors";
+import YGOProRoomList from "../../infrastructure/YGOProRoomList";
+import { YGOProRoom } from "../../domain/YGOProRoom";
+
+// ---- helpers ----
+
+const makeLogger = () => ({
+	child: jest.fn().mockReturnThis(),
+	info: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn(),
+	debug: jest.fn(),
+});
+
+const makeSocket = () => ({
+	id: "sock-test",
+	destroy: jest.fn(),
+	send: jest.fn(),
+});
+
+const makeMessageRepository = () => ({
+	errorMessage: jest.fn().mockReturnValue(Buffer.alloc(4)),
+	joinGameMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+});
+
+const makeRepo = () => ({
+	findAll: jest.fn().mockReturnValue([{ name: "Anna", deck: "Anna.ydk" }]),
+	findByName: jest.fn().mockReturnValue({ name: "Anna", deck: "Anna.ydk" }),
+	pickRandom: jest.fn().mockReturnValue({ name: "Anna", deck: "Anna.ydk" }),
+});
+
+const makeProvider = () => ({
+	requestJoin: jest.fn().mockResolvedValue(undefined),
+});
+
+const makeModule = (overrides: Partial<WindbotModuleDeps> = {}): WindbotModule =>
+	WindbotModule.createForTests({
+		enabled: true,
+		repo: makeRepo(),
+		tokenStore: WindbotTokenStore.createForTests(),
+		provider: makeProvider() as never,
+		...overrides,
+	});
+
+/**
+ * Build a valid join message buffer (48 bytes) as expected by YGOProJoinGameMessage.
+ * version(u16) + align(u16) + gameid(u32) + pass(utf16, 40 bytes)
+ */
+const makeJoinData = (pass: string): Buffer => {
+	const data = Buffer.alloc(48, 0);
+	// Use the same version as mercuryConfig to pass validateVersion
+	data.writeUInt16LE(0x1362, 0);
+	data.writeUInt16LE(0, 2);
+	data.writeUInt32LE(0, 4);
+	const passChars = pass.slice(0, 20);
+	for (let i = 0; i < passChars.length; i++) {
+		data.writeUInt16LE(passChars.charCodeAt(i), 8 + i * 2);
+	}
+	return data;
+};
+
+const makePrevMsg = (): Buffer => {
+	const prevMsg = Buffer.alloc(40, 0);
+	Buffer.from("TestPlayer", "utf16le").copy(prevMsg, 0);
+	return prevMsg;
+};
+
+const makeCtx = (rawPass: string, overrides: Partial<JoinContext> = {}): JoinContext => {
+	const parts = rawPass.split("#");
+	return {
+		rawPass,
+		command: parts[0],
+		password: parts[1] ?? "",
+		playerInfo: {
+			name: "TestPlayer",
+			password: "",
+			previousMessage: makePrevMsg(),
+		},
+		socket: makeSocket(),
+		socketId: "sock-test",
+		eventEmitter: new EventEmitter(),
+		messageRepository: makeMessageRepository(),
+		logger: makeLogger(),
+		checkIfUserCanJoin: { check: jest.fn().mockResolvedValue(true) },
+		message: { data: makeJoinData(rawPass), previousMessage: makePrevMsg() },
+		...overrides,
+	} as unknown as JoinContext;
+};
+
+// ---- tests ----
+
+describe("WindBotJoinStrategy", () => {
+	let waitingSpy: jest.SpyInstance;
+	let emitSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		// Prevent real WaitingState from being set up so handleJoin doesn't crash
+		// Unit tests only care that the strategy calls the right methods, not that
+		// the WaitingState processes JOIN events.
+		waitingSpy = jest.spyOn(YGOProRoom.prototype, "waiting").mockImplementation(() => undefined);
+		emitSpy = jest.spyOn(YGOProRoom.prototype, "emit").mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		waitingSpy.mockRestore();
+		emitSpy.mockRestore();
+		const rooms = YGOProRoomList.getRooms();
+		while (rooms.length) {
+			YGOProRoomList.deleteRoom(rooms[0]);
+		}
+	});
+
+	describe("matches()", () => {
+		it("returns false when windbot module is not enabled", () => {
+			const mod = WindbotModule.createForTests({
+				enabled: false,
+				repo: makeRepo(),
+				tokenStore: WindbotTokenStore.createForTests(),
+				provider: makeProvider() as never,
+			});
+			const strategy = new WindBotJoinStrategy(mod);
+
+			expect(strategy.matches(makeCtx(""))).toBe(false);
+			expect(strategy.matches(makeCtx("AI"))).toBe(false);
+			expect(strategy.matches(makeCtx("AI#Anna"))).toBe(false);
+		});
+
+		it("returns true for blank password when enabled", () => {
+			const strategy = new WindBotJoinStrategy(makeModule());
+			expect(strategy.matches(makeCtx(""))).toBe(true);
+		});
+
+		it("returns true for 'AI' password when enabled", () => {
+			const strategy = new WindBotJoinStrategy(makeModule());
+			expect(strategy.matches(makeCtx("AI"))).toBe(true);
+		});
+
+		it("returns true for 'AI#Anna' password when enabled", () => {
+			const strategy = new WindBotJoinStrategy(makeModule());
+			expect(strategy.matches(makeCtx("AI#Anna"))).toBe(true);
+		});
+
+		it("returns false for non-AI passwords even when enabled", () => {
+			const strategy = new WindBotJoinStrategy(makeModule());
+			expect(strategy.matches(makeCtx("NORMALROOM"))).toBe(false);
+			expect(strategy.matches(makeCtx("AIJOIN#sometoken"))).toBe(false);
+		});
+	});
+
+	describe("handle()", () => {
+		describe("tag-mode rejection (REQ-JOIN-103 / REQ-ROOM-502)", () => {
+			it("rejects tag-mode rooms before any room or token is created", async () => {
+				// Force YGOProRoom.create to return a room whose isTag returns true
+				const fakeRoom = {
+					isTag: true,
+					id: 42,
+					noHost: false,
+					noReconnect: false,
+					windbot: undefined,
+					waiting: jest.fn(),
+					emit: jest.fn(),
+				};
+				jest.spyOn(YGOProRoom, "create").mockReturnValueOnce(fakeRoom as never);
+
+				const mod = makeModule();
+				const strategy = new WindBotJoinStrategy(mod);
+
+				const socket = makeSocket();
+				const ctx = makeCtx("AI", { socket: socket as never });
+
+				await strategy.handle(ctx);
+
+				// Error should be sent
+				expect(socket.send).toHaveBeenCalled();
+				// No room should be in the list (not added because of tag rejection)
+				expect(YGOProRoomList.getRooms().length).toBe(0);
+			});
+
+			it("does not reject when mode is SINGLE (not tag)", async () => {
+				const mod = makeModule();
+				const strategy = new WindBotJoinStrategy(mod);
+
+				const ctx = makeCtx("AI");
+
+				await strategy.handle(ctx);
+
+				// Room should have been created and added (isTag is false for "AI" password)
+				expect(YGOProRoomList.getRooms().length).toBeGreaterThan(0);
+			});
+		});
+
+		describe("happy path", () => {
+			it("creates a room with noHost=true and noReconnect=true when AI password", async () => {
+				const mod = makeModule();
+				const strategy = new WindBotJoinStrategy(mod);
+
+				const ctx = makeCtx("AI");
+
+				await strategy.handle(ctx);
+
+				const room = YGOProRoomList.getRooms()[0];
+				expect(room).toBeDefined();
+				expect(room.noHost).toBe(true);
+				expect(room.noReconnect).toBe(true);
+			});
+
+			it("sets windbot data on the created room after requestBot resolves", async () => {
+				const mod = makeModule();
+				const strategy = new WindBotJoinStrategy(mod);
+
+				const ctx = makeCtx("AI#Anna");
+
+				await strategy.handle(ctx);
+
+				// Wait for the fire-and-forget to resolve
+				await new Promise((r) => setImmediate(r));
+
+				const room = YGOProRoomList.getRooms()[0];
+				expect(room.windbot).toBeDefined();
+				expect(room.windbot?.name).toBe("Anna");
+			});
+
+			it("calls requestBot via the module", async () => {
+				const tokenStore = WindbotTokenStore.createForTests();
+				const provider = makeProvider();
+				const mod = makeModule({ tokenStore, provider: provider as never });
+				const strategy = new WindBotJoinStrategy(mod);
+
+				const ctx = makeCtx("AI");
+
+				await strategy.handle(ctx);
+				await new Promise((r) => setImmediate(r));
+
+				// Provider must have been called (token was registered + HTTP fired)
+				expect(provider.requestJoin).toHaveBeenCalled();
+			});
+
+			it("parses bot name from AI#BotName", async () => {
+				const repo = makeRepo();
+				const mod = makeModule({ repo });
+				const strategy = new WindBotJoinStrategy(mod);
+
+				const ctx = makeCtx("AI#Gear");
+
+				await strategy.handle(ctx);
+
+				expect(repo.findByName).toHaveBeenCalledWith("Gear");
+			});
+
+			it("uses null (random bot) for plain 'AI' password", async () => {
+				const repo = makeRepo();
+				const mod = makeModule({ repo });
+				const strategy = new WindBotJoinStrategy(mod);
+
+				const ctx = makeCtx("AI");
+
+				await strategy.handle(ctx);
+
+				// pickRandom called because no name specified
+				expect(repo.pickRandom).toHaveBeenCalled();
+			});
+		});
+
+		describe("requestBot failure path", () => {
+			it("sends error to human and destroys socket when requestBot throws", async () => {
+				const provider = {
+					requestJoin: jest.fn().mockRejectedValue(new WindbotUnreachableError("Anna", 10)),
+				};
+				const mod = makeModule({ provider: provider as never });
+				const strategy = new WindBotJoinStrategy(mod);
+
+				const socket = makeSocket();
+				const ctx = makeCtx("AI", {
+					socket: socket as never,
+					messageRepository: makeMessageRepository() as never,
+				});
+
+				await strategy.handle(ctx);
+				// Wait for the fire-and-forget rejection handler
+				await new Promise((r) => setImmediate(r));
+
+				expect(socket.send).toHaveBeenCalled();
+			});
+
+			it("removes the room from the list when requestBot fails", async () => {
+				const provider = {
+					requestJoin: jest.fn().mockRejectedValue(new WindbotUnreachableError("Anna", 10)),
+				};
+				const mod = makeModule({ provider: provider as never });
+				const strategy = new WindBotJoinStrategy(mod);
+
+				const ctx = makeCtx("AI");
+
+				await strategy.handle(ctx);
+				// Wait for the fire-and-forget rejection handler
+				await new Promise((r) => setImmediate(r));
+
+				// Room must be deleted
+				expect(YGOProRoomList.getRooms().length).toBe(0);
+			});
+		});
+	});
+});

--- a/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.ts
@@ -10,12 +10,12 @@ import YGOProRoomList from "../../infrastructure/YGOProRoomList";
 /**
  * WindBotJoinStrategy — handles blank / AI / AI#name join passwords.
  *
- * Matches only when WindbotModule is enabled (REQ-JOIN-102: falls through to
- * DefaultJoinStrategy when ENABLE_WINDBOT=false, so AI/blank become normal room names).
+ * Matches only when WindbotModule is enabled (falls through to DefaultJoinStrategy
+ * when ENABLE_WINDBOT=false, so AI/blank become normal room names).
  *
- * REQ-JOIN-103 / REQ-ROOM-502: rejects tag-mode rooms BEFORE any room or token is created.
- * REQ-ROOM-501: sets windbot, noHost, noReconnect flags on the created room.
- * REQ-HTTP-402/403: fires requestBot as fire-and-forget; on failure destroys room + notifies human.
+ * Rejects tag-mode rooms BEFORE any room or token is created.
+ * Sets windbot, noHost, noReconnect flags on the created room.
+ * Fires requestBot as fire-and-forget; on failure destroys room + notifies human.
  */
 export class WindBotJoinStrategy implements JoinStrategy {
 	constructor(private readonly module: WindbotModule) {}
@@ -59,7 +59,7 @@ export class WindBotJoinStrategy implements JoinStrategy {
 			ctx.messageRepository,
 		);
 
-		// REQ-JOIN-103 / REQ-ROOM-502: reject tag-mode BEFORE adding to list or issuing token
+		// Reject tag-mode BEFORE adding to list or issuing token
 		if (room.isTag) {
 			const errorBuf = ctx.messageRepository.errorMessage(ErrorMessageType.JOINERROR, 0);
 			ctx.socket.send(errorBuf);
@@ -68,7 +68,6 @@ export class WindBotJoinStrategy implements JoinStrategy {
 			return;
 		}
 
-		// Set windbot flags (REQ-ROOM-501)
 		// The actual windbot data (name/deck) will be filled once requestBot resolves below.
 		// For now set a placeholder — we overwrite after bot is resolved.
 		room.noHost = true;
@@ -82,8 +81,8 @@ export class WindBotJoinStrategy implements JoinStrategy {
 		room.emit("JOIN", ctx.message, ctx.socket);
 
 		// Fire-and-forget: request bot — handle failure internally.
-		// REQ-HTTP-402: pass () => room.finalizing so the retry loop aborts
-		// as soon as the room begins teardown (e.g. triggered by a concurrent failure).
+		// Pass () => room.finalizing so the retry loop aborts as soon as the room
+		// begins teardown (e.g. triggered by a concurrent failure).
 		this._requestBotFireAndForget(room, botNameOrNull, ctx);
 	}
 
@@ -99,7 +98,7 @@ export class WindBotJoinStrategy implements JoinStrategy {
 				room.windbot = { name: bot.name, deck: bot.deck };
 			})
 			.catch(() => {
-				// REQ-HTTP-403: on trigger failure, destroy room + notify human
+				// On trigger failure, destroy room + notify human
 				YGOProRoomList.deleteRoom(room);
 
 				const errorBuf = ctx.messageRepository.errorMessage(ErrorMessageType.JOINERROR, 0);

--- a/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.ts
@@ -51,6 +51,7 @@ export class WindBotJoinStrategy implements JoinStrategy {
 		if (room.isTag) {
 			const errorBuf = ctx.messageRepository.errorMessage(ErrorMessageType.JOINERROR, 0);
 			ctx.socket.send(errorBuf);
+			ctx.socket.destroy();
 			// Room was NOT added to the list — no cleanup needed
 			return;
 		}
@@ -91,6 +92,7 @@ export class WindBotJoinStrategy implements JoinStrategy {
 
 				const errorBuf = ctx.messageRepository.errorMessage(ErrorMessageType.JOINERROR, 0);
 				ctx.socket.send(errorBuf);
+				ctx.socket.destroy();
 			});
 	}
 }

--- a/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.ts
@@ -1,0 +1,95 @@
+import { generateUniqueId } from "src/utils/generateUniqueId";
+
+import { ErrorMessageType } from "ygopro-msg-encode";
+
+import { WindbotModule } from "../../../windbot/application/WindbotModule";
+import { JoinContext, JoinStrategy } from "./JoinStrategy";
+import { YGOProRoom } from "../../domain/YGOProRoom";
+import YGOProRoomList from "../../infrastructure/YGOProRoomList";
+
+/**
+ * WindBotJoinStrategy — handles blank / AI / AI#name join passwords.
+ *
+ * Matches only when WindbotModule is enabled (REQ-JOIN-102: falls through to
+ * DefaultJoinStrategy when ENABLE_WINDBOT=false, so AI/blank become normal room names).
+ *
+ * REQ-JOIN-103 / REQ-ROOM-502: rejects tag-mode rooms BEFORE any room or token is created.
+ * REQ-ROOM-501: sets windbot, noHost, noReconnect flags on the created room.
+ * REQ-HTTP-402/403: fires requestBot as fire-and-forget; on failure destroys room + notifies human.
+ */
+export class WindBotJoinStrategy implements JoinStrategy {
+	constructor(private readonly module: WindbotModule) {}
+
+	matches(ctx: JoinContext): boolean {
+		if (!this.module.isEnabled()) {
+			return false;
+		}
+
+		const pass = ctx.rawPass;
+		return pass === "" || pass === "AI" || pass.startsWith("AI#");
+	}
+
+	async handle(ctx: JoinContext): Promise<void> {
+		// Determine bot name from password
+		// "AI#Anna" → botName = "Anna", "AI" or "" → botName = null (random)
+		const botNameOrNull = ctx.rawPass.startsWith("AI#")
+			? ctx.rawPass.slice(3)
+			: null;
+
+		// Create the room through the SAME path as the default flow
+		const room = YGOProRoom.create(
+			generateUniqueId(),
+			ctx.rawPass,
+			ctx.logger,
+			ctx.eventEmitter,
+			ctx.playerInfo,
+			ctx.socketId,
+			ctx.messageRepository,
+		);
+
+		// REQ-JOIN-103 / REQ-ROOM-502: reject tag-mode BEFORE adding to list or issuing token
+		if (room.isTag) {
+			const errorBuf = ctx.messageRepository.errorMessage(ErrorMessageType.JOINERROR, 0);
+			ctx.socket.send(errorBuf);
+			// Room was NOT added to the list — no cleanup needed
+			return;
+		}
+
+		// Set windbot flags (REQ-ROOM-501)
+		// The actual windbot data (name/deck) will be filled once requestBot resolves below.
+		// For now set a placeholder — we overwrite after bot is resolved.
+		room.noHost = true;
+		room.noReconnect = true;
+
+		// Add room and activate waiting state (same as default flow)
+		YGOProRoomList.addRoom(room);
+		room.waiting();
+
+		// Emit JOIN for the human client (enters team 0)
+		room.emit("JOIN", ctx.message, ctx.socket);
+
+		// Fire-and-forget: request bot — handle failure internally
+		// TODO PR-5: replace () => false with () => room.finalizing once that field exists
+		this._requestBotFireAndForget(room, botNameOrNull, ctx);
+	}
+
+	private _requestBotFireAndForget(
+		room: YGOProRoom,
+		botNameOrNull: string | null,
+		ctx: JoinContext,
+	): void {
+		this.module
+			.requestBot(room.id, botNameOrNull, () => false)
+			.then(({ bot }) => {
+				// Set windbot data on the room now that we know the bot
+				room.windbot = { name: bot.name, deck: bot.deck };
+			})
+			.catch(() => {
+				// REQ-HTTP-403: on trigger failure, destroy room + notify human
+				YGOProRoomList.deleteRoom(room);
+
+				const errorBuf = ctx.messageRepository.errorMessage(ErrorMessageType.JOINERROR, 0);
+				ctx.socket.send(errorBuf);
+			});
+	}
+}

--- a/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.ts
@@ -25,16 +25,28 @@ export class WindBotJoinStrategy implements JoinStrategy {
 			return false;
 		}
 
-		const pass = ctx.rawPass;
-		return pass === "" || pass === "AI" || pass.startsWith("AI#");
+		// Blank password routes to windbot when enabled
+		if (ctx.rawPass === "") {
+			return true;
+		}
+
+		// Extract config segment (everything before the first "#"), split by comma,
+		// trim and lowercase — check if "ai" is among the tokens.
+		// This is ORDER-INDEPENDENT and CASE-INSENSITIVE.
+		// Examples: "AI#Anna", "ai,jtp#Joey", "nc,ns,ai#joey", "jtp,ai", "ai"
+		const configSegment = ctx.rawPass.split("#")[0];
+		const tokens = configSegment.split(",").map((t) => t.trim().toLowerCase());
+		return tokens.includes("ai");
 	}
 
 	async handle(ctx: JoinContext): Promise<void> {
-		// Determine bot name from password
-		// "AI#Anna" → botName = "Anna", "AI" or "" → botName = null (random)
-		const botNameOrNull = ctx.rawPass.startsWith("AI#")
-			? ctx.rawPass.slice(3)
-			: null;
+		// Determine bot name from the segment AFTER the first "#"
+		// ctx.password is rawPass.split("#")[1] ?? "" (set by YGOProJoinHandler)
+		// "ai,jtp#Joey" → botName = "Joey"
+		// "nc,ns,ai#joey" → botName = "joey"
+		// "ai" / "nc,ai" (no "#") → botName = null (random)
+		// blank → null (random)
+		const botNameOrNull = ctx.password !== "" ? ctx.password : null;
 
 		// Create the room through the SAME path as the default flow
 		const room = YGOProRoom.create(

--- a/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.ts
@@ -68,8 +68,9 @@ export class WindBotJoinStrategy implements JoinStrategy {
 		// Emit JOIN for the human client (enters team 0)
 		room.emit("JOIN", ctx.message, ctx.socket);
 
-		// Fire-and-forget: request bot — handle failure internally
-		// TODO PR-5: replace () => false with () => room.finalizing once that field exists
+		// Fire-and-forget: request bot — handle failure internally.
+		// REQ-HTTP-402: pass () => room.finalizing so the retry loop aborts
+		// as soon as the room begins teardown (e.g. triggered by a concurrent failure).
 		this._requestBotFireAndForget(room, botNameOrNull, ctx);
 	}
 
@@ -79,7 +80,7 @@ export class WindBotJoinStrategy implements JoinStrategy {
 		ctx: JoinContext,
 	): void {
 		this.module
-			.requestBot(room.id, botNameOrNull, () => false)
+			.requestBot(room.id, botNameOrNull, () => room.finalizing)
 			.then(({ bot }) => {
 				// Set windbot data on the room now that we know the bot
 				room.windbot = { name: bot.name, deck: bot.deck };

--- a/src/ygopro/room/application/join-strategies/YGOProJoinHandlerStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/YGOProJoinHandlerStrategy.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Integration tests for YGOProJoinHandler with strategy chain.
+ *
+ * Verifies that:
+ * 1. Normal (non-AI) joins still work (regression guard for DefaultJoinStrategy extraction)
+ * 2. Strategy chain iterates in order until one handles
+ * 3. The registry can be injected for testing via createForTests
+ */
+
+import { EventEmitter } from "stream";
+
+import { YGOProJoinHandler } from "../YGOProJoinHandler";
+import { JoinStrategyRegistry } from "./JoinStrategyRegistry";
+import { JoinContext, JoinStrategy } from "./JoinStrategy";
+
+import YGOProRoomList from "../../infrastructure/YGOProRoomList";
+import { YGOProRoom } from "../../domain/YGOProRoom";
+
+// Suppress unhandled WaitingState errors in tests that don't set up full room infrastructure
+let waitingSpy: jest.SpyInstance;
+let roomEmitSpy: jest.SpyInstance;
+
+// ---- helpers ----
+
+const makeLogger = () => ({
+	child: jest.fn().mockReturnThis(),
+	info: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn(),
+	debug: jest.fn(),
+});
+
+const makeSocket = (id = "sock-handler") => ({
+	id,
+	destroy: jest.fn(),
+	send: jest.fn(),
+	roomId: undefined as number | undefined,
+});
+
+const makeMessageRepository = () => ({
+	errorMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	joinGameMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	typeChangeMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	playerEnterMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	playerChangeMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	spectatorCountMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+});
+
+const makeCheckIfUserCanJoin = () => ({
+	check: jest.fn().mockResolvedValue(true),
+});
+
+/**
+ * Build a minimal JOIN_GAME ClientMessage payload.
+ *
+ * YGOProCtosJoinGame field layout (from BinaryField decorators):
+ *   - version:  u16 at offset 0  (2 bytes)
+ *   - (padding) 2 bytes at offset 2
+ *   - gameid:   u32 at offset 4  (4 bytes)
+ *   - pass:     utf16 at offset 8, max 20 chars = 40 bytes
+ *
+ * Total data size: 48 bytes minimum.
+ */
+const makeJoinMessage = (pass: string): { data: Buffer; previousMessage: Buffer } => {
+	// Build previousMessage (PlayerInfo): 40 bytes, UTF-16LE player name
+	// PlayerInfoMessage reads up to data.length bytes from previousMessage
+	const prevMsg = Buffer.alloc(40, 0);
+	const nameEncoded = Buffer.from("TestPlayer", "utf16le");
+	nameEncoded.copy(prevMsg, 0);
+
+	// Build join data according to actual BinaryField layout
+	const data = Buffer.alloc(48, 0);
+	data.writeUInt16LE(0x1362, 0); // version at offset 0
+	data.writeUInt16LE(0, 2);       // padding/gametype
+	data.writeUInt32LE(0, 4);       // gameid at offset 4
+
+	// pass at offset 8, max 20 UTF-16LE chars
+	const passChars = pass.slice(0, 20);
+	for (let i = 0; i < passChars.length; i++) {
+		data.writeUInt16LE(passChars.charCodeAt(i), 8 + i * 2);
+	}
+
+	return { data, previousMessage: prevMsg };
+};
+
+// ---- tests ----
+
+describe("YGOProJoinHandler — strategy chain integration", () => {
+	let emitter: EventEmitter;
+
+	beforeEach(() => {
+		emitter = new EventEmitter();
+		JoinStrategyRegistry.reset();
+		const rooms = YGOProRoomList.getRooms();
+		while (rooms.length) {
+			YGOProRoomList.deleteRoom(rooms[0]);
+		}
+		// Prevent real WaitingState setup and JOIN processing in these integration tests
+		waitingSpy = jest.spyOn(YGOProRoom.prototype, "waiting").mockImplementation(() => undefined);
+		roomEmitSpy = jest.spyOn(YGOProRoom.prototype, "emit").mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		JoinStrategyRegistry.reset();
+		waitingSpy.mockRestore();
+		roomEmitSpy.mockRestore();
+	});
+
+	it("still creates a normal room for a non-AI join (DefaultJoinStrategy regression)", async () => {
+		// Listen for the JOIN emit that WaitingState would handle
+		emitter.on("JOIN", jest.fn());
+
+		const socket = makeSocket();
+		const messageRepo = makeMessageRepository();
+		const checkJoin = makeCheckIfUserCanJoin();
+		const logger = makeLogger();
+
+		new YGOProJoinHandler(
+			emitter,
+			logger as never,
+			socket as never,
+			checkJoin as never,
+			messageRepo as never,
+		);
+
+		const { data, previousMessage } = makeJoinMessage("NORMALROOM");
+		emitter.emit(18 as unknown as string, { data, previousMessage });
+
+		// Allow async ops to complete
+		await new Promise((r) => setImmediate(r));
+
+		const room = YGOProRoomList.findByName("NORMALROOM");
+		expect(room).not.toBeNull();
+	});
+
+	it("iterates strategies in order — first matching strategy handles", async () => {
+		const handled: string[] = [];
+
+		const s1: JoinStrategy = {
+			matches: (_ctx: JoinContext) => {
+				handled.push("s1-matches");
+				return false;
+			},
+			handle: jest.fn(),
+		};
+		const s2: JoinStrategy = {
+			matches: (_ctx: JoinContext) => {
+				handled.push("s2-matches");
+				return true;
+			},
+			handle: jest.fn().mockResolvedValue(undefined),
+		};
+		const s3: JoinStrategy = {
+			matches: jest.fn().mockReturnValue(true),
+			handle: jest.fn(),
+		};
+
+		const registry = JoinStrategyRegistry.createForTests([s1, s2, s3]);
+
+		const socket = makeSocket();
+		const messageRepo = makeMessageRepository();
+		const checkJoin = makeCheckIfUserCanJoin();
+		const logger = makeLogger();
+
+		const handler = new YGOProJoinHandler(
+			emitter,
+			logger as never,
+			socket as never,
+			checkJoin as never,
+			messageRepo as never,
+			registry,
+		);
+
+		const { data, previousMessage } = makeJoinMessage("ANYTHING");
+		emitter.emit(18 as unknown as string, { data, previousMessage });
+
+		await new Promise((r) => setImmediate(r));
+
+		// s1 evaluated but did not match; s2 matched and handled; s3 never evaluated
+		expect(handled).toContain("s1-matches");
+		expect(handled).toContain("s2-matches");
+		expect(s2.handle).toHaveBeenCalled();
+		expect(s3.handle).not.toHaveBeenCalled();
+	});
+
+	it("YGOProJoinHandler uses the default registry when none is injected", () => {
+		const socket = makeSocket();
+		const messageRepo = makeMessageRepository();
+		const checkJoin = makeCheckIfUserCanJoin();
+		const logger = makeLogger();
+
+		expect(() => {
+			new YGOProJoinHandler(
+				emitter,
+				logger as never,
+				socket as never,
+				checkJoin as never,
+				messageRepo as never,
+			);
+		}).not.toThrow();
+	});
+});

--- a/src/ygopro/room/domain/YGOProRoom.ts
+++ b/src/ygopro/room/domain/YGOProRoom.ts
@@ -69,12 +69,10 @@ export class YGOProRoom extends YgoRoom {
   private readonly _cardRepository: CardYGOProRepository;
   private readonly _deckRules: DeckRules;
 
-  // PR-4: windbot room flags (REQ-ROOM-501)
   windbot?: { name: string; deck: string };
   noHost: boolean = false;
   noReconnect: boolean = false;
 
-  // PR-5: finalizing flag (REQ-HTTP-402)
   // Set to true when the room begins teardown (removeRoom entry point in YGOProDuelingState).
   // The WindBotJoinStrategy retry-abort callback reads this to stop retrying when the room
   // is being torn down.

--- a/src/ygopro/room/domain/YGOProRoom.ts
+++ b/src/ygopro/room/domain/YGOProRoom.ts
@@ -74,6 +74,12 @@ export class YGOProRoom extends YgoRoom {
   noHost: boolean = false;
   noReconnect: boolean = false;
 
+  // PR-5: finalizing flag (REQ-HTTP-402)
+  // Set to true when the room begins teardown (removeRoom entry point in YGOProDuelingState).
+  // The WindBotJoinStrategy retry-abort callback reads this to stop retrying when the room
+  // is being torn down.
+  finalizing: boolean = false;
+
   private constructor({
     id,
     name,

--- a/src/ygopro/room/domain/YGOProRoom.ts
+++ b/src/ygopro/room/domain/YGOProRoom.ts
@@ -69,6 +69,11 @@ export class YGOProRoom extends YgoRoom {
   private readonly _cardRepository: CardYGOProRepository;
   private readonly _deckRules: DeckRules;
 
+  // PR-4: windbot room flags (REQ-ROOM-501)
+  windbot?: { name: string; deck: string };
+  noHost: boolean = false;
+  noReconnect: boolean = false;
+
   private constructor({
     id,
     name,

--- a/src/ygopro/room/domain/YGOProRoomFinalizing.test.ts
+++ b/src/ygopro/room/domain/YGOProRoomFinalizing.test.ts
@@ -1,9 +1,9 @@
 /**
- * PR-5 tests — room.finalizing lifecycle and captain-via-toRPS.
+ * room.finalizing lifecycle and captain-via-toRPS.
  *
- * REQ-HTTP-402: room.finalizing flips to true when removeRoom() is called
+ * room.finalizing flips to true when removeRoom() is called
  *               (the teardown entry point inside YGOProDuelingState).
- * REQ-CLIENT-603: the bot (team-1 player) is already isCaptain when RPS runs
+ * The bot (team-1 player) is already isCaptain when RPS runs
  *                 because toRPS() calls captain() on both team players unconditionally.
  */
 
@@ -62,7 +62,7 @@ class TestRoomState extends YGOProRoomState {
 	}
 }
 
-// ---- REQ-CLIENT-603: captain via toRPS() ----
+// ---- captain via toRPS() ----
 
 describe("captain assignment via toRPS() (REQ-CLIENT-603)", () => {
 	it("sets isCaptain=true on the team-0 player after toRPS()", () => {

--- a/src/ygopro/room/domain/YGOProRoomFinalizing.test.ts
+++ b/src/ygopro/room/domain/YGOProRoomFinalizing.test.ts
@@ -1,0 +1,159 @@
+/**
+ * PR-5 tests — room.finalizing lifecycle and captain-via-toRPS.
+ *
+ * REQ-HTTP-402: room.finalizing flips to true when removeRoom() is called
+ *               (the teardown entry point inside YGOProDuelingState).
+ * REQ-CLIENT-603: the bot (team-1 player) is already isCaptain when RPS runs
+ *                 because toRPS() calls captain() on both team players unconditionally.
+ */
+
+import { EventEmitter } from "stream";
+
+import { YGOProRoom } from "./YGOProRoom";
+import { YGOProRoomState } from "./YGOProRoomState";
+import { YGOProClient } from "../../client/domain/YGOProClient";
+import { Team } from "@shared/room/Team";
+
+// ---- helpers ----
+
+const makeLogger = () => ({
+	child: jest.fn().mockReturnThis(),
+	info: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn(),
+	debug: jest.fn(),
+});
+
+const makeMessageRepo = () => ({
+	joinGameMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	typeChangeMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	typeChangeMessageFromType: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	playerEnterMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	playerChangeMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	spectatorCountMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	watchChangeMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	errorMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	selectHandMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+});
+
+const makeSocket = () => ({
+	id: "sock-1",
+	send: jest.fn(),
+	destroy: jest.fn(),
+	onMessage: jest.fn(),
+	remoteAddress: "127.0.0.1",
+});
+
+const createRoom = (): YGOProRoom =>
+	YGOProRoom.create(
+		1,
+		"TESTROOM",
+		makeLogger() as never,
+		new EventEmitter(),
+		{ name: "TestPlayer", password: "", previousMessage: Buffer.alloc(0) } as never,
+		"sock-test",
+		makeMessageRepo() as never,
+	);
+
+/** Expose toRPS for test — since it is protected we subclass. */
+class TestRoomState extends YGOProRoomState {
+	callToRPS(room: YGOProRoom): void {
+		this.toRPS(room);
+	}
+}
+
+// ---- REQ-CLIENT-603: captain via toRPS() ----
+
+describe("captain assignment via toRPS() (REQ-CLIENT-603)", () => {
+	it("sets isCaptain=true on the team-0 player after toRPS()", () => {
+		const room = createRoom();
+		const logger = makeLogger();
+		const sock = makeSocket();
+
+		const humanClient = new YGOProClient({
+			name: "Human",
+			socket: sock as never,
+			logger: logger as never,
+			position: 0,
+			room,
+			host: true,
+			id: "h1",
+			team: Team.PLAYER,
+		});
+		room.addPlayerUnsafe(humanClient);
+
+		const botClient = new YGOProClient({
+			name: "Bot",
+			socket: makeSocket() as never,
+			logger: logger as never,
+			position: 0,
+			room,
+			host: false,
+			id: "b1",
+			team: Team.OPPONENT,
+		});
+		room.addPlayerUnsafe(botClient);
+		botClient.markInternal();
+
+		const state = new TestRoomState(new EventEmitter());
+		state.callToRPS(room);
+
+		expect(humanClient.isCaptain).toBe(true);
+	});
+
+	it("sets isCaptain=true on the team-1 (bot) player after toRPS()", () => {
+		const room = createRoom();
+		const logger = makeLogger();
+
+		const humanClient = new YGOProClient({
+			name: "Human",
+			socket: makeSocket() as never,
+			logger: logger as never,
+			position: 0,
+			room,
+			host: true,
+			id: "h1",
+			team: Team.PLAYER,
+		});
+		room.addPlayerUnsafe(humanClient);
+
+		const botClient = new YGOProClient({
+			name: "Bot",
+			socket: makeSocket() as never,
+			logger: logger as never,
+			position: 0,
+			room,
+			host: false,
+			id: "b1",
+			team: Team.OPPONENT,
+		});
+		room.addPlayerUnsafe(botClient);
+		botClient.markInternal();
+
+		const state = new TestRoomState(new EventEmitter());
+		state.callToRPS(room);
+
+		// Bot (team-1) is captain — the isCaptain gate in handleRPSChoice will pass
+		expect(botClient.isCaptain).toBe(true);
+	});
+
+	it("bot is NOT captain before toRPS() runs", () => {
+		const room = createRoom();
+		const logger = makeLogger();
+
+		const botClient = new YGOProClient({
+			name: "Bot",
+			socket: makeSocket() as never,
+			logger: logger as never,
+			position: 0,
+			room,
+			host: false,
+			id: "b1",
+			team: Team.OPPONENT,
+		});
+		botClient.markInternal();
+
+		// No toRPS called yet
+		expect(botClient.isCaptain).toBe(false);
+	});
+});

--- a/src/ygopro/room/domain/YGOProRoomWindbotFlags.test.ts
+++ b/src/ygopro/room/domain/YGOProRoomWindbotFlags.test.ts
@@ -1,7 +1,7 @@
 /**
- * Tests for windbot-specific flags added to YGOProRoom in PR-4 and PR-5.
- * REQ-ROOM-501: noHost, noReconnect, windbot? flags.
- * REQ-HTTP-402 (PR-5): finalizing flag — defaults false, flips true on teardown.
+ * Tests for windbot-specific flags added to YGOProRoom.
+ * noHost, noReconnect, windbot? flags.
+ * finalizing flag — defaults false, flips true on teardown.
  */
 
 import { EventEmitter } from "stream";
@@ -75,7 +75,7 @@ describe("YGOProRoom windbot flags", () => {
 		});
 	});
 
-	describe("finalizing (PR-5 — REQ-HTTP-402)", () => {
+	describe("finalizing (REQ-HTTP-402)", () => {
 		it("finalizing defaults to false", () => {
 			const room = createRoom();
 			expect(room.finalizing).toBe(false);

--- a/src/ygopro/room/domain/YGOProRoomWindbotFlags.test.ts
+++ b/src/ygopro/room/domain/YGOProRoomWindbotFlags.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for windbot-specific flags added to YGOProRoom in PR-4.
+ * REQ-ROOM-501: noHost, noReconnect, windbot? flags.
+ */
+
+import { EventEmitter } from "stream";
+
+import { YGOProRoom } from "./YGOProRoom";
+
+const makeLogger = () => ({
+	child: jest.fn().mockReturnThis(),
+	info: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn(),
+	debug: jest.fn(),
+});
+
+const makeMessageRepo = () => ({
+	joinGameMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	typeChangeMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	playerEnterMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	playerChangeMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	spectatorCountMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+	errorMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+});
+
+const createRoom = (): YGOProRoom =>
+	YGOProRoom.create(
+		1,
+		"TESTROOM",
+		makeLogger() as never,
+		new EventEmitter(),
+		{ name: "TestPlayer", password: "", previousMessage: Buffer.alloc(0) } as never,
+		"sock-test",
+		makeMessageRepo() as never,
+	);
+
+describe("YGOProRoom windbot flags", () => {
+	describe("defaults (non-windbot rooms)", () => {
+		it("noHost defaults to false", () => {
+			const room = createRoom();
+			expect(room.noHost).toBe(false);
+		});
+
+		it("noReconnect defaults to false", () => {
+			const room = createRoom();
+			expect(room.noReconnect).toBe(false);
+		});
+
+		it("windbot is undefined by default", () => {
+			const room = createRoom();
+			expect(room.windbot).toBeUndefined();
+		});
+	});
+
+	describe("setters", () => {
+		it("noHost can be set to true", () => {
+			const room = createRoom();
+			room.noHost = true;
+			expect(room.noHost).toBe(true);
+		});
+
+		it("noReconnect can be set to true", () => {
+			const room = createRoom();
+			room.noReconnect = true;
+			expect(room.noReconnect).toBe(true);
+		});
+
+		it("windbot can be set with name and deck", () => {
+			const room = createRoom();
+			room.windbot = { name: "Anna", deck: "Anna.ydk" };
+			expect(room.windbot?.name).toBe("Anna");
+			expect(room.windbot?.deck).toBe("Anna.ydk");
+		});
+	});
+});

--- a/src/ygopro/room/domain/YGOProRoomWindbotFlags.test.ts
+++ b/src/ygopro/room/domain/YGOProRoomWindbotFlags.test.ts
@@ -1,6 +1,7 @@
 /**
- * Tests for windbot-specific flags added to YGOProRoom in PR-4.
+ * Tests for windbot-specific flags added to YGOProRoom in PR-4 and PR-5.
  * REQ-ROOM-501: noHost, noReconnect, windbot? flags.
+ * REQ-HTTP-402 (PR-5): finalizing flag — defaults false, flips true on teardown.
  */
 
 import { EventEmitter } from "stream";
@@ -71,6 +72,19 @@ describe("YGOProRoom windbot flags", () => {
 			room.windbot = { name: "Anna", deck: "Anna.ydk" };
 			expect(room.windbot?.name).toBe("Anna");
 			expect(room.windbot?.deck).toBe("Anna.ydk");
+		});
+	});
+
+	describe("finalizing (PR-5 — REQ-HTTP-402)", () => {
+		it("finalizing defaults to false", () => {
+			const room = createRoom();
+			expect(room.finalizing).toBe(false);
+		});
+
+		it("finalizing can be set to true", () => {
+			const room = createRoom();
+			room.finalizing = true;
+			expect(room.finalizing).toBe(true);
 		});
 	});
 });

--- a/src/ygopro/room/domain/states/YGOProDuelingState.ts
+++ b/src/ygopro/room/domain/states/YGOProDuelingState.ts
@@ -15,9 +15,9 @@ import { Team } from "@shared/room/Team";
 
 import { YGOProClient } from "../../../client/domain/YGOProClient";
 import { DuelRecord } from "../DuelRecord";
+import { FinalizeYGOProRoom } from "../../application/FinalizeYGOProRoom";
 import { YGOProRoom } from "../YGOProRoom";
 import { getMessageIdentifier } from "../../../utils/response-time-utils";
-import { WindbotModule } from "../../../windbot/application/WindbotModule";
 
 import {
   OcgcoreScriptConstants,
@@ -36,7 +36,6 @@ import {
   YGOProStocTeammateSurrender,
 } from "ygopro-msg-encode";
 import { GameOverDomainEvent } from "@shared/room/domain/match/domain/domain-events/GameOverDomainEvent";
-import MercuryRoomList from "@ygopro/room/infrastructure/YGOProRoomList";
 import WebSocketSingleton from "src/web-socket-server/WebSocketSingleton";
 
 export class YGOProDuelingState extends RoomState {
@@ -629,23 +628,6 @@ export class YGOProDuelingState extends RoomState {
   }
 
   private removeRoom(): void {
-    // Mark finalizing BEFORE broadcasting so any in-flight retry loop
-    // (WindBotJoinStrategy._requestBotFireAndForget) sees the flag and aborts.
-    this.room.finalizing = true;
-
-    // Clean up any windbot tokens still registered for this room. This is a no-op when:
-    //   • windbot is not initialized (non-windbot server, or ENABLE_WINDBOT=false)
-    //   • windbot is initialized but disabled
-    //   • the bot already consumed its token before duel end (clearByRoom returns 0)
-    // Guard: isInitialized() prevents getInstance() from throwing for non-windbot rooms.
-    if (WindbotModule.isInitialized() && WindbotModule.getInstance().isEnabled()) {
-      WindbotModule.getInstance().cleanupRoom(this.room.id);
-    }
-
-    WebSocketSingleton.getInstance().broadcast({
-      action: "REMOVE-ROOM",
-      data: this.room.toRealTimePresentation(),
-    });
-    MercuryRoomList.deleteRoom(this.room);
+    FinalizeYGOProRoom.run(this.room);
   }
 }

--- a/src/ygopro/room/domain/states/YGOProDuelingState.ts
+++ b/src/ygopro/room/domain/states/YGOProDuelingState.ts
@@ -629,12 +629,11 @@ export class YGOProDuelingState extends RoomState {
   }
 
   private removeRoom(): void {
-    // PR-5: mark finalizing BEFORE broadcasting so any in-flight retry loop
+    // Mark finalizing BEFORE broadcasting so any in-flight retry loop
     // (WindBotJoinStrategy._requestBotFireAndForget) sees the flag and aborts.
     this.room.finalizing = true;
 
-    // PR-6 (REQ-TOKEN-204 / REQ-PROVIDER-303): clean up any windbot tokens still
-    // registered for this room. This is a no-op when:
+    // Clean up any windbot tokens still registered for this room. This is a no-op when:
     //   • windbot is not initialized (non-windbot server, or ENABLE_WINDBOT=false)
     //   • windbot is initialized but disabled
     //   • the bot already consumed its token before duel end (clearByRoom returns 0)

--- a/src/ygopro/room/domain/states/YGOProDuelingState.ts
+++ b/src/ygopro/room/domain/states/YGOProDuelingState.ts
@@ -628,6 +628,10 @@ export class YGOProDuelingState extends RoomState {
   }
 
   private removeRoom(): void {
+    // PR-5: mark finalizing BEFORE broadcasting so any in-flight retry loop
+    // (WindBotJoinStrategy._requestBotFireAndForget) sees the flag and aborts.
+    this.room.finalizing = true;
+
     WebSocketSingleton.getInstance().broadcast({
       action: "REMOVE-ROOM",
       data: this.room.toRealTimePresentation(),

--- a/src/ygopro/room/domain/states/YGOProDuelingState.ts
+++ b/src/ygopro/room/domain/states/YGOProDuelingState.ts
@@ -17,6 +17,7 @@ import { YGOProClient } from "../../../client/domain/YGOProClient";
 import { DuelRecord } from "../DuelRecord";
 import { YGOProRoom } from "../YGOProRoom";
 import { getMessageIdentifier } from "../../../utils/response-time-utils";
+import { WindbotModule } from "../../../windbot/application/WindbotModule";
 
 import {
   OcgcoreScriptConstants,
@@ -631,6 +632,16 @@ export class YGOProDuelingState extends RoomState {
     // PR-5: mark finalizing BEFORE broadcasting so any in-flight retry loop
     // (WindBotJoinStrategy._requestBotFireAndForget) sees the flag and aborts.
     this.room.finalizing = true;
+
+    // PR-6 (REQ-TOKEN-204 / REQ-PROVIDER-303): clean up any windbot tokens still
+    // registered for this room. This is a no-op when:
+    //   • windbot is not initialized (non-windbot server, or ENABLE_WINDBOT=false)
+    //   • windbot is initialized but disabled
+    //   • the bot already consumed its token before duel end (clearByRoom returns 0)
+    // Guard: isInitialized() prevents getInstance() from throwing for non-windbot rooms.
+    if (WindbotModule.isInitialized() && WindbotModule.getInstance().isEnabled()) {
+      WindbotModule.getInstance().cleanupRoom(this.room.id);
+    }
 
     WebSocketSingleton.getInstance().broadcast({
       action: "REMOVE-ROOM",

--- a/src/ygopro/room/domain/states/YGOProDuelingStateCleanup.test.ts
+++ b/src/ygopro/room/domain/states/YGOProDuelingStateCleanup.test.ts
@@ -1,7 +1,7 @@
 /**
- * PR-6 tests — WindbotModule cleanup hook in YGOProDuelingState.removeRoom().
+ * WindbotModule cleanup hook in YGOProDuelingState.removeRoom().
  *
- * REQ-TOKEN-204 / REQ-PROVIDER-303: when a room finalizes, all windbot tokens
+ * When a room finalizes, all windbot tokens
  * for that room must be cleaned up.
  *
  * Critical invariants:
@@ -55,7 +55,7 @@ function simulateRemoveRoomHook(roomId: number): number | undefined {
 
 // ---------- tests ----------
 
-describe("YGOProDuelingState — removeRoom() windbot cleanup hook (PR-6)", () => {
+describe("YGOProDuelingState — removeRoom() windbot cleanup hook", () => {
 	afterEach(() => {
 		WindbotModule.resetForTests();
 		jest.restoreAllMocks();

--- a/src/ygopro/room/domain/states/YGOProDuelingStateCleanup.test.ts
+++ b/src/ygopro/room/domain/states/YGOProDuelingStateCleanup.test.ts
@@ -1,0 +1,152 @@
+/**
+ * PR-6 tests — WindbotModule cleanup hook in YGOProDuelingState.removeRoom().
+ *
+ * REQ-TOKEN-204 / REQ-PROVIDER-303: when a room finalizes, all windbot tokens
+ * for that room must be cleaned up.
+ *
+ * Critical invariants:
+ * 1. When WindbotModule IS initialized AND enabled → cleanupRoom(roomId) is called.
+ * 2. When WindbotModule is NOT initialized → no throw, no cleanup call (no-op).
+ *    This is the common case for existing non-windbot rooms — must be 100% safe.
+ * 3. Existing removeRoom behavior (broadcast REMOVE-ROOM, deleteRoom) is unchanged
+ *    regardless of windbot init state.
+ *
+ * We test the guard + integration behaviour directly against WindbotModule statics
+ * and the CleanupWindBotTokens use case, without needing a full YGOProDuelingState
+ * instance (which requires OCGCore spin-up). The actual hook is two lines in removeRoom().
+ */
+
+import { WindbotModule, WindbotModuleDeps } from "../../../windbot/application/WindbotModule";
+import { WindbotTokenStore } from "../../../windbot/domain/WindbotTokenStore";
+
+// ---------- helpers ----------
+
+const makeRepo = () => ({
+	findAll: jest.fn().mockReturnValue([]),
+	findByName: jest.fn().mockReturnValue(undefined),
+	pickRandom: jest.fn().mockReturnValue(undefined),
+});
+
+const makeProvider = () => ({
+	requestJoin: jest.fn().mockResolvedValue(undefined),
+});
+
+const makeDeps = (overrides: Partial<WindbotModuleDeps> = {}): WindbotModuleDeps => ({
+	enabled: true,
+	repo: makeRepo(),
+	tokenStore: WindbotTokenStore.createForTests(),
+	provider: makeProvider() as unknown as WindbotModuleDeps["provider"],
+	...overrides,
+});
+
+/**
+ * Simulate the exact two-line hook from removeRoom():
+ *   if (WindbotModule.isInitialized() && WindbotModule.getInstance().isEnabled()) {
+ *     WindbotModule.getInstance().cleanupRoom(roomId);
+ *   }
+ * Returns the cleanup count if executed, or undefined if skipped (no-op).
+ */
+function simulateRemoveRoomHook(roomId: number): number | undefined {
+	if (WindbotModule.isInitialized() && WindbotModule.getInstance().isEnabled()) {
+		return WindbotModule.getInstance().cleanupRoom(roomId);
+	}
+	return undefined;
+}
+
+// ---------- tests ----------
+
+describe("YGOProDuelingState — removeRoom() windbot cleanup hook (PR-6)", () => {
+	afterEach(() => {
+		WindbotModule.resetForTests();
+		jest.restoreAllMocks();
+	});
+
+	describe("no-op path — WindbotModule not initialized (common case: non-windbot rooms)", () => {
+		it("does NOT throw when WindbotModule is not initialized", () => {
+			// Critical regression guard: all existing non-windbot rooms must be unaffected.
+			// isInitialized() === false → hook is skipped entirely, no throw.
+			expect(() => simulateRemoveRoomHook(42)).not.toThrow();
+		});
+
+		it("returns undefined (hook is skipped) when WindbotModule is not initialized", () => {
+			// Confirms the hook body never runs — returns undefined rather than a count.
+			const result = simulateRemoveRoomHook(42);
+			expect(result).toBeUndefined();
+		});
+
+		it("does NOT call getInstance() when WindbotModule is not initialized", () => {
+			const getInstanceSpy = jest.spyOn(WindbotModule, "getInstance");
+			simulateRemoveRoomHook(42);
+			expect(getInstanceSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("no-op path — WindbotModule initialized but disabled", () => {
+		it("does NOT call cleanupRoom when module is initialized but disabled", () => {
+			WindbotModule.init(makeDeps({ enabled: false }));
+			const cleanupSpy = jest.spyOn(WindbotModule.getInstance(), "cleanupRoom");
+
+			simulateRemoveRoomHook(42);
+
+			expect(cleanupSpy).not.toHaveBeenCalled();
+		});
+
+		it("returns undefined (hook is skipped) when module is disabled", () => {
+			WindbotModule.init(makeDeps({ enabled: false }));
+			const result = simulateRemoveRoomHook(42);
+			expect(result).toBeUndefined();
+		});
+	});
+
+	describe("cleanup path — WindbotModule initialized and enabled", () => {
+		it("calls cleanupRoom(roomId) when module IS initialized and enabled", () => {
+			WindbotModule.init(makeDeps({ enabled: true }));
+			const cleanupSpy = jest.spyOn(WindbotModule.getInstance(), "cleanupRoom");
+
+			simulateRemoveRoomHook(42);
+
+			expect(cleanupSpy).toHaveBeenCalledWith(42);
+		});
+
+		it("removes windbot tokens for the finalizing room (integration)", () => {
+			const tokenStore = WindbotTokenStore.createForTests();
+			tokenStore.register(42, "Anna", "Anna.ydk");
+			tokenStore.register(42, "Gear", "Gear.ydk");
+			// Different room — must NOT be affected
+			tokenStore.register(99, "Rex", "Rex.ydk");
+
+			WindbotModule.init(makeDeps({ tokenStore, enabled: true }));
+
+			const count = simulateRemoveRoomHook(42);
+			expect(count).toBe(2);
+
+			// Room 99 token must survive
+			expect(tokenStore.clearByRoom(99)).toBe(1);
+		});
+
+		it("returns 0 (harmless) when the bot already consumed its token before duel end", () => {
+			// Normal duel flow: bot connected → consumed token → duel ends → cleanup = no-op
+			const tokenStore = WindbotTokenStore.createForTests();
+			const token = tokenStore.register(42, "Anna", "Anna.ydk");
+			tokenStore.consume(token); // bot consumed on connect-back
+
+			WindbotModule.init(makeDeps({ tokenStore, enabled: true }));
+
+			const count = simulateRemoveRoomHook(42);
+			expect(count).toBe(0);
+		});
+
+		it("does not touch tokens of other rooms", () => {
+			const tokenStore = WindbotTokenStore.createForTests();
+			tokenStore.register(1, "Anna", "Anna.ydk");
+			tokenStore.register(2, "Gear", "Gear.ydk");
+
+			WindbotModule.init(makeDeps({ tokenStore, enabled: true }));
+
+			simulateRemoveRoomHook(1);
+
+			// Room 2 token must still be present
+			expect(tokenStore.clearByRoom(2)).toBe(1);
+		});
+	});
+});

--- a/src/ygopro/windbot/application/CleanupWindBotTokens.test.ts
+++ b/src/ygopro/windbot/application/CleanupWindBotTokens.test.ts
@@ -1,0 +1,38 @@
+import { CleanupWindBotTokens } from "./CleanupWindBotTokens";
+import { WindbotTokenStore } from "../domain/WindbotTokenStore";
+
+describe("CleanupWindBotTokens", () => {
+	let tokenStore: WindbotTokenStore;
+	let useCase: CleanupWindBotTokens;
+
+	beforeEach(() => {
+		tokenStore = WindbotTokenStore.createForTests();
+		useCase = new CleanupWindBotTokens(tokenStore);
+	});
+
+	it("delegates to tokenStore.clearByRoom and returns the count", () => {
+		tokenStore.register(10, "Anna", "Anna.ydk");
+		tokenStore.register(10, "Gear", "Gear.ydk");
+
+		const count = useCase.execute(10);
+
+		expect(count).toBe(2);
+	});
+
+	it("returns 0 when no tokens exist for the given roomId", () => {
+		const count = useCase.execute(999);
+
+		expect(count).toBe(0);
+	});
+
+	it("does not clear tokens for other rooms", () => {
+		const otherToken = tokenStore.register(20, "Bob", "Bob.ydk");
+		tokenStore.register(10, "Anna", "Anna.ydk");
+
+		useCase.execute(10);
+
+		// otherToken still consumable
+		const payload = tokenStore.consume(otherToken);
+		expect(payload.botName).toBe("Bob");
+	});
+});

--- a/src/ygopro/windbot/application/CleanupWindBotTokens.ts
+++ b/src/ygopro/windbot/application/CleanupWindBotTokens.ts
@@ -1,0 +1,9 @@
+import { WindbotTokenStore } from "../domain/WindbotTokenStore";
+
+export class CleanupWindBotTokens {
+	constructor(private readonly tokenStore: WindbotTokenStore) {}
+
+	execute(roomId: number): number {
+		return this.tokenStore.clearByRoom(roomId);
+	}
+}

--- a/src/ygopro/windbot/application/ConsumeWindBotToken.test.ts
+++ b/src/ygopro/windbot/application/ConsumeWindBotToken.test.ts
@@ -1,0 +1,31 @@
+import { ConsumeWindBotToken } from "./ConsumeWindBotToken";
+import { WindbotTokenStore } from "../domain/WindbotTokenStore";
+
+describe("ConsumeWindBotToken", () => {
+	let tokenStore: WindbotTokenStore;
+	let useCase: ConsumeWindBotToken;
+
+	beforeEach(() => {
+		tokenStore = WindbotTokenStore.createForTests();
+		useCase = new ConsumeWindBotToken(tokenStore);
+	});
+
+	it("delegates to tokenStore.consume and returns the payload", () => {
+		const token = tokenStore.register(42, "Anna", "Anna.ydk");
+
+		const result = useCase.execute(token);
+
+		expect(result).toEqual({ roomId: 42, botName: "Anna", deck: "Anna.ydk" });
+	});
+
+	it("re-throws the Error from the store when token is not found", () => {
+		expect(() => useCase.execute("nonexistenttoken")).toThrow("Windbot token not found");
+	});
+
+	it("second consume of same token throws (one-shot behavior delegated to store)", () => {
+		const token = tokenStore.register(1, "Gear", "Gear.ydk");
+		useCase.execute(token);
+
+		expect(() => useCase.execute(token)).toThrow("Windbot token not found");
+	});
+});

--- a/src/ygopro/windbot/application/ConsumeWindBotToken.ts
+++ b/src/ygopro/windbot/application/ConsumeWindBotToken.ts
@@ -1,0 +1,9 @@
+import { WindbotTokenPayload, WindbotTokenStore } from "../domain/WindbotTokenStore";
+
+export class ConsumeWindBotToken {
+	constructor(private readonly tokenStore: WindbotTokenStore) {}
+
+	execute(token: string): WindbotTokenPayload {
+		return this.tokenStore.consume(token);
+	}
+}

--- a/src/ygopro/windbot/application/RequestWindBotJoin.test.ts
+++ b/src/ygopro/windbot/application/RequestWindBotJoin.test.ts
@@ -1,0 +1,111 @@
+import { RequestWindBotJoin } from "./RequestWindBotJoin";
+import { WindbotBotlistRepository } from "../domain/WindbotBotlistRepository";
+import { WindbotTokenStore } from "../domain/WindbotTokenStore";
+import { WindbotData } from "../domain/WindbotData";
+import { WindbotNotFoundError } from "../domain/WindbotErrors";
+import { WindbotsExhaustedError } from "../domain/WindbotErrors";
+
+const makeBot = (overrides: Partial<WindbotData> = {}): WindbotData => ({
+	name: "Anna",
+	deck: "Anna.ydk",
+	...overrides,
+});
+
+const makeRepo = (overrides: Partial<WindbotBotlistRepository> = {}): WindbotBotlistRepository => ({
+	findAll: jest.fn().mockReturnValue([]),
+	findByName: jest.fn().mockReturnValue(null),
+	pickRandom: jest.fn().mockReturnValue(null),
+	...overrides,
+});
+
+describe("RequestWindBotJoin", () => {
+	let tokenStore: WindbotTokenStore;
+
+	beforeEach(() => {
+		tokenStore = WindbotTokenStore.createForTests();
+	});
+
+	describe("named bot lookup", () => {
+		it("returns { token, bot } when repo finds the bot by name", () => {
+			const bot = makeBot();
+			const repo = makeRepo({ findByName: jest.fn().mockReturnValue(bot) });
+			const useCase = new RequestWindBotJoin(repo, tokenStore);
+
+			const result = useCase.execute(42, "Anna");
+
+			expect(result.bot).toBe(bot);
+			expect(result.token).toMatch(/^[A-Za-z0-9]{12}$/);
+		});
+
+		it("throws WindbotNotFoundError when named bot is not in the list", () => {
+			const repo = makeRepo({ findByName: jest.fn().mockReturnValue(null) });
+			const useCase = new RequestWindBotJoin(repo, tokenStore);
+
+			expect(() => useCase.execute(1, "Unknown")).toThrow(WindbotNotFoundError);
+		});
+
+		it("registers the token with the correct roomId", () => {
+			const bot = makeBot();
+			const repo = makeRepo({ findByName: jest.fn().mockReturnValue(bot) });
+			const useCase = new RequestWindBotJoin(repo, tokenStore);
+
+			const { token } = useCase.execute(99, "Anna");
+
+			const payload = tokenStore.consume(token);
+			expect(payload.roomId).toBe(99);
+		});
+
+		it("registers token with bot.deck when no deckOverride provided", () => {
+			const bot = makeBot({ deck: "Anna.ydk" });
+			const repo = makeRepo({ findByName: jest.fn().mockReturnValue(bot) });
+			const useCase = new RequestWindBotJoin(repo, tokenStore);
+
+			const { token } = useCase.execute(1, "Anna");
+
+			const payload = tokenStore.consume(token);
+			expect(payload.deck).toBe("Anna.ydk");
+		});
+
+		it("registers token with deckOverride when provided", () => {
+			const bot = makeBot({ deck: "Anna.ydk" });
+			const repo = makeRepo({ findByName: jest.fn().mockReturnValue(bot) });
+			const useCase = new RequestWindBotJoin(repo, tokenStore);
+
+			const { token } = useCase.execute(1, "Anna", "CustomDeck.ydk");
+
+			const payload = tokenStore.consume(token);
+			expect(payload.deck).toBe("CustomDeck.ydk");
+		});
+	});
+
+	describe("random bot selection", () => {
+		it("returns { token, bot } from pickRandom when botName is null", () => {
+			const bot = makeBot({ name: "Gear", deck: "Gear.ydk" });
+			const repo = makeRepo({ pickRandom: jest.fn().mockReturnValue(bot) });
+			const useCase = new RequestWindBotJoin(repo, tokenStore);
+
+			const result = useCase.execute(5, null);
+
+			expect(result.bot).toBe(bot);
+			expect(result.token).toMatch(/^[A-Za-z0-9]{12}$/);
+		});
+
+		it("throws WindbotsExhaustedError when pickRandom returns null", () => {
+			const repo = makeRepo({ pickRandom: jest.fn().mockReturnValue(null) });
+			const useCase = new RequestWindBotJoin(repo, tokenStore);
+
+			expect(() => useCase.execute(1, null)).toThrow(WindbotsExhaustedError);
+		});
+
+		it("registers token with bot.deck when no deckOverride and using random selection", () => {
+			const bot = makeBot({ name: "Gear", deck: "Gear.ydk" });
+			const repo = makeRepo({ pickRandom: jest.fn().mockReturnValue(bot) });
+			const useCase = new RequestWindBotJoin(repo, tokenStore);
+
+			const { token } = useCase.execute(7, null);
+
+			const payload = tokenStore.consume(token);
+			expect(payload.deck).toBe("Gear.ydk");
+		});
+	});
+});

--- a/src/ygopro/windbot/application/RequestWindBotJoin.ts
+++ b/src/ygopro/windbot/application/RequestWindBotJoin.ts
@@ -1,0 +1,43 @@
+import { WindbotBotlistRepository } from "../domain/WindbotBotlistRepository";
+import { WindbotData } from "../domain/WindbotData";
+import { WindbotNotFoundError, WindbotsExhaustedError } from "../domain/WindbotErrors";
+import { WindbotTokenStore } from "../domain/WindbotTokenStore";
+
+export type RequestWindBotJoinResult = {
+	token: string;
+	bot: WindbotData;
+};
+
+export class RequestWindBotJoin {
+	constructor(
+		private readonly repo: WindbotBotlistRepository,
+		private readonly tokenStore: WindbotTokenStore
+	) {}
+
+	execute(
+		roomId: number,
+		botNameOrNull: string | null,
+		deckOverride?: string
+	): RequestWindBotJoinResult {
+		const bot = this._resolveBot(botNameOrNull);
+		const deck = deckOverride ?? bot.deck;
+		const token = this.tokenStore.register(roomId, bot.name, deck);
+		return { token, bot };
+	}
+
+	private _resolveBot(botNameOrNull: string | null): WindbotData {
+		if (botNameOrNull !== null) {
+			const bot = this.repo.findByName(botNameOrNull);
+			if (bot === null) {
+				throw new WindbotNotFoundError(botNameOrNull);
+			}
+			return bot;
+		}
+
+		const bot = this.repo.pickRandom();
+		if (bot === null) {
+			throw new WindbotsExhaustedError();
+		}
+		return bot;
+	}
+}

--- a/src/ygopro/windbot/application/WindbotModule.test.ts
+++ b/src/ygopro/windbot/application/WindbotModule.test.ts
@@ -1,0 +1,160 @@
+import { WindbotModule, WindbotModuleDeps } from "./WindbotModule";
+import { WindbotData } from "../domain/WindbotData";
+import { WindbotTokenStore } from "../domain/WindbotTokenStore";
+import { FileBotlistRepository } from "../infrastructure/FileBotlistRepository";
+import { WindbotBotlistRepository } from "../domain/WindbotBotlistRepository";
+import { WindbotUnreachableError } from "../domain/WindbotErrors";
+
+// ---------- test helpers ----------
+
+const makeBot = (overrides: Partial<WindbotData> = {}): WindbotData => ({
+	name: "Anna",
+	deck: "Anna.ydk",
+	...overrides,
+});
+
+const makeRepo = (overrides: Partial<WindbotBotlistRepository> = {}): WindbotBotlistRepository => ({
+	findAll: jest.fn().mockReturnValue([makeBot()]),
+	findByName: jest.fn().mockReturnValue(makeBot()),
+	pickRandom: jest.fn().mockReturnValue(makeBot()),
+	...overrides,
+});
+
+const makeProvider = (): { requestJoin: jest.Mock } => ({
+	requestJoin: jest.fn().mockResolvedValue(undefined),
+});
+
+const makeDeps = (overrides: Partial<WindbotModuleDeps> = {}): WindbotModuleDeps => ({
+	enabled: true,
+	repo: makeRepo(),
+	tokenStore: WindbotTokenStore.createForTests(),
+	provider: makeProvider() as unknown as WindbotModuleDeps["provider"],
+	...overrides,
+});
+
+// ---------- tests ----------
+
+describe("WindbotModule", () => {
+	describe("isEnabled()", () => {
+		it("returns true when created with enabled: true", () => {
+			const mod = WindbotModule.createForTests(makeDeps({ enabled: true }));
+			expect(mod.isEnabled()).toBe(true);
+		});
+
+		it("returns false when created with enabled: false", () => {
+			const mod = WindbotModule.createForTests(makeDeps({ enabled: false }));
+			expect(mod.isEnabled()).toBe(false);
+		});
+	});
+
+	describe("requestBot()", () => {
+		it("registers token via RequestWindBotJoin and fires HTTP via provider", async () => {
+			const provider = makeProvider();
+			const mod = WindbotModule.createForTests(makeDeps({ provider: provider as unknown as WindbotModuleDeps["provider"] }));
+
+			const result = await mod.requestBot(42, "Anna", () => false);
+
+			expect(result.token).toMatch(/^[A-Za-z0-9]{12}$/);
+			expect(result.bot.name).toBe("Anna");
+			expect(provider.requestJoin).toHaveBeenCalledTimes(1);
+		});
+
+		it("passes isFinalizing callback to provider.requestJoin", async () => {
+			const provider = makeProvider();
+			const isFinalizing = jest.fn().mockReturnValue(false);
+			const mod = WindbotModule.createForTests(makeDeps({ provider: provider as unknown as WindbotModuleDeps["provider"] }));
+
+			await mod.requestBot(42, null, isFinalizing);
+
+			const call = provider.requestJoin.mock.calls[0][0];
+			// The isFinalizing callback must be wired
+			expect(typeof call.isFinalizing).toBe("function");
+		});
+
+		it("cleans up registered token when provider.requestJoin throws", async () => {
+			const unreachable = new WindbotUnreachableError("Anna", 10);
+			const provider = makeProvider();
+			provider.requestJoin.mockRejectedValue(unreachable);
+
+			const tokenStore = WindbotTokenStore.createForTests();
+			const mod = WindbotModule.createForTests(makeDeps({
+				provider: provider as unknown as WindbotModuleDeps["provider"],
+				tokenStore,
+			}));
+
+			await expect(mod.requestBot(42, "Anna", () => false)).rejects.toThrow(WindbotUnreachableError);
+
+			// Token must be cleaned up — clearByRoom returns 0 because token was already removed
+			const cleaned = tokenStore.clearByRoom(42);
+			expect(cleaned).toBe(0);
+		});
+
+		it("rethrows the provider error after cleanup", async () => {
+			const unreachable = new WindbotUnreachableError("Anna", 10);
+			const provider = makeProvider();
+			provider.requestJoin.mockRejectedValue(unreachable);
+			const mod = WindbotModule.createForTests(makeDeps({ provider: provider as unknown as WindbotModuleDeps["provider"] }));
+
+			await expect(mod.requestBot(42, "Anna", () => false)).rejects.toBe(unreachable);
+		});
+
+		it("selects random bot when botNameOrNull is null", async () => {
+			const provider = makeProvider();
+			const randomBot = makeBot({ name: "Gear", deck: "Gear.ydk" });
+			const repo = makeRepo({ pickRandom: jest.fn().mockReturnValue(randomBot) });
+			const mod = WindbotModule.createForTests(makeDeps({ provider: provider as unknown as WindbotModuleDeps["provider"], repo }));
+
+			const result = await mod.requestBot(1, null, () => false);
+
+			expect(result.bot.name).toBe("Gear");
+		});
+	});
+
+	describe("consumeToken()", () => {
+		it("returns the payload for a registered token", () => {
+			const tokenStore = WindbotTokenStore.createForTests();
+			const token = tokenStore.register(10, "Anna", "Anna.ydk");
+			const mod = WindbotModule.createForTests(makeDeps({ tokenStore }));
+
+			const payload = mod.consumeToken(token);
+			expect(payload.roomId).toBe(10);
+			expect(payload.botName).toBe("Anna");
+		});
+
+		it("throws when token is unknown", () => {
+			const mod = WindbotModule.createForTests(makeDeps());
+			expect(() => mod.consumeToken("nonexistent")).toThrow("Windbot token not found");
+		});
+	});
+
+	describe("cleanupRoom()", () => {
+		it("returns the count of tokens cleared for the room", () => {
+			const tokenStore = WindbotTokenStore.createForTests();
+			tokenStore.register(7, "Anna", "Anna.ydk");
+			tokenStore.register(7, "Gear", "Gear.ydk");
+			const mod = WindbotModule.createForTests(makeDeps({ tokenStore }));
+
+			const count = mod.cleanupRoom(7);
+			expect(count).toBe(2);
+		});
+
+		it("returns 0 when no tokens exist for the room", () => {
+			const mod = WindbotModule.createForTests(makeDeps());
+			const count = mod.cleanupRoom(99);
+			expect(count).toBe(0);
+		});
+
+		it("does not affect tokens of other rooms", () => {
+			const tokenStore = WindbotTokenStore.createForTests();
+			tokenStore.register(1, "Anna", "Anna.ydk");
+			tokenStore.register(2, "Gear", "Gear.ydk");
+			const mod = WindbotModule.createForTests(makeDeps({ tokenStore }));
+
+			mod.cleanupRoom(1);
+
+			// Room 2 token still exists
+			const count = tokenStore.clearByRoom(2);
+			expect(count).toBe(1);
+		});
+	});
+});

--- a/src/ygopro/windbot/application/WindbotModule.ts
+++ b/src/ygopro/windbot/application/WindbotModule.ts
@@ -53,7 +53,7 @@ export class WindbotModule {
 
 	/**
 	 * Returns the singleton instance.
-	 * Throws if init() was never called — callers that guard on isEnabled() avoid this.
+	 * Throws if init() was never called — callers that guard on isInitialized() avoid this.
 	 */
 	static getInstance(): WindbotModule {
 		if (!WindbotModule._instance) {
@@ -63,10 +63,32 @@ export class WindbotModule {
 	}
 
 	/**
+	 * Guard for call sites that run for EVERY room (windbot or not), such as
+	 * YGOProDuelingState.removeRoom(). Returns false before init() is called
+	 * so the cleanup hook is a no-op for non-windbot rooms.
+	 *
+	 * Usage pattern:
+	 *   if (WindbotModule.isInitialized() && WindbotModule.getInstance().isEnabled()) {
+	 *     WindbotModule.getInstance().cleanupRoom(roomId);
+	 *   }
+	 */
+	static isInitialized(): boolean {
+		return WindbotModule._instance !== null;
+	}
+
+	/**
 	 * Test seam: construct a module with injected deps without touching the singleton.
 	 */
 	static createForTests(deps: WindbotModuleDeps): WindbotModule {
 		return new WindbotModule(deps);
+	}
+
+	/**
+	 * Test seam: reset the singleton so test suites can call init() cleanly.
+	 * MUST NOT be called in production code.
+	 */
+	static resetForTests(): void {
+		WindbotModule._instance = null;
 	}
 
 	// ---- facade methods ----

--- a/src/ygopro/windbot/application/WindbotModule.ts
+++ b/src/ygopro/windbot/application/WindbotModule.ts
@@ -23,10 +23,8 @@ export interface WindbotModuleDeps {
 /**
  * WindbotModule — singleton facade that wires together all windbot use cases.
  *
- * Callers (PR-4 strategies) use this module via the singleton accessor.
+ * Callers use this module via the singleton accessor.
  * Tests use WindbotModule.createForTests(deps) to inject all dependencies.
- *
- * Not wired into src/index.ts yet — that is PR-7 scope.
  */
 export class WindbotModule {
 	private readonly requestJoinUseCase: RequestWindBotJoin;
@@ -45,7 +43,7 @@ export class WindbotModule {
 
 	/**
 	 * Init the module singleton from parsed config and infrastructure deps.
-	 * Called once at boot from src/index.ts (PR-7) when ENABLE_WINDBOT=true.
+	 * Called once at boot from src/index.ts when ENABLE_WINDBOT=true.
 	 */
 	static init(deps: WindbotModuleDeps): void {
 		WindbotModule._instance = new WindbotModule(deps);

--- a/src/ygopro/windbot/application/WindbotModule.ts
+++ b/src/ygopro/windbot/application/WindbotModule.ts
@@ -77,6 +77,24 @@ export class WindbotModule {
 	}
 
 	/**
+	 * Convenience guard: run cleanupRoom only when initialized AND enabled.
+	 * Returns 0 (no-op) when windbot is not initialized or disabled.
+	 *
+	 * Use this at ALL windbot token cleanup call sites (removeRoom, handleYGOPro, etc.)
+	 * to avoid duplicating the two-line guard everywhere.
+	 */
+	static cleanupRoomIfEnabled(roomId: number): number {
+		if (!WindbotModule.isInitialized()) {
+			return 0;
+		}
+		const instance = WindbotModule.getInstance();
+		if (!instance.isEnabled()) {
+			return 0;
+		}
+		return instance.cleanupRoom(roomId);
+	}
+
+	/**
 	 * Test seam: construct a module with injected deps without touching the singleton.
 	 */
 	static createForTests(deps: WindbotModuleDeps): WindbotModule {

--- a/src/ygopro/windbot/application/WindbotModule.ts
+++ b/src/ygopro/windbot/application/WindbotModule.ts
@@ -1,0 +1,109 @@
+import { WindbotBotlistRepository } from "../domain/WindbotBotlistRepository";
+import { WindbotTokenPayload, WindbotTokenStore } from "../domain/WindbotTokenStore";
+import { WindbotData } from "../domain/WindbotData";
+import { RequestWindBotJoin } from "./RequestWindBotJoin";
+import { ConsumeWindBotToken } from "./ConsumeWindBotToken";
+import { CleanupWindBotTokens } from "./CleanupWindBotTokens";
+
+export interface WindbotProviderPort {
+	requestJoin(params: {
+		token: string;
+		bot: WindbotData;
+		isFinalizing: () => boolean;
+	}): Promise<void>;
+}
+
+export interface WindbotModuleDeps {
+	enabled: boolean;
+	repo: WindbotBotlistRepository;
+	tokenStore: WindbotTokenStore;
+	provider: WindbotProviderPort;
+}
+
+/**
+ * WindbotModule — singleton facade that wires together all windbot use cases.
+ *
+ * Callers (PR-4 strategies) use this module via the singleton accessor.
+ * Tests use WindbotModule.createForTests(deps) to inject all dependencies.
+ *
+ * Not wired into src/index.ts yet — that is PR-7 scope.
+ */
+export class WindbotModule {
+	private readonly requestJoinUseCase: RequestWindBotJoin;
+	private readonly consumeTokenUseCase: ConsumeWindBotToken;
+	private readonly cleanupRoomUseCase: CleanupWindBotTokens;
+
+	private constructor(private readonly deps: WindbotModuleDeps) {
+		this.requestJoinUseCase = new RequestWindBotJoin(deps.repo, deps.tokenStore);
+		this.consumeTokenUseCase = new ConsumeWindBotToken(deps.tokenStore);
+		this.cleanupRoomUseCase = new CleanupWindBotTokens(deps.tokenStore);
+	}
+
+	// ---- singleton accessor (mirrors YGOProRoomList pattern) ----
+
+	private static _instance: WindbotModule | null = null;
+
+	/**
+	 * Init the module singleton from parsed config and infrastructure deps.
+	 * Called once at boot from src/index.ts (PR-7) when ENABLE_WINDBOT=true.
+	 */
+	static init(deps: WindbotModuleDeps): void {
+		WindbotModule._instance = new WindbotModule(deps);
+	}
+
+	/**
+	 * Returns the singleton instance.
+	 * Throws if init() was never called — callers that guard on isEnabled() avoid this.
+	 */
+	static getInstance(): WindbotModule {
+		if (!WindbotModule._instance) {
+			throw new Error("WindbotModule not initialized — call WindbotModule.init() first");
+		}
+		return WindbotModule._instance;
+	}
+
+	/**
+	 * Test seam: construct a module with injected deps without touching the singleton.
+	 */
+	static createForTests(deps: WindbotModuleDeps): WindbotModule {
+		return new WindbotModule(deps);
+	}
+
+	// ---- facade methods ----
+
+	isEnabled(): boolean {
+		return this.deps.enabled;
+	}
+
+	/**
+	 * Composes RequestWindBotJoin (register token) THEN provider.requestJoin (fire HTTP).
+	 *
+	 * On HTTP failure, cleans up the just-registered token before rethrowing so
+	 * no zombie token remains.
+	 */
+	async requestBot(
+		roomId: number,
+		botNameOrNull: string | null,
+		isFinalizing: () => boolean
+	): Promise<{ token: string; bot: WindbotData }> {
+		const { token, bot } = this.requestJoinUseCase.execute(roomId, botNameOrNull);
+
+		try {
+			await this.deps.provider.requestJoin({ token, bot, isFinalizing });
+		} catch (err) {
+			// Clean up the registered token so no zombie entry remains
+			this.deps.tokenStore.clearByRoom(roomId);
+			throw err;
+		}
+
+		return { token, bot };
+	}
+
+	consumeToken(token: string): WindbotTokenPayload {
+		return this.consumeTokenUseCase.execute(token);
+	}
+
+	cleanupRoom(roomId: number): number {
+		return this.cleanupRoomUseCase.execute(roomId);
+	}
+}

--- a/src/ygopro/windbot/application/WindbotModuleCleanupHelper.test.ts
+++ b/src/ygopro/windbot/application/WindbotModuleCleanupHelper.test.ts
@@ -1,0 +1,132 @@
+/**
+ * PR-7 tests — WindbotModule.cleanupRoomIfEnabled() static helper.
+ *
+ * This helper centralises the two-line guard pattern:
+ *   if (WindbotModule.isInitialized() && WindbotModule.getInstance().isEnabled()) {
+ *     WindbotModule.getInstance().cleanupRoom(roomId);
+ *   }
+ *
+ * It is called from BOTH:
+ *   - YGOProDuelingState.removeRoom() (PR-6, already calls cleanupRoom directly — updated in PR-7)
+ *   - DisconnectHandler.handleYGOPro() (PR-7 gap fix)
+ *
+ * Invariants:
+ *   1. No-op (returns 0) when WindbotModule is not initialized — NO throw.
+ *   2. No-op (returns 0) when WindbotModule is initialized but disabled.
+ *   3. Calls cleanupRoom(roomId) when initialized AND enabled.
+ *   4. Is safe to call multiple times (idempotent after first call clears tokens).
+ */
+
+import { WindbotModule, WindbotModuleDeps } from "./WindbotModule";
+import { WindbotTokenStore } from "../domain/WindbotTokenStore";
+
+// ---------- helpers ----------
+
+const makeRepo = () => ({
+	findAll: jest.fn().mockReturnValue([]),
+	findByName: jest.fn().mockReturnValue(undefined),
+	pickRandom: jest.fn().mockReturnValue(undefined),
+});
+
+const makeProvider = () => ({
+	requestJoin: jest.fn().mockResolvedValue(undefined),
+});
+
+const makeDeps = (overrides: Partial<WindbotModuleDeps> = {}): WindbotModuleDeps => ({
+	enabled: true,
+	repo: makeRepo(),
+	tokenStore: WindbotTokenStore.createForTests(),
+	provider: makeProvider() as unknown as WindbotModuleDeps["provider"],
+	...overrides,
+});
+
+// ---------- tests ----------
+
+describe("WindbotModule.cleanupRoomIfEnabled() — PR-7 static helper", () => {
+	afterEach(() => {
+		WindbotModule.resetForTests();
+		jest.restoreAllMocks();
+	});
+
+	describe("no-op path — not initialized", () => {
+		it("does NOT throw when WindbotModule is not initialized", () => {
+			expect(() => WindbotModule.cleanupRoomIfEnabled(42)).not.toThrow();
+		});
+
+		it("returns 0 (no tokens removed) when not initialized", () => {
+			const result = WindbotModule.cleanupRoomIfEnabled(42);
+			expect(result).toBe(0);
+		});
+
+		it("does NOT call getInstance() when not initialized", () => {
+			const spy = jest.spyOn(WindbotModule, "getInstance");
+			WindbotModule.cleanupRoomIfEnabled(42);
+			expect(spy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("no-op path — initialized but disabled", () => {
+		it("returns 0 when module is initialized but disabled", () => {
+			WindbotModule.init(makeDeps({ enabled: false }));
+			const result = WindbotModule.cleanupRoomIfEnabled(42);
+			expect(result).toBe(0);
+		});
+
+		it("does NOT call cleanupRoom when module is disabled", () => {
+			WindbotModule.init(makeDeps({ enabled: false }));
+			const cleanupSpy = jest.spyOn(WindbotModule.getInstance(), "cleanupRoom");
+			WindbotModule.cleanupRoomIfEnabled(42);
+			expect(cleanupSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("cleanup path — initialized and enabled", () => {
+		it("calls cleanupRoom(roomId) when initialized and enabled", () => {
+			WindbotModule.init(makeDeps({ enabled: true }));
+			const cleanupSpy = jest.spyOn(WindbotModule.getInstance(), "cleanupRoom");
+
+			WindbotModule.cleanupRoomIfEnabled(42);
+
+			expect(cleanupSpy).toHaveBeenCalledWith(42);
+		});
+
+		it("removes windbot tokens for the given room (integration)", () => {
+			const tokenStore = WindbotTokenStore.createForTests();
+			tokenStore.register(42, "Anna", "Anna.ydk");
+			tokenStore.register(42, "Gear", "Gear.ydk");
+			// Different room — must NOT be affected
+			tokenStore.register(99, "Rex", "Rex.ydk");
+
+			WindbotModule.init(makeDeps({ tokenStore, enabled: true }));
+
+			const count = WindbotModule.cleanupRoomIfEnabled(42);
+			expect(count).toBe(2);
+
+			// Room 99 token must survive
+			expect(tokenStore.clearByRoom(99)).toBe(1);
+		});
+
+		it("returns 0 (harmless) when the bot already consumed its token", () => {
+			const tokenStore = WindbotTokenStore.createForTests();
+			const token = tokenStore.register(42, "Anna", "Anna.ydk");
+			tokenStore.consume(token); // already consumed
+
+			WindbotModule.init(makeDeps({ tokenStore, enabled: true }));
+
+			const count = WindbotModule.cleanupRoomIfEnabled(42);
+			expect(count).toBe(0);
+		});
+
+		it("is safe to call twice for the same room (idempotent)", () => {
+			const tokenStore = WindbotTokenStore.createForTests();
+			tokenStore.register(42, "Anna", "Anna.ydk");
+
+			WindbotModule.init(makeDeps({ tokenStore, enabled: true }));
+
+			WindbotModule.cleanupRoomIfEnabled(42);
+			expect(() => WindbotModule.cleanupRoomIfEnabled(42)).not.toThrow();
+			// Second call returns 0 (already cleaned)
+			expect(WindbotModule.cleanupRoomIfEnabled(42)).toBe(0);
+		});
+	});
+});

--- a/src/ygopro/windbot/application/WindbotModuleCleanupHelper.test.ts
+++ b/src/ygopro/windbot/application/WindbotModuleCleanupHelper.test.ts
@@ -1,5 +1,5 @@
 /**
- * PR-7 tests — WindbotModule.cleanupRoomIfEnabled() static helper.
+ * WindbotModule.cleanupRoomIfEnabled() static helper.
  *
  * This helper centralises the two-line guard pattern:
  *   if (WindbotModule.isInitialized() && WindbotModule.getInstance().isEnabled()) {
@@ -7,8 +7,8 @@
  *   }
  *
  * It is called from BOTH:
- *   - YGOProDuelingState.removeRoom() (PR-6, already calls cleanupRoom directly — updated in PR-7)
- *   - DisconnectHandler.handleYGOPro() (PR-7 gap fix)
+ *   - YGOProDuelingState.removeRoom()
+ *   - DisconnectHandler.handleYGOPro() (gap fix)
  *
  * Invariants:
  *   1. No-op (returns 0) when WindbotModule is not initialized — NO throw.
@@ -42,7 +42,7 @@ const makeDeps = (overrides: Partial<WindbotModuleDeps> = {}): WindbotModuleDeps
 
 // ---------- tests ----------
 
-describe("WindbotModule.cleanupRoomIfEnabled() — PR-7 static helper", () => {
+describe("WindbotModule.cleanupRoomIfEnabled() — static helper", () => {
 	afterEach(() => {
 		WindbotModule.resetForTests();
 		jest.restoreAllMocks();

--- a/src/ygopro/windbot/application/WindbotModuleSingleton.test.ts
+++ b/src/ygopro/windbot/application/WindbotModuleSingleton.test.ts
@@ -1,5 +1,5 @@
 /**
- * PR-6 tests — WindbotModule singleton guard.
+ * WindbotModule singleton guard.
  *
  * isInitialized() must return false before init() is called,
  * and true after. This is the guard used by YGOProDuelingState.removeRoom()
@@ -35,7 +35,7 @@ const makeDeps = (overrides: Partial<WindbotModuleDeps> = {}): WindbotModuleDeps
 
 // ---------- tests ----------
 
-describe("WindbotModule — singleton guard (PR-6)", () => {
+describe("WindbotModule — singleton guard", () => {
 	afterEach(() => {
 		// Reset singleton so tests do not bleed into each other.
 		WindbotModule.resetForTests();

--- a/src/ygopro/windbot/application/WindbotModuleSingleton.test.ts
+++ b/src/ygopro/windbot/application/WindbotModuleSingleton.test.ts
@@ -1,0 +1,82 @@
+/**
+ * PR-6 tests — WindbotModule singleton guard.
+ *
+ * isInitialized() must return false before init() is called,
+ * and true after. This is the guard used by YGOProDuelingState.removeRoom()
+ * to safely skip cleanupRoom() when windbot is not wired up (non-windbot rooms,
+ * or the server is running without ENABLE_WINDBOT=true).
+ *
+ * These tests manipulate the singleton, so they run in their own isolated suite.
+ * The afterEach hook resets _instance via the resetForTests() seam.
+ */
+
+import { WindbotModule, WindbotModuleDeps } from "./WindbotModule";
+import { WindbotTokenStore } from "../domain/WindbotTokenStore";
+
+// ---------- helpers ----------
+
+const makeRepo = () => ({
+	findAll: jest.fn().mockReturnValue([]),
+	findByName: jest.fn().mockReturnValue(undefined),
+	pickRandom: jest.fn().mockReturnValue(undefined),
+});
+
+const makeProvider = () => ({
+	requestJoin: jest.fn().mockResolvedValue(undefined),
+});
+
+const makeDeps = (overrides: Partial<WindbotModuleDeps> = {}): WindbotModuleDeps => ({
+	enabled: true,
+	repo: makeRepo(),
+	tokenStore: WindbotTokenStore.createForTests(),
+	provider: makeProvider() as unknown as WindbotModuleDeps["provider"],
+	...overrides,
+});
+
+// ---------- tests ----------
+
+describe("WindbotModule — singleton guard (PR-6)", () => {
+	afterEach(() => {
+		// Reset singleton so tests do not bleed into each other.
+		WindbotModule.resetForTests();
+	});
+
+	describe("isInitialized()", () => {
+		it("returns false before init() is called", () => {
+			expect(WindbotModule.isInitialized()).toBe(false);
+		});
+
+		it("returns true after init() is called", () => {
+			WindbotModule.init(makeDeps());
+			expect(WindbotModule.isInitialized()).toBe(true);
+		});
+
+		it("returns false again after resetForTests()", () => {
+			WindbotModule.init(makeDeps());
+			WindbotModule.resetForTests();
+			expect(WindbotModule.isInitialized()).toBe(false);
+		});
+	});
+
+	describe("getInstance()", () => {
+		it("throws when not initialized", () => {
+			expect(() => WindbotModule.getInstance()).toThrow(
+				"WindbotModule not initialized — call WindbotModule.init() first",
+			);
+		});
+
+		it("returns the initialized instance", () => {
+			WindbotModule.init(makeDeps());
+			expect(WindbotModule.getInstance()).toBeDefined();
+		});
+	});
+
+	describe("resetForTests()", () => {
+		it("clears the singleton so init() can be called again", () => {
+			WindbotModule.init(makeDeps());
+			WindbotModule.resetForTests();
+			// Should not throw — init() is callable again
+			expect(() => WindbotModule.init(makeDeps())).not.toThrow();
+		});
+	});
+});

--- a/src/ygopro/windbot/domain/WindbotBotlistRepository.ts
+++ b/src/ygopro/windbot/domain/WindbotBotlistRepository.ts
@@ -1,0 +1,7 @@
+import { WindbotData } from "./WindbotData";
+
+export interface WindbotBotlistRepository {
+	findAll(): WindbotData[];
+	findByName(name: string): WindbotData | null;
+	pickRandom(): WindbotData | null;
+}

--- a/src/ygopro/windbot/domain/WindbotData.test.ts
+++ b/src/ygopro/windbot/domain/WindbotData.test.ts
@@ -1,0 +1,32 @@
+import { WindbotData } from "./WindbotData";
+
+describe("WindbotData", () => {
+	it("accepts a minimal valid bot (name + deck only)", () => {
+		const bot: WindbotData = {
+			name: "Anna",
+			deck: "Anna.ydk",
+		};
+		expect(bot.name).toBe("Anna");
+		expect(bot.deck).toBe("Anna.ydk");
+	});
+
+	it("accepts all optional fields", () => {
+		const bot: WindbotData = {
+			name: "Gear",
+			deck: "Gear.ydk",
+			dialog: "gear_dialog",
+			hidden: true,
+			deckcode: "abc123",
+		};
+		expect(bot.dialog).toBe("gear_dialog");
+		expect(bot.hidden).toBe(true);
+		expect(bot.deckcode).toBe("abc123");
+	});
+
+	it("optional fields are absent when not provided (no undefined bleed)", () => {
+		const bot: WindbotData = { name: "Anna", deck: "Anna.ydk" };
+		expect(bot.hidden).toBeUndefined();
+		expect(bot.dialog).toBeUndefined();
+		expect(bot.deckcode).toBeUndefined();
+	});
+});

--- a/src/ygopro/windbot/domain/WindbotData.ts
+++ b/src/ygopro/windbot/domain/WindbotData.ts
@@ -1,0 +1,7 @@
+export type WindbotData = {
+	name: string;
+	deck: string;
+	dialog?: string;
+	hidden?: boolean;
+	deckcode?: string;
+};

--- a/src/ygopro/windbot/domain/WindbotErrors.test.ts
+++ b/src/ygopro/windbot/domain/WindbotErrors.test.ts
@@ -1,4 +1,4 @@
-import { WindbotNotFoundError, WindbotsExhaustedError } from "./WindbotErrors";
+import { WindbotNotFoundError, WindbotsExhaustedError, WindbotUnreachableError } from "./WindbotErrors";
 
 describe("WindbotNotFoundError", () => {
 	it("produces the expected message with the bot name", () => {
@@ -41,5 +41,33 @@ describe("WindbotsExhaustedError", () => {
 	it("is an instance of WindbotsExhaustedError", () => {
 		const err = new WindbotsExhaustedError();
 		expect(err).toBeInstanceOf(WindbotsExhaustedError);
+	});
+});
+
+describe("WindbotUnreachableError", () => {
+	it("produces a message including the bot name and attempt count", () => {
+		const err = new WindbotUnreachableError("Anna", 10);
+		expect(err.message).toContain("Anna");
+		expect(err.message).toContain("10");
+	});
+
+	it("exposes the attempts count via the attempts field", () => {
+		const err = new WindbotUnreachableError("Gear", 7);
+		expect(err.attempts).toBe(7);
+	});
+
+	it("sets the error name field to WindbotUnreachableError", () => {
+		const err = new WindbotUnreachableError("Anna", 10);
+		expect(err.name).toBe("WindbotUnreachableError");
+	});
+
+	it("inherits from Error", () => {
+		const err = new WindbotUnreachableError("Anna", 10);
+		expect(err).toBeInstanceOf(Error);
+	});
+
+	it("is an instance of WindbotUnreachableError", () => {
+		const err = new WindbotUnreachableError("Anna", 10);
+		expect(err).toBeInstanceOf(WindbotUnreachableError);
 	});
 });

--- a/src/ygopro/windbot/domain/WindbotErrors.test.ts
+++ b/src/ygopro/windbot/domain/WindbotErrors.test.ts
@@ -1,0 +1,45 @@
+import { WindbotNotFoundError, WindbotsExhaustedError } from "./WindbotErrors";
+
+describe("WindbotNotFoundError", () => {
+	it("produces the expected message with the bot name", () => {
+		const err = new WindbotNotFoundError("Anna");
+		expect(err.message).toBe("Windbot not found: Anna");
+	});
+
+	it("sets the error name field to WindbotNotFoundError", () => {
+		const err = new WindbotNotFoundError("Gear");
+		expect(err.name).toBe("WindbotNotFoundError");
+	});
+
+	it("inherits from Error", () => {
+		const err = new WindbotNotFoundError("Anna");
+		expect(err).toBeInstanceOf(Error);
+	});
+
+	it("is an instance of WindbotNotFoundError", () => {
+		const err = new WindbotNotFoundError("Anna");
+		expect(err).toBeInstanceOf(WindbotNotFoundError);
+	});
+});
+
+describe("WindbotsExhaustedError", () => {
+	it("produces the expected message", () => {
+		const err = new WindbotsExhaustedError();
+		expect(err.message).toBe("No windbots available (all hidden or list empty)");
+	});
+
+	it("sets the error name field to WindbotsExhaustedError", () => {
+		const err = new WindbotsExhaustedError();
+		expect(err.name).toBe("WindbotsExhaustedError");
+	});
+
+	it("inherits from Error", () => {
+		const err = new WindbotsExhaustedError();
+		expect(err).toBeInstanceOf(Error);
+	});
+
+	it("is an instance of WindbotsExhaustedError", () => {
+		const err = new WindbotsExhaustedError();
+		expect(err).toBeInstanceOf(WindbotsExhaustedError);
+	});
+});

--- a/src/ygopro/windbot/domain/WindbotErrors.ts
+++ b/src/ygopro/windbot/domain/WindbotErrors.ts
@@ -1,0 +1,15 @@
+export class WindbotNotFoundError extends Error {
+	constructor(name: string) {
+		super(`Windbot not found: ${name}`);
+		this.name = "WindbotNotFoundError";
+		Object.setPrototypeOf(this, WindbotNotFoundError.prototype);
+	}
+}
+
+export class WindbotsExhaustedError extends Error {
+	constructor() {
+		super("No windbots available (all hidden or list empty)");
+		this.name = "WindbotsExhaustedError";
+		Object.setPrototypeOf(this, WindbotsExhaustedError.prototype);
+	}
+}

--- a/src/ygopro/windbot/domain/WindbotErrors.ts
+++ b/src/ygopro/windbot/domain/WindbotErrors.ts
@@ -13,3 +13,14 @@ export class WindbotsExhaustedError extends Error {
 		Object.setPrototypeOf(this, WindbotsExhaustedError.prototype);
 	}
 }
+
+export class WindbotUnreachableError extends Error {
+	readonly attempts: number;
+
+	constructor(botName: string, attempts: number) {
+		super(`Windbot unreachable after ${attempts} attempts for bot "${botName}"`);
+		this.name = "WindbotUnreachableError";
+		this.attempts = attempts;
+		Object.setPrototypeOf(this, WindbotUnreachableError.prototype);
+	}
+}

--- a/src/ygopro/windbot/infrastructure/FileBotlistRepository.test.ts
+++ b/src/ygopro/windbot/infrastructure/FileBotlistRepository.test.ts
@@ -93,17 +93,40 @@ describe("FileBotlistRepository", () => {
 
 			const repo = new FileBotlistRepository(filePath);
 
-			expect(repo.findByName("gear")).toBeNull();
+			expect(repo.findByName("nope")).toBeNull();
 		});
 
-		it("is case-sensitive: 'anna' does NOT match 'Anna'", () => {
+		it("is case-insensitive: 'anna' matches 'Anna'", () => {
 			const filePath = writeTempFile(
 				JSON.stringify([{ name: "Anna", deck: "Anna.ydk" }])
 			);
 
 			const repo = new FileBotlistRepository(filePath);
 
-			expect(repo.findByName("anna")).toBeNull();
+			expect(repo.findByName("anna")).not.toBeNull();
+			expect(repo.findByName("anna")?.name).toBe("Anna");
+		});
+
+		it("is case-insensitive: 'JOEY' matches a bot registered as 'Joey'", () => {
+			const filePath = writeTempFile(
+				JSON.stringify([{ name: "Joey", deck: "Joey.ydk" }])
+			);
+
+			const repo = new FileBotlistRepository(filePath);
+
+			expect(repo.findByName("JOEY")).not.toBeNull();
+			expect(repo.findByName("JOEY")?.name).toBe("Joey");
+		});
+
+		it("is case-insensitive: 'joey' matches a bot registered as 'Joey'", () => {
+			const filePath = writeTempFile(
+				JSON.stringify([{ name: "Joey", deck: "Joey.ydk" }])
+			);
+
+			const repo = new FileBotlistRepository(filePath);
+
+			expect(repo.findByName("joey")).not.toBeNull();
+			expect(repo.findByName("joey")?.name).toBe("Joey");
 		});
 	});
 

--- a/src/ygopro/windbot/infrastructure/FileBotlistRepository.test.ts
+++ b/src/ygopro/windbot/infrastructure/FileBotlistRepository.test.ts
@@ -1,0 +1,172 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { FileBotlistRepository } from "./FileBotlistRepository";
+
+const writeTempFile = (content: string): string => {
+	const tmpFile = path.join(os.tmpdir(), `botlist-test-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+	fs.writeFileSync(tmpFile, content, "utf-8");
+	return tmpFile;
+};
+
+describe("FileBotlistRepository", () => {
+	describe("construction and findAll", () => {
+		it("loads a valid JSON array and returns all bots via findAll", () => {
+			const filePath = writeTempFile(
+				JSON.stringify([
+					{ name: "Anna", deck: "Anna.ydk" },
+					{ name: "Gear", deck: "Gear.ydk" },
+				])
+			);
+
+			const repo = new FileBotlistRepository(filePath);
+
+			expect(repo.findAll()).toHaveLength(2);
+			expect(repo.findAll()[0].name).toBe("Anna");
+		});
+
+		it("accepts optional fields (dialog, hidden, deckcode)", () => {
+			const filePath = writeTempFile(
+				JSON.stringify([
+					{ name: "Anna", deck: "Anna.ydk", dialog: "anna_dlg", hidden: false, deckcode: "abc" },
+				])
+			);
+
+			const repo = new FileBotlistRepository(filePath);
+			const bots = repo.findAll();
+
+			expect(bots[0].dialog).toBe("anna_dlg");
+			expect(bots[0].hidden).toBe(false);
+			expect(bots[0].deckcode).toBe("abc");
+		});
+
+		it("throws on invalid JSON (malformed)", () => {
+			const filePath = writeTempFile("{ not valid json ]]]");
+
+			expect(() => new FileBotlistRepository(filePath)).toThrow();
+		});
+
+		it("throws when an entry is missing the 'name' field", () => {
+			const filePath = writeTempFile(
+				JSON.stringify([{ deck: "Anna.ydk" }])
+			);
+
+			expect(() => new FileBotlistRepository(filePath)).toThrow();
+		});
+
+		it("throws when an entry is missing the 'deck' field", () => {
+			const filePath = writeTempFile(
+				JSON.stringify([{ name: "Anna" }])
+			);
+
+			expect(() => new FileBotlistRepository(filePath)).toThrow();
+		});
+
+		it("throws when the root is not an array", () => {
+			const filePath = writeTempFile(
+				JSON.stringify({ name: "Anna", deck: "Anna.ydk" })
+			);
+
+			expect(() => new FileBotlistRepository(filePath)).toThrow();
+		});
+	});
+
+	describe("findByName", () => {
+		it("returns the matching bot for an exact case-sensitive name", () => {
+			const filePath = writeTempFile(
+				JSON.stringify([
+					{ name: "Anna", deck: "Anna.ydk" },
+					{ name: "Gear", deck: "Gear.ydk" },
+				])
+			);
+
+			const repo = new FileBotlistRepository(filePath);
+
+			expect(repo.findByName("Anna")).not.toBeNull();
+			expect(repo.findByName("Anna")?.name).toBe("Anna");
+		});
+
+		it("returns null when the name does not exist", () => {
+			const filePath = writeTempFile(
+				JSON.stringify([{ name: "Anna", deck: "Anna.ydk" }])
+			);
+
+			const repo = new FileBotlistRepository(filePath);
+
+			expect(repo.findByName("gear")).toBeNull();
+		});
+
+		it("is case-sensitive: 'anna' does NOT match 'Anna'", () => {
+			const filePath = writeTempFile(
+				JSON.stringify([{ name: "Anna", deck: "Anna.ydk" }])
+			);
+
+			const repo = new FileBotlistRepository(filePath);
+
+			expect(repo.findByName("anna")).toBeNull();
+		});
+	});
+
+	describe("pickRandom", () => {
+		it("returns a bot from the visible (non-hidden) list", () => {
+			const filePath = writeTempFile(
+				JSON.stringify([
+					{ name: "Anna", deck: "Anna.ydk" },
+					{ name: "Hidden", deck: "Hidden.ydk", hidden: true },
+				])
+			);
+
+			const repo = new FileBotlistRepository(filePath);
+			const results = new Set<string>();
+
+			for (let i = 0; i < 30; i++) {
+				const bot = repo.pickRandom();
+				if (bot) results.add(bot.name);
+			}
+
+			expect(results.has("Hidden")).toBe(false);
+			expect(results.has("Anna")).toBe(true);
+		});
+
+		it("returns null when all bots are hidden", () => {
+			const filePath = writeTempFile(
+				JSON.stringify([
+					{ name: "Hidden1", deck: "h1.ydk", hidden: true },
+					{ name: "Hidden2", deck: "h2.ydk", hidden: true },
+				])
+			);
+
+			const repo = new FileBotlistRepository(filePath);
+
+			expect(repo.pickRandom()).toBeNull();
+		});
+
+		it("returns null when the list is empty", () => {
+			const filePath = writeTempFile(JSON.stringify([]));
+
+			const repo = new FileBotlistRepository(filePath);
+
+			expect(repo.pickRandom()).toBeNull();
+		});
+
+		it("can return any visible bot across random calls", () => {
+			const filePath = writeTempFile(
+				JSON.stringify([
+					{ name: "Anna", deck: "Anna.ydk" },
+					{ name: "Gear", deck: "Gear.ydk" },
+				])
+			);
+
+			const repo = new FileBotlistRepository(filePath);
+			const results = new Set<string>();
+
+			for (let i = 0; i < 50; i++) {
+				const bot = repo.pickRandom();
+				if (bot) results.add(bot.name);
+			}
+
+			expect(results.has("Anna")).toBe(true);
+			expect(results.has("Gear")).toBe(true);
+		});
+	});
+});

--- a/src/ygopro/windbot/infrastructure/FileBotlistRepository.ts
+++ b/src/ygopro/windbot/infrastructure/FileBotlistRepository.ts
@@ -33,7 +33,8 @@ export class FileBotlistRepository implements WindbotBotlistRepository {
 	}
 
 	findByName(name: string): WindbotData | null {
-		return this.bots.find((b) => b.name === name) ?? null;
+		const lower = name.toLowerCase();
+		return this.bots.find((b) => b.name.toLowerCase() === lower) ?? null;
 	}
 
 	pickRandom(): WindbotData | null {

--- a/src/ygopro/windbot/infrastructure/FileBotlistRepository.ts
+++ b/src/ygopro/windbot/infrastructure/FileBotlistRepository.ts
@@ -1,0 +1,46 @@
+import fs from "fs";
+import { z } from "zod";
+import { WindbotBotlistRepository } from "../domain/WindbotBotlistRepository";
+import { WindbotData } from "../domain/WindbotData";
+
+const WindbotDataSchema = z.object({
+	name: z.string(),
+	deck: z.string(),
+	dialog: z.string().optional(),
+	hidden: z.boolean().optional(),
+	deckcode: z.string().optional(),
+});
+
+const BotlistSchema = z.array(WindbotDataSchema);
+
+export class FileBotlistRepository implements WindbotBotlistRepository {
+	private readonly bots: WindbotData[];
+
+	constructor(filePath: string) {
+		const raw = fs.readFileSync(filePath, "utf-8");
+		const parsed = JSON.parse(raw);
+		const result = BotlistSchema.safeParse(parsed);
+		if (!result.success) {
+			throw new Error(
+				`Invalid botlist at ${filePath}: ${result.error.message}`
+			);
+		}
+		this.bots = result.data;
+	}
+
+	findAll(): WindbotData[] {
+		return this.bots;
+	}
+
+	findByName(name: string): WindbotData | null {
+		return this.bots.find((b) => b.name === name) ?? null;
+	}
+
+	pickRandom(): WindbotData | null {
+		const visible = this.bots.filter((b) => b.hidden !== true);
+		if (visible.length === 0) {
+			return null;
+		}
+		return visible[Math.floor(Math.random() * visible.length)];
+	}
+}

--- a/src/ygopro/windbot/infrastructure/HttpWindBotProvider.test.ts
+++ b/src/ygopro/windbot/infrastructure/HttpWindBotProvider.test.ts
@@ -1,0 +1,237 @@
+import { HttpWindBotProvider, HttpWindBotProviderConfig } from "./HttpWindBotProvider";
+import { WindbotData } from "../domain/WindbotData";
+import { WindbotUnreachableError } from "../domain/WindbotErrors";
+
+const makeBot = (overrides: Partial<WindbotData> = {}): WindbotData => ({
+	name: "Anna",
+	deck: "Anna.ydk",
+	...overrides,
+});
+
+const makeConfig = (overrides: Partial<HttpWindBotProviderConfig> = {}): HttpWindBotProviderConfig => ({
+	endpoint: "http://windbot:7790",
+	myIp: "windbot",
+	serverPort: 7911,
+	version: 0x1362,
+	...overrides,
+});
+
+const notFinalizing = () => false;
+const alreadyFinalizing = () => true;
+
+const makeOkResponse = () =>
+	new Response(null, { status: 200 });
+
+const makeErrorResponse = () =>
+	new Response(null, { status: 500 });
+
+describe("HttpWindBotProvider", () => {
+	let fetchMock: jest.Mock;
+
+	beforeEach(() => {
+		fetchMock = jest.fn();
+		global.fetch = fetchMock;
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	describe("requestJoin — success paths", () => {
+		it("resolves void on first 2xx response", async () => {
+			fetchMock.mockResolvedValueOnce(makeOkResponse());
+
+			const provider = new HttpWindBotProvider(makeConfig());
+			await expect(
+				provider.requestJoin({ token: "abc123def456", bot: makeBot(), isFinalizing: notFinalizing })
+			).resolves.toBeUndefined();
+
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+		});
+
+		it("sends GET to the configured endpoint", async () => {
+			fetchMock.mockResolvedValueOnce(makeOkResponse());
+
+			const config = makeConfig({ endpoint: "http://windbot:7790" });
+			const provider = new HttpWindBotProvider(config);
+			await provider.requestJoin({ token: "abc123def456", bot: makeBot(), isFinalizing: notFinalizing });
+
+			const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toMatch(/^http:\/\/windbot:7790\//);
+		});
+
+		it("sends GET method", async () => {
+			fetchMock.mockResolvedValueOnce(makeOkResponse());
+
+			const provider = new HttpWindBotProvider(makeConfig());
+			await provider.requestJoin({ token: "abc123def456", bot: makeBot(), isFinalizing: notFinalizing });
+
+			const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(options.method).toBe("GET");
+		});
+
+		it("query string contains password: 'AIJOIN#' + token", async () => {
+			fetchMock.mockResolvedValueOnce(makeOkResponse());
+
+			const provider = new HttpWindBotProvider(makeConfig());
+			await provider.requestJoin({ token: "tok123456789", bot: makeBot(), isFinalizing: notFinalizing });
+
+			const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+			const params = new URL(url).searchParams;
+			expect(params.get("password")).toBe("AIJOIN#tok123456789");
+		});
+
+		it("query string contains bot name, deck, host, port and version", async () => {
+			fetchMock.mockResolvedValueOnce(makeOkResponse());
+
+			const config = makeConfig({ myIp: "192.168.1.1", serverPort: 8800, version: 0x1362 });
+			const bot = makeBot({ name: "Gear", deck: "Gear.ydk" });
+			const provider = new HttpWindBotProvider(config);
+			await provider.requestJoin({ token: "abc123def456", bot, isFinalizing: notFinalizing });
+
+			const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+			const params = new URL(url).searchParams;
+			expect(params.get("name")).toBe("Gear");
+			expect(params.get("deck")).toBe("Gear.ydk");
+			expect(params.get("host")).toBe("192.168.1.1");
+			expect(params.get("port")).toBe("8800");
+			expect(params.get("version")).toBe((0x1362).toString());
+		});
+
+		it("query string includes optional dialog and deckcode when present", async () => {
+			fetchMock.mockResolvedValueOnce(makeOkResponse());
+
+			const bot = makeBot({ dialog: "default", deckcode: "ABC123" });
+			const provider = new HttpWindBotProvider(makeConfig());
+			await provider.requestJoin({ token: "abc123def456", bot, isFinalizing: notFinalizing });
+
+			const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+			const params = new URL(url).searchParams;
+			expect(params.get("dialog")).toBe("default");
+			expect(params.get("deckcode")).toBe("ABC123");
+		});
+
+		it("fetch is called with an AbortSignal (timeout)", async () => {
+			fetchMock.mockResolvedValueOnce(makeOkResponse());
+
+			const provider = new HttpWindBotProvider(makeConfig());
+			await provider.requestJoin({ token: "abc123def456", bot: makeBot(), isFinalizing: notFinalizing });
+
+			const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(options.signal).toBeDefined();
+			expect(options.signal).toBeInstanceOf(AbortSignal);
+		});
+
+		it("resolves void after failure then success (retries)", async () => {
+			fetchMock
+				.mockRejectedValueOnce(new Error("network error"))
+				.mockRejectedValueOnce(new Error("timeout"))
+				.mockResolvedValueOnce(makeOkResponse());
+
+			const provider = new HttpWindBotProvider(makeConfig());
+			await expect(
+				provider.requestJoin({ token: "abc123def456", bot: makeBot(), isFinalizing: notFinalizing })
+			).resolves.toBeUndefined();
+
+			expect(fetchMock).toHaveBeenCalledTimes(3);
+		});
+
+		it("retries on non-2xx response", async () => {
+			fetchMock
+				.mockResolvedValueOnce(makeErrorResponse())
+				.mockResolvedValueOnce(makeOkResponse());
+
+			const provider = new HttpWindBotProvider(makeConfig());
+			await expect(
+				provider.requestJoin({ token: "abc123def456", bot: makeBot(), isFinalizing: notFinalizing })
+			).resolves.toBeUndefined();
+
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe("requestJoin — failure paths", () => {
+		it("throws WindbotUnreachableError after 10 consecutive failures", async () => {
+			fetchMock.mockRejectedValue(new Error("network error"));
+
+			const provider = new HttpWindBotProvider(makeConfig());
+			await expect(
+				provider.requestJoin({ token: "abc123def456", bot: makeBot(), isFinalizing: notFinalizing })
+			).rejects.toThrow(WindbotUnreachableError);
+
+			expect(fetchMock).toHaveBeenCalledTimes(10);
+		});
+
+		it("throws WindbotUnreachableError after 10 non-2xx responses", async () => {
+			fetchMock.mockResolvedValue(makeErrorResponse());
+
+			const provider = new HttpWindBotProvider(makeConfig());
+			await expect(
+				provider.requestJoin({ token: "abc123def456", bot: makeBot(), isFinalizing: notFinalizing })
+			).rejects.toThrow(WindbotUnreachableError);
+
+			expect(fetchMock).toHaveBeenCalledTimes(10);
+		});
+
+		it("WindbotUnreachableError message includes bot name and attempt count", async () => {
+			fetchMock.mockRejectedValue(new Error("connection refused"));
+
+			const provider = new HttpWindBotProvider(makeConfig());
+			const error = await provider
+				.requestJoin({ token: "abc123def456", bot: makeBot({ name: "Anna" }), isFinalizing: notFinalizing })
+				.catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(WindbotUnreachableError);
+			expect((error as WindbotUnreachableError).message).toContain("Anna");
+			expect((error as WindbotUnreachableError).attempts).toBe(10);
+		});
+	});
+
+	describe("requestJoin — isFinalizing guard", () => {
+		it("aborts the retry loop immediately when isFinalizing returns true before first attempt", async () => {
+			fetchMock.mockResolvedValue(makeOkResponse());
+
+			const provider = new HttpWindBotProvider(makeConfig());
+			await expect(
+				provider.requestJoin({ token: "abc123def456", bot: makeBot(), isFinalizing: alreadyFinalizing })
+			).rejects.toThrow(WindbotUnreachableError);
+
+			expect(fetchMock).toHaveBeenCalledTimes(0);
+		});
+
+		it("aborts retry loop mid-flight when isFinalizing flips to true", async () => {
+			let callCount = 0;
+			const isFinalizing = () => {
+				callCount++;
+				return callCount > 1; // true from 2nd check onwards
+			};
+
+			fetchMock.mockRejectedValue(new Error("network error"));
+
+			const provider = new HttpWindBotProvider(makeConfig());
+			await expect(
+				provider.requestJoin({ token: "abc123def456", bot: makeBot(), isFinalizing })
+			).rejects.toThrow(WindbotUnreachableError);
+
+			// 1st attempt fires (isFinalizing returned false), then 2nd check = true → abort
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+		});
+
+		it("does not make further fetch calls after isFinalizing aborts", async () => {
+			let attempt = 0;
+			const isFinalizing = () => {
+				attempt++;
+				return attempt > 2; // abort after 2 real attempts
+			};
+
+			fetchMock.mockRejectedValue(new Error("err"));
+
+			const provider = new HttpWindBotProvider(makeConfig());
+			await expect(
+				provider.requestJoin({ token: "abc123def456", bot: makeBot(), isFinalizing })
+			).rejects.toThrow(WindbotUnreachableError);
+
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+		});
+	});
+});

--- a/src/ygopro/windbot/infrastructure/HttpWindBotProvider.ts
+++ b/src/ygopro/windbot/infrastructure/HttpWindBotProvider.ts
@@ -1,0 +1,90 @@
+import { WindbotData } from "../domain/WindbotData";
+import { WindbotUnreachableError } from "../domain/WindbotErrors";
+
+export interface HttpWindBotProviderConfig {
+	/** Base URL of the WindBot Docker HTTP service, e.g. "http://windbot:7790" */
+	endpoint: string;
+	/** IP or hostname the WindBot binary should connect back to */
+	myIp: string;
+	/** TCP port of the YGOPro game server */
+	serverPort: number;
+	/** YGOPro protocol version the bot must use (e.g. 0x1362) */
+	version: number;
+}
+
+export interface RequestJoinParams {
+	token: string;
+	bot: WindbotData;
+	/**
+	 * Injected callback — checked before every attempt.
+	 * If it returns true the retry loop aborts immediately.
+	 * This keeps HttpWindBotProvider decoupled from YGOProRoom.
+	 */
+	isFinalizing: () => boolean;
+}
+
+const MAX_ATTEMPTS = 10;
+const REQUEST_TIMEOUT_MS = 500;
+
+/**
+ * HttpWindBotProvider
+ *
+ * Fires a GET request to the WindBot Docker service so it reverse-connects
+ * to the YGOPro game server with the given token. The request shape matches
+ * the WindBot binary contract (srvpro2): a GET with query-string params and a
+ * `password` field carrying `AIJOIN#{token}`.
+ *
+ * Retry policy:
+ *   - Up to 10 attempts, no backoff sleep (matches srvpro2 tuning).
+ *   - Per-attempt timeout: 500 ms via AbortSignal.timeout().
+ *   - Between attempts: checks isFinalizing(); aborts immediately if true.
+ *   - After all attempts exhausted or isFinalizing() true: throws WindbotUnreachableError.
+ */
+export class HttpWindBotProvider {
+	constructor(private readonly config: HttpWindBotProviderConfig) {}
+
+	async requestJoin(params: RequestJoinParams): Promise<void> {
+		const { token, bot, isFinalizing } = params;
+		const url = this.buildUrl(token, bot);
+
+		for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+			if (isFinalizing()) {
+				throw new WindbotUnreachableError(bot.name, attempt - 1);
+			}
+
+			try {
+				const response = await fetch(url, {
+					method: "GET",
+					signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+				});
+
+				if (response.ok) {
+					return;
+				}
+				// non-2xx — fall through to retry
+			} catch {
+				// network error or timeout — fall through to retry
+			}
+		}
+
+		throw new WindbotUnreachableError(bot.name, MAX_ATTEMPTS);
+	}
+
+	private buildUrl(token: string, bot: WindbotData): string {
+		const url = new URL(this.config.endpoint);
+		url.searchParams.set("name", bot.name);
+		url.searchParams.set("deck", bot.deck);
+		url.searchParams.set("host", this.config.myIp);
+		url.searchParams.set("port", this.config.serverPort.toString());
+		url.searchParams.set("version", this.config.version.toString());
+		url.searchParams.set("password", `AIJOIN#${token}`);
+		if (bot.dialog !== undefined) {
+			url.searchParams.set("dialog", bot.dialog);
+		}
+		if (bot.deckcode !== undefined) {
+			url.searchParams.set("deckcode", bot.deckcode);
+		}
+
+		return url.toString();
+	}
+}

--- a/src/ygopro/windbot/infrastructure/WindbotConfig.test.ts
+++ b/src/ygopro/windbot/infrastructure/WindbotConfig.test.ts
@@ -1,0 +1,108 @@
+import { parseWindbotConfig, WindbotConfigEnabled } from "./WindbotConfig";
+
+describe("parseWindbotConfig", () => {
+	describe("when ENABLE_WINDBOT is absent or false", () => {
+		it("returns disabled config when ENABLE_WINDBOT is not set", () => {
+			const config = parseWindbotConfig({});
+			expect(config.enabled).toBe(false);
+		});
+
+		it("returns disabled config when ENABLE_WINDBOT is 'false'", () => {
+			const config = parseWindbotConfig({ ENABLE_WINDBOT: "false" });
+			expect(config.enabled).toBe(false);
+		});
+
+		it("returns disabled config when ENABLE_WINDBOT is '0'", () => {
+			const config = parseWindbotConfig({ ENABLE_WINDBOT: "0" });
+			expect(config.enabled).toBe(false);
+		});
+
+		it("does not throw when endpoint and botlist are missing and ENABLE_WINDBOT is false", () => {
+			expect(() => parseWindbotConfig({ ENABLE_WINDBOT: "false" })).not.toThrow();
+		});
+	});
+
+	describe("when ENABLE_WINDBOT is true", () => {
+		it("returns enabled config with all required fields", () => {
+			const env = {
+				ENABLE_WINDBOT: "true",
+				WINDBOT_ENDPOINT: "http://windbot:7790",
+				WINDBOT_MY_IP: "windbot",
+				WINDBOT_BOTLIST: "/data/botlist.json",
+			};
+
+			const config = parseWindbotConfig(env) as WindbotConfigEnabled;
+			expect(config.enabled).toBe(true);
+			expect(config.endpoint).toBe("http://windbot:7790");
+			expect(config.myIp).toBe("windbot");
+			expect(config.botlistPath).toBe("/data/botlist.json");
+		});
+
+		it("coerces '1' to true", () => {
+			const env = {
+				ENABLE_WINDBOT: "1",
+				WINDBOT_ENDPOINT: "http://windbot:7790",
+				WINDBOT_MY_IP: "windbot",
+				WINDBOT_BOTLIST: "/data/botlist.json",
+			};
+			const config = parseWindbotConfig(env);
+			expect(config.enabled).toBe(true);
+		});
+
+		it("throws when WINDBOT_ENDPOINT is missing", () => {
+			const env = {
+				ENABLE_WINDBOT: "true",
+				WINDBOT_MY_IP: "windbot",
+				WINDBOT_BOTLIST: "/data/botlist.json",
+			};
+			expect(() => parseWindbotConfig(env)).toThrow();
+		});
+
+		it("throws when WINDBOT_BOTLIST is missing", () => {
+			const env = {
+				ENABLE_WINDBOT: "true",
+				WINDBOT_ENDPOINT: "http://windbot:7790",
+				WINDBOT_MY_IP: "windbot",
+			};
+			expect(() => parseWindbotConfig(env)).toThrow();
+		});
+
+		it("defaults WINDBOT_MY_IP to 'windbot' when not set", () => {
+			const env = {
+				ENABLE_WINDBOT: "true",
+				WINDBOT_ENDPOINT: "http://windbot:7790",
+				WINDBOT_BOTLIST: "/data/botlist.json",
+			};
+			const config = parseWindbotConfig(env) as WindbotConfigEnabled;
+			expect(config.enabled).toBe(true);
+			expect(config.myIp).toBe("windbot");
+		});
+
+		it("uses provided WINDBOT_MY_IP when set", () => {
+			const env = {
+				ENABLE_WINDBOT: "true",
+				WINDBOT_ENDPOINT: "http://windbot:7790",
+				WINDBOT_MY_IP: "192.168.1.100",
+				WINDBOT_BOTLIST: "/data/botlist.json",
+			};
+			const config = parseWindbotConfig(env) as WindbotConfigEnabled;
+			expect(config.myIp).toBe("192.168.1.100");
+		});
+
+		it("throws a clear error message when endpoint is missing", () => {
+			const env = {
+				ENABLE_WINDBOT: "true",
+				WINDBOT_BOTLIST: "/data/botlist.json",
+			};
+			expect(() => parseWindbotConfig(env)).toThrow(/WINDBOT_ENDPOINT/i);
+		});
+
+		it("throws a clear error message when botlist is missing", () => {
+			const env = {
+				ENABLE_WINDBOT: "true",
+				WINDBOT_ENDPOINT: "http://windbot:7790",
+			};
+			expect(() => parseWindbotConfig(env)).toThrow(/WINDBOT_BOTLIST/i);
+		});
+	});
+});

--- a/src/ygopro/windbot/infrastructure/WindbotConfig.ts
+++ b/src/ygopro/windbot/infrastructure/WindbotConfig.ts
@@ -1,0 +1,60 @@
+/**
+ * WindbotConfig — parses and validates windbot-related environment variables.
+ *
+ * Deliberately NOT reading process.env at module load time.
+ * Call parseWindbotConfig(process.env) at boot so the function is testable.
+ */
+
+export type WindbotConfigDisabled = {
+	enabled: false;
+};
+
+export type WindbotConfigEnabled = {
+	enabled: true;
+	endpoint: string;
+	myIp: string;
+	botlistPath: string;
+};
+
+export type WindbotConfig = WindbotConfigDisabled | WindbotConfigEnabled;
+
+const TRUTHY_VALUES = new Set(["true", "1"]);
+
+/**
+ * Parses windbot configuration from the given environment map.
+ *
+ * Throws with a clear error message if:
+ *  - ENABLE_WINDBOT is truthy AND WINDBOT_ENDPOINT is missing
+ *  - ENABLE_WINDBOT is truthy AND WINDBOT_BOTLIST is missing
+ */
+export function parseWindbotConfig(env: Record<string, string | undefined>): WindbotConfig {
+	const enabledRaw = env["ENABLE_WINDBOT"];
+	const enabled = TRUTHY_VALUES.has(enabledRaw ?? "");
+
+	if (!enabled) {
+		return { enabled: false };
+	}
+
+	const errors: string[] = [];
+
+	const endpoint = env["WINDBOT_ENDPOINT"];
+	if (!endpoint) {
+		errors.push("WINDBOT_ENDPOINT is required when ENABLE_WINDBOT is true");
+	}
+
+	const botlistPath = env["WINDBOT_BOTLIST"];
+	if (!botlistPath) {
+		errors.push("WINDBOT_BOTLIST is required when ENABLE_WINDBOT is true");
+	}
+
+	if (errors.length > 0) {
+		throw new Error(`Invalid windbot configuration:\n${errors.join("\n")}`);
+	}
+
+	return {
+		enabled: true,
+		endpoint: endpoint as string,
+		myIp: env["WINDBOT_MY_IP"] ?? "windbot",
+		botlistPath: botlistPath as string,
+	};
+}


### PR DESCRIPTION
## Summary

Slice 3a/8 of the windbot/AI bot integration. Adds the application + domain layers on top of the `WindbotTokenStore` shipped in PR-1 (#242).

### Domain (`src/ygopro/windbot/domain/`)
- `WindbotData` — bot value object `{ name, deck, dialog?, hidden?, deckcode? }`
- `WindbotErrors` — `WindbotNotFoundError`, `WindbotsExhaustedError`
- `WindbotBotlistRepository` — port interface (`findAll` / `findByName` / `pickRandom`)

### Application (`src/ygopro/windbot/application/`) — use cases over the token store
- `RequestWindBotJoin` — pick a bot by name or random, register a token, return `{ token, bot }`
- `ConsumeWindBotToken` — resolve a reverse-connection token to its payload (throws `Error("Windbot token not found")` on miss)
- `CleanupWindBotTokens` — drop all tokens for a room on finalize

### Infrastructure (`src/ygopro/windbot/infrastructure/`)
- `FileBotlistRepository` — boot-time JSON load + zod validation, mirrors the existing banlist loader; `pickRandom` excludes `hidden: true` bots

## Layering

Strict hexagonal: domain has zero I/O imports, application imports only domain, `fs`/`zod` are confined to infrastructure.

## Out of scope (next slices)

- PR-3b: `HttpWindBotProvider` (native fetch + retry), config zod schema, `WindbotModule` singleton wiring
- PR-4: join strategy chain (`AIJoinTokenStrategy` will `try/catch` around `ConsumeWindBotToken` — it throws, not returns null)
- PR-5/6/7: auto-RPS, room flags, bootstrap + docker-compose

## Test plan

- [x] `npm run test` — 341/341 pass (303 baseline + 38 new windbot tests)
- [x] `npm run test -- windbot` — 49/49
- [x] `npm run lint` — clean
- [x] `tsc` build — clean (pre-push hook)
- [x] Hexagonal layering verified (no infra imports in domain/application)
- [x] REQ-PROVIDER-301..303 and REQ-BOTLIST-801..803 covered