### PR TITLE
test: co-locate utils and stats tests (migration pilot)

### DIFF
--- a/src/shared/stats/basic/application/BasicStatsCalculator.test.ts
+++ b/src/shared/stats/basic/application/BasicStatsCalculator.test.ts
@@ -1,21 +1,22 @@
 
 import { faker } from "@faker-js/faker";
 import { mock, MockProxy } from "jest-mock-extended";
-import { Logger } from "../../../../src/shared/logger/domain/Logger";
-import { Player } from "../../../../src/shared/player/domain/Player";
-import { Team } from "../../../../src/shared/room/Team";
-import { BasicStatsCalculator } from "../../../../src/shared/stats/basic/application/BasicStatsCalculator";
-import { MatchResumeCreator } from "../../../../src/shared/stats/match-resume/application/MatchResumeCreator";
-import { DuelResumeCreator } from "../../../../src/shared/stats/match-resume/duel-resume/application/DuelResumeCreator";
-import { PlayerStats } from "../../../../src/shared/stats/player-stats/domain/PlayerStats";
-import { PlayerStatsRepository } from "../../../../src/shared/stats/player-stats/domain/PlayerStatsRepository";
-import { UserProfile } from "../../../../src/shared/user-profile/domain/UserProfile";
-import { UserProfileRepository } from "../../../../src/shared/user-profile/domain/UserProfileRepository";
-import { GameMother } from "../../../../src/test-support/mothers/player/GameMother";
-import { GameOverDomainEventMother } from "../../../../src/test-support/mothers/player/GameOverDomainEventMother";
-import { PlayerMother } from "../../../../src/test-support/mothers/player/PlayerMother";
-import { PlayerStatsMother } from "../../../../src/test-support/mothers/player/PlayerStatsMother";
-import { UserProfileMother } from "../../../../src/test-support/mothers/user-profile/UserProfileMother";
+import { Logger } from "@shared/logger/domain/Logger";
+import { Player } from "@shared/player/domain/Player";
+import { Team } from "@shared/room/Team";
+import { MatchResumeCreator } from "@shared/stats/match-resume/application/MatchResumeCreator";
+import { DuelResumeCreator } from "@shared/stats/match-resume/duel-resume/application/DuelResumeCreator";
+import { PlayerStats } from "@shared/stats/player-stats/domain/PlayerStats";
+import { PlayerStatsRepository } from "@shared/stats/player-stats/domain/PlayerStatsRepository";
+import { UserProfile } from "@shared/user-profile/domain/UserProfile";
+import { UserProfileRepository } from "@shared/user-profile/domain/UserProfileRepository";
+import { GameMother } from "@test-support/mothers/player/GameMother";
+import { GameOverDomainEventMother } from "@test-support/mothers/player/GameOverDomainEventMother";
+import { PlayerMother } from "@test-support/mothers/player/PlayerMother";
+import { PlayerStatsMother } from "@test-support/mothers/player/PlayerStatsMother";
+import { UserProfileMother } from "@test-support/mothers/user-profile/UserProfileMother";
+
+import { BasicStatsCalculator } from "./BasicStatsCalculator";
 
 describe("BasicStatsCalculator", () => {
 	let basicStatsCalculator: BasicStatsCalculator;

--- a/src/utils/BufferToUTF16.test.ts
+++ b/src/utils/BufferToUTF16.test.ts
@@ -1,4 +1,4 @@
-import { BufferToUTF16 } from "../../../src/utils/BufferToUTF16";
+import { BufferToUTF16 } from "./BufferToUTF16";
 
 describe("BufferToUTF16", () => {
   it("should convert buffer to UTF16 string correctly", () => {


### PR DESCRIPTION
Pilot slice of the legacy `tests/` → co-location migration (per [docs/testing.md](../blob/main/docs/testing.md)). Establishes the pattern; groups B–F follow in separate PRs.

## Summary

- Move `BufferToUTF16` and `BasicStatsCalculator` tests next to their sources in `src/`.
- Switch imports to `@shared`/`@test-support` aliases (relative for same-dir).
- Remove the emptied `tests/` directories.

## Changes

| From | To |
|------|----|
| `tests/modules/utils/BufferToUTF16.test.ts` | `src/utils/BufferToUTF16.test.ts` |
| `tests/modules/stats/basic/BasicStatsCalculator.test.ts` | `src/shared/stats/basic/application/BasicStatsCalculator.test.ts` |

## The migration pattern (for B–F)

`git mv` test next to its source → imports to `@`-aliases → drop emptied `tests/` dirs → run suite + lint.

## Test plan

- [x] `npx jest` — 504 passed, 53 suites (count unchanged)
- [x] `npx tsc --noEmit` — clean
- [x] eslint clean on both moved files