### PR TITLE
refactor(test): co-locate shared test-support and consolidate YGOProRoom

### DIFF
--- a/src/test-support/mocks/MessageRepositoryMock.ts
+++ b/src/test-support/mocks/MessageRepositoryMock.ts
@@ -1,4 +1,4 @@
-import { MessageRepository } from "../../../../src/shared/messages/MessageRepository";
+import { MessageRepository } from "@shared/messages/MessageRepository";
 
 export class MessageRepositoryMock extends MessageRepository {
   selectHandMessage = jest.fn().mockReturnValue(Buffer.from("select-hand"));

--- a/src/test-support/mocks/logger/LoggerMock.ts
+++ b/src/test-support/mocks/logger/LoggerMock.ts
@@ -1,4 +1,4 @@
-import { Logger } from "../../../../../src/shared/logger/domain/Logger";
+import { Logger } from "@shared/logger/domain/Logger";
 
 export class LoggerMock implements Logger {
   debug(_message: unknown, _context?: Record<string, unknown>): void {

--- a/src/test-support/mocks/socket/SocketMock.ts
+++ b/src/test-support/mocks/socket/SocketMock.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 
-import { ISocket } from "../../../../../src/shared/socket/domain/ISocket";
+import { ISocket } from "@shared/socket/domain/ISocket";
 
 export class SocketMock implements ISocket {
 	id = faker.string.uuid();

--- a/src/test-support/mothers/PlayerInfoMessageMother.ts
+++ b/src/test-support/mothers/PlayerInfoMessageMother.ts
@@ -1,4 +1,4 @@
-import { PlayerInfoMessage } from "../../../../src/edopro/messages/client-to-server/PlayerInfoMessage";
+import { PlayerInfoMessage } from "@edopro/messages/client-to-server/PlayerInfoMessage";
 
 export class PlayerInfoMessageMother {
 	static create(): PlayerInfoMessage {

--- a/src/test-support/mothers/client/ClientMother.ts
+++ b/src/test-support/mothers/client/ClientMother.ts
@@ -1,8 +1,8 @@
 import { faker } from "@faker-js/faker";
 
-import { Client } from "../../../../../src/edopro/client/domain/Client";
-import { Logger } from "../../../../../src/shared/logger/domain/Logger";
-import { ISocket } from "../../../../../src/shared/socket/domain/ISocket";
+import { Client } from "@edopro/client/domain/Client";
+import { Logger } from "@shared/logger/domain/Logger";
+import { ISocket } from "@shared/socket/domain/ISocket";
 import { LoggerMock } from "../../mocks/logger/LoggerMock";
 import { SocketMock } from "../../mocks/socket/SocketMock";
 

--- a/src/test-support/mothers/player/GameMother.ts
+++ b/src/test-support/mothers/player/GameMother.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import { Game } from "../../../../../src/shared/player/domain/Player";
+import { Game } from "@shared/player/domain/Player";
 
 const GAME_RESULTS = ["winner", "losser", "deuce"];
 

--- a/src/test-support/mothers/player/GameOverDomainEventMother.ts
+++ b/src/test-support/mothers/player/GameOverDomainEventMother.ts
@@ -2,7 +2,7 @@ import { faker } from "@faker-js/faker";
 import {
 	GameOverData,
 	GameOverDomainEvent,
-} from "../../../../../src/shared/room/domain/match/domain/domain-events/GameOverDomainEvent";
+} from "@shared/room/domain/match/domain/domain-events/GameOverDomainEvent";
 
 import { PlayerMother } from "./PlayerMother";
 

--- a/src/test-support/mothers/player/PlayerMother.ts
+++ b/src/test-support/mothers/player/PlayerMother.ts
@@ -1,8 +1,8 @@
 import { faker } from "@faker-js/faker";
 
-import { Player } from "../../../../../src/shared/player/domain/Player";
-import { PlayerData } from "../../../../../src/shared/player/domain/PlayerData";
-import { Team } from "../../../../../src/shared/room/Team";
+import { Player } from "@shared/player/domain/Player";
+import { PlayerData } from "@shared/player/domain/PlayerData";
+import { Team } from "@shared/room/Team";
 import { GameMother } from "./GameMother";
 
 export class PlayerMother {

--- a/src/test-support/mothers/player/PlayerStatsMother.ts
+++ b/src/test-support/mothers/player/PlayerStatsMother.ts
@@ -2,7 +2,7 @@ import { faker } from "@faker-js/faker";
 import {
 	PlayerStats,
 	PlayerStatsProperties,
-} from "../../../../../src/shared/stats/player-stats/domain/PlayerStats";
+} from "@shared/stats/player-stats/domain/PlayerStats";
 
 export class PlayerStatsMother {
 	static create(params?: Partial<PlayerStatsProperties>): PlayerStats {

--- a/src/test-support/mothers/room/RoomMother.ts
+++ b/src/test-support/mothers/room/RoomMother.ts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 import EventEmitter from "events";
 
-import { Room, RoomAttr } from "../../../../../src/edopro/room/domain/Room";
+import { Room, RoomAttr } from "@edopro/room/domain/Room";
 import { LoggerMock } from "../../mocks/logger/LoggerMock";
 
 export class RoomMother {

--- a/src/test-support/mothers/room/SimpleRoomMother.ts
+++ b/src/test-support/mothers/room/SimpleRoomMother.ts
@@ -1,9 +1,9 @@
 import { faker } from "@faker-js/faker";
 import { EventEmitter } from "events";
 
-import { YgoRoom } from "../../../../../src/shared/room/domain/YgoRoom";
-import { RoomActionQueue } from "../../../../../src/shared/room/RoomActionQueue";
-import { RoomType } from "../../../../../src/shared/room/domain/RoomType";
+import { YgoRoom } from "@shared/room/domain/YgoRoom";
+import { RoomActionQueue } from "@shared/room/RoomActionQueue";
+import { RoomType } from "@shared/room/domain/RoomType";
 
 class SimpleRoom extends YgoRoom {
   public actionQueue = new RoomActionQueue();

--- a/src/test-support/mothers/room/YGOProRoomMother.ts
+++ b/src/test-support/mothers/room/YGOProRoomMother.ts
@@ -1,23 +1,27 @@
 import { faker } from "@faker-js/faker";
 import EventEmitter from "events";
+import { randomInt } from "crypto";
 
+import { YGOProRoom } from "@ygopro/room/domain/YGOProRoom";
 import { PlayerInfoMessageMother } from "../PlayerInfoMessageMother";
 import { MessageRepositoryMock } from "../../mocks/MessageRepositoryMock";
 import { LoggerMock } from "../../mocks/logger/LoggerMock";
-import { randomInt } from "crypto";
-import { YGOProRoom } from "../../../../../src/ygopro/room/domain/YGOProRoom";
+
+interface YGOProRoomMotherProps {
+    id: number;
+    command: string;
+    createdBySocketId: string;
+}
 
 export class YGOProRoomMother {
-    static create({ command }: { command: string }): YGOProRoom {
-        const socketId = faker.string.uuid();
-        const id = randomInt(0, 10000);
+    static create(overrides?: Partial<YGOProRoomMotherProps>): YGOProRoom {
         return YGOProRoom.create(
-            id,
-            command,
+            overrides?.id ?? randomInt(0, 10000),
+            overrides?.command ?? faker.string.alpha({ length: 6 }),
             new LoggerMock(),
             new EventEmitter(),
             PlayerInfoMessageMother.create(),
-            socketId,
+            overrides?.createdBySocketId ?? faker.string.uuid(),
             new MessageRepositoryMock(),
         );
     }

--- a/src/test-support/mothers/user-profile/UserProfileMother.ts
+++ b/src/test-support/mothers/user-profile/UserProfileMother.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import { UserProfile, UserProfileProperties } from "../../../../../src/shared/user-profile/domain/UserProfile";
+import { UserProfile, UserProfileProperties } from "@shared/user-profile/domain/UserProfile";
 
 export class UserProfileMother {
 	static create(params?: Partial<UserProfileProperties>): UserProfile {

--- a/src/ygopro/room/application/FinalizeYGOProRoom.test.ts
+++ b/src/ygopro/room/application/FinalizeYGOProRoom.test.ts
@@ -22,24 +22,14 @@ jest.mock("../../../web-socket-server/WebSocketSingleton", () => {
 	};
 });
 
-import { EventEmitter } from "stream";
-
 import { WindbotModule, WindbotModuleDeps } from "../../windbot/application/WindbotModule";
 import { WindbotTokenStore } from "../../windbot/domain/WindbotTokenStore";
 import { FinalizeYGOProRoom } from "./FinalizeYGOProRoom";
-import { YGOProRoom } from "../domain/YGOProRoom";
 import MercuryRoomList from "../infrastructure/YGOProRoomList";
 import WebSocketSingleton from "../../../web-socket-server/WebSocketSingleton";
+import { YGOProRoomMother } from "@test-support/mothers/room/YGOProRoomMother";
 
 // ---------- helpers ----------
-
-const makeLogger = () => ({
-	child: jest.fn().mockReturnThis(),
-	info: jest.fn(),
-	warn: jest.fn(),
-	error: jest.fn(),
-	debug: jest.fn(),
-});
 
 const makeSocket = (closed = true) => ({
 	id: `sock-${Math.random()}`,
@@ -47,11 +37,6 @@ const makeSocket = (closed = true) => ({
 	destroy: jest.fn(),
 	send: jest.fn(),
 	removeAllListeners: jest.fn(),
-});
-
-const makeMessageRepository = () => ({
-	errorMessage: jest.fn().mockReturnValue(Buffer.alloc(4)),
-	joinGameMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
 });
 
 const makeRepo = () => ({
@@ -72,8 +57,6 @@ const makeDeps = (overrides: Partial<WindbotModuleDeps> = {}): WindbotModuleDeps
 	...overrides,
 });
 
-const makeEventEmitter = () => new EventEmitter();
-
 interface FakeClient {
 	socket: ReturnType<typeof makeSocket>;
 	destroy: jest.Mock;
@@ -91,15 +74,7 @@ const makeClient = (socket = makeSocket()): FakeClient => {
  * Build a real room registered in MercuryRoomList and stub its client list.
  */
 const createRoomInList = (clients: FakeClient[] = []) => {
-	const room = YGOProRoom.create(
-		Math.floor(Math.random() * 100000),
-		"AIROOM",
-		makeLogger() as never,
-		makeEventEmitter(),
-		{ name: "Human", password: "", previousMessage: Buffer.alloc(0) } as never,
-		"sock-human",
-		makeMessageRepository() as never,
-	);
+	const room = YGOProRoomMother.create({ command: "AIROOM" });
 	Object.defineProperty(room, "clients", { get: () => clients, configurable: true });
 	MercuryRoomList.addRoom(room);
 	return room;

--- a/src/ygopro/room/domain/YGOProRoomFinalizing.test.ts
+++ b/src/ygopro/room/domain/YGOProRoomFinalizing.test.ts
@@ -13,6 +13,7 @@ import { YGOProRoom } from "./YGOProRoom";
 import { YGOProRoomState } from "./YGOProRoomState";
 import { YGOProClient } from "../../client/domain/YGOProClient";
 import { Team } from "@shared/room/Team";
+import { YGOProRoomMother } from "@test-support/mothers/room/YGOProRoomMother";
 
 // ---- helpers ----
 
@@ -24,18 +25,6 @@ const makeLogger = () => ({
 	debug: jest.fn(),
 });
 
-const makeMessageRepo = () => ({
-	joinGameMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
-	typeChangeMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
-	typeChangeMessageFromType: jest.fn().mockReturnValue(Buffer.alloc(0)),
-	playerEnterMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
-	playerChangeMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
-	spectatorCountMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
-	watchChangeMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
-	errorMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
-	selectHandMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
-});
-
 const makeSocket = () => ({
 	id: "sock-1",
 	send: jest.fn(),
@@ -44,16 +33,7 @@ const makeSocket = () => ({
 	remoteAddress: "127.0.0.1",
 });
 
-const createRoom = (): YGOProRoom =>
-	YGOProRoom.create(
-		1,
-		"TESTROOM",
-		makeLogger() as never,
-		new EventEmitter(),
-		{ name: "TestPlayer", password: "", previousMessage: Buffer.alloc(0) } as never,
-		"sock-test",
-		makeMessageRepo() as never,
-	);
+const createRoom = (): YGOProRoom => YGOProRoomMother.create();
 
 /** Expose toRPS for test — since it is protected we subclass. */
 class TestRoomState extends YGOProRoomState {

--- a/src/ygopro/room/domain/YGOProRoomWindbotFlags.test.ts
+++ b/src/ygopro/room/domain/YGOProRoomWindbotFlags.test.ts
@@ -4,37 +4,9 @@
  * finalizing flag — defaults false, flips true on teardown.
  */
 
-import { EventEmitter } from "stream";
+import { YGOProRoomMother } from "@test-support/mothers/room/YGOProRoomMother";
 
-import { YGOProRoom } from "./YGOProRoom";
-
-const makeLogger = () => ({
-	child: jest.fn().mockReturnThis(),
-	info: jest.fn(),
-	warn: jest.fn(),
-	error: jest.fn(),
-	debug: jest.fn(),
-});
-
-const makeMessageRepo = () => ({
-	joinGameMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
-	typeChangeMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
-	playerEnterMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
-	playerChangeMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
-	spectatorCountMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
-	errorMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
-});
-
-const createRoom = (): YGOProRoom =>
-	YGOProRoom.create(
-		1,
-		"TESTROOM",
-		makeLogger() as never,
-		new EventEmitter(),
-		{ name: "TestPlayer", password: "", previousMessage: Buffer.alloc(0) } as never,
-		"sock-test",
-		makeMessageRepo() as never,
-	);
+const createRoom = () => YGOProRoomMother.create();
 
 describe("YGOProRoom windbot flags", () => {
 	describe("defaults (non-windbot rooms)", () => {

--- a/tests/modules/mercury/room/domain/YGOProRoom.test.ts
+++ b/tests/modules/mercury/room/domain/YGOProRoom.test.ts
@@ -1,7 +1,7 @@
 import "reflect-metadata";
 
 import { GameMode } from "ygopro-msg-encode";
-import { YGOProRoomMother } from "../../../shared/mothers/room/YGOProRoomMother";
+import { YGOProRoomMother } from "../../../../../src/test-support/mothers/room/YGOProRoomMother";
 import YGOProBanListMemoryRepository from "../../../../../src/ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository";
 import { YGOProBanList } from "../../../../../src/ygopro/ban-list/domain/YGOProBanList";
 

--- a/tests/modules/room/domain/Room.test.ts
+++ b/tests/modules/room/domain/Room.test.ts
@@ -1,7 +1,7 @@
  
 import { Room } from "../../../../src/edopro/room/domain/Room";
-import { ClientMother } from "../../shared/mothers/client/ClientMother";
-import { RoomMother } from "../../shared/mothers/room/RoomMother";
+import { ClientMother } from "../../../../src/test-support/mothers/client/ClientMother";
+import { RoomMother } from "../../../../src/test-support/mothers/room/RoomMother";
 
 describe("Room", () => {
 	let room: Room;

--- a/tests/modules/room/domain/YgoRoom.test.ts
+++ b/tests/modules/room/domain/YgoRoom.test.ts
@@ -1,6 +1,6 @@
 import { YgoRoom } from "../../../../src/shared/room/domain/YgoRoom";
-import { ClientMother } from "../../shared/mothers/client/ClientMother";
-import { SimpleRoomMother } from "../../shared/mothers/room/SimpleRoomMother";
+import { ClientMother } from "../../../../src/test-support/mothers/client/ClientMother";
+import { SimpleRoomMother } from "../../../../src/test-support/mothers/room/SimpleRoomMother";
 
 describe("YgoRoom", () => {
   describe("Lock-Free", () => {

--- a/tests/modules/stats/basic/BasicStatsCalculator.test.ts
+++ b/tests/modules/stats/basic/BasicStatsCalculator.test.ts
@@ -11,11 +11,11 @@ import { PlayerStats } from "../../../../src/shared/stats/player-stats/domain/Pl
 import { PlayerStatsRepository } from "../../../../src/shared/stats/player-stats/domain/PlayerStatsRepository";
 import { UserProfile } from "../../../../src/shared/user-profile/domain/UserProfile";
 import { UserProfileRepository } from "../../../../src/shared/user-profile/domain/UserProfileRepository";
-import { GameMother } from "../../../../tests/modules/shared/mothers/player/GameMother";
-import { GameOverDomainEventMother } from "../../../../tests/modules/shared/mothers/player/GameOverDomainEventMother";
-import { PlayerMother } from "../../../../tests/modules/shared/mothers/player/PlayerMother";
-import { PlayerStatsMother } from "../../../../tests/modules/shared/mothers/player/PlayerStatsMother";
-import { UserProfileMother } from "../../../../tests/modules/shared/mothers/user-profile/UserProfileMother";
+import { GameMother } from "../../../../src/test-support/mothers/player/GameMother";
+import { GameOverDomainEventMother } from "../../../../src/test-support/mothers/player/GameOverDomainEventMother";
+import { PlayerMother } from "../../../../src/test-support/mothers/player/PlayerMother";
+import { PlayerStatsMother } from "../../../../src/test-support/mothers/player/PlayerStatsMother";
+import { UserProfileMother } from "../../../../src/test-support/mothers/user-profile/UserProfileMother";
 
 describe("BasicStatsCalculator", () => {
 	let basicStatsCalculator: BasicStatsCalculator;

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -23,6 +23,9 @@
       ],
       "@ygopro/*": [
         "src/ygopro/*"
+      ],
+      "@test-support/*": [
+        "src/test-support/*"
       ]
     }
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,9 @@
       ],
       "@ygopro/*": [
         "src/ygopro/*"
+      ],
+      "@test-support/*": [
+        "src/test-support/*"
       ]
     }
   },
@@ -34,6 +37,8 @@
   "exclude": [
     "node_modules",
     "dist",
-    "tests"
+    "tests",
+    "**/*.test.ts",
+    "src/test-support/**"
   ]
 }


### PR DESCRIPTION
First slice of the test-standardization migration (see [docs/testing.md](../blob/main/docs/testing.md)). Knocks out targets #1 and #2.

## Summary

- Move shared Object Mothers + Mock classes from `tests/modules/shared/` → `src/test-support/` (the canonical home per the testing standard). `git mv` preserves history.
- Stop shipping test code to `dist/`: exclude `**/*.test.ts` and `src/test-support/**` from the production `tsconfig.json`.
- Consolidate the 3 inline `YGOProRoom` factories onto `YGOProRoomMother` — it was the one domain object built two different ways.

## What to review first

`tsconfig.json` / `tsconfig.eslint.json` (the build-exclude + alias change) and `YGOProRoomMother.ts` (now takes `overrides`). The rest is mechanical moves + import path updates.

## Changes

| Area | Change |
|------|--------|
| `src/test-support/**` | 13 files moved here (10 Mothers + 3 Mock classes) |
| `tsconfig.json` | Exclude `**/*.test.ts` + `src/test-support/**`; add `@test-support/*` alias |
| `tsconfig.eslint.json` | Add `@test-support/*` alias (resolver uses this tsconfig) |
| 4 legacy `tests/` files | Import paths updated to `src/test-support/` |
| 3 `src/` test files | Inline room factories → `YGOProRoomMother` |

## Why the dual tsconfig change

The eslint `import/no-unresolved` resolver reads `tsconfig.eslint.json`, which has its own `paths` block separate from `tsconfig.json`. A new alias must be declared in **both**.

## Out of scope (follow-up)

- Migrate the 26 legacy `tests/` files to co-location (per module, separate PRs)
- Add `.prettierrc` (2 spaces)
- `prebuild` clean of `dist/` so the test-exclude guarantee is self-enforcing

## Test plan

- [x] `npx jest` — 504 passed, 53 suites (count unchanged)
- [x] `npm run build` — succeeds; `dist/` has zero `*.test.js` / `test-support` after a clean rebuild
- [x] `npx tsc --noEmit` — clean