### PR TITLE
chore: add .editorconfig for 2-space indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+# Markdown: trailing spaces are significant (line breaks)
+[*.md]
+trim_trailing_whitespace = false

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,7 +10,7 @@ How we write tests in EDOpro-server-ts: where they live, how we build test data,
 2. **Build domain objects with a Mother.** Use (or create) an Object Mother for shared domain entities. Use a local `make*` factory only for stubs specific to that one suite.
 3. **Mock infra with the shared doubles.** `LoggerMock`, `SocketMock`, `MessageRepositoryMock` for ubiquitous interfaces; `jest.mock()` for module singletons; `mock<T>()` (jest-mock-extended) for one-off interface mocks.
 4. **Reset singletons** in `afterEach` (e.g. `WindbotModule.resetForTests()`, `JoinStrategyRegistry.reset()`).
-5. **Format:** 2-space indentation. `npm run lint:fix` enforces it via the pre-commit hook.
+5. **Format:** 2-space indentation — your editor applies it via `.editorconfig`.
 
 ## Where tests live
 
@@ -82,7 +82,7 @@ Always reset shared singleton state in `afterEach` so suites don't leak into eac
 
 | Topic | Decision |
 |-------|----------|
-| Indentation | **2 spaces** (no tabs). Enforced by Prettier + `lint:fix`. |
+| Indentation | **2 spaces** (no tabs), applied by editors via `.editorconfig`. Not CI-gated — the eslint config intentionally omits stylistic rules. |
 | `describe` | The unit under test: `describe("WindbotModule")` or `describe("WindbotModule.requestBot()")`. |
 | `it` | Behavior, present tense, no "should": `it("throws when the token is missing")`. |
 | No scaffolding | No `PR-N` / `REQ-XXX` labels in comments or test names. Comments explain *why*, not *what*. |
@@ -99,9 +99,9 @@ Always reset shared singleton state in `afterEach` so suites don't leak into eac
 
 Known consolidation work, done opportunistically as modules are touched:
 
-| Target | Action |
+| Target | Status |
 |--------|--------|
-| `YGOProRoom` built two ways | Replace the 3 inline factories in `src/ygopro/room/**` with `YGOProRoomMother`. |
-| Mothers & mocks under `tests/` | Move to `src/test-support/`; update imports. |
-| 26 legacy tests in `tests/` | Migrate to co-location per module; drop `tests/` from `jest roots` when empty. |
-| Missing `.prettierrc` | Add one (2 spaces) so formatting is enforced, not manual. |
+| `YGOProRoom` built two ways | ✅ Consolidated onto `YGOProRoomMother`. |
+| Mothers & mocks under `tests/` | ✅ Moved to `src/test-support/`. |
+| 2-space formatting | ✅ `.editorconfig` added (editor-applied, not CI-gated). |
+| 26 legacy tests in `tests/` | Pending — migrate to co-location per module; drop `tests/` from `jest roots` when empty. |


### PR DESCRIPTION
## Summary

- Add `.editorconfig` so editors apply 2-space indent, LF, UTF-8 and a trailing newline automatically.
- Update `docs/testing.md` to match (drops the stale "prettier" wording) and marks the completed migration targets.

## Why .editorconfig (and not an eslint indent rule)

CI gates on `npm run lint`, and `eslint.config.mjs` **intentionally** disables the stylistic rules (comment: *"Disable stylistic rules that were causing errors"* — the core `indent` rule chokes on the codebase's TS decorators). A global indent rule would either turn CI red repo-wide or force a big-bang reformat. `.editorconfig` guides every editor without gating — no new dependency, no reformat, no reversal of that team decision.

## Changes

| File | Change |
|------|--------|
| `.editorconfig` | **New** — 2-space, LF, UTF-8, final newline; markdown keeps trailing spaces |
| `docs/testing.md` | Formatting section + migration-targets table updated to reality |

## Scope

Does not reformat existing files — formatting converges as files are touched. Closes the "formatting" item of the testing-standardization plan. Remaining: migrate the 26 legacy `tests/` files to co-location (separate per-module PRs).

## Test plan

- [x] No code changed — config + docs only
- [x] `.editorconfig` is valid INI; CI unaffected (no lint rule added)