### PR TITLE
feat(ticket): add socket resolvedUserId field and single-use ticket repository

### DIFF
--- a/src/shared/socket/domain/ISocket.ts
+++ b/src/shared/socket/domain/ISocket.ts
@@ -1,6 +1,7 @@
 export interface ISocket {
 	id?: string;
 	roomId?: number;
+	resolvedUserId?: string;
 	send(message: Buffer): void;
 	onMessage(callback: (message: Buffer) => void): void;
 	onClose(callback: () => void): void;

--- a/src/shared/socket/domain/WebSocketClientSocket.test.ts
+++ b/src/shared/socket/domain/WebSocketClientSocket.test.ts
@@ -1,0 +1,30 @@
+import WebSocket from "ws";
+
+import { WebSocketClientSocket } from "./WebSocketClientSocket";
+
+jest.mock("ws");
+
+const makeRawSocket = (): WebSocket =>
+  ({
+    on: jest.fn(),
+    off: jest.fn(),
+    send: jest.fn(),
+    close: jest.fn(),
+    terminate: jest.fn(),
+    readyState: WebSocket.OPEN,
+  } as unknown as WebSocket);
+
+describe("WebSocketClientSocket", () => {
+  describe("resolvedUserId", () => {
+    it("is undefined by default", () => {
+      const socket = new WebSocketClientSocket(makeRawSocket());
+      expect(socket.resolvedUserId).toBeUndefined();
+    });
+
+    it("can be set after construction", () => {
+      const socket = new WebSocketClientSocket(makeRawSocket());
+      socket.resolvedUserId = "user-123";
+      expect(socket.resolvedUserId).toBe("user-123");
+    });
+  });
+});

--- a/src/shared/socket/domain/WebSocketClientSocket.ts
+++ b/src/shared/socket/domain/WebSocketClientSocket.ts
@@ -5,6 +5,7 @@ import { ISocket } from "./ISocket";
 export class WebSocketClientSocket implements ISocket {
   id?: string;
   roomId?: number;
+  resolvedUserId?: string;
   private readonly socket: WebSocket;
   private isClosed = false;
   private messageCallback?: (data: WebSocket.Data) => void;

--- a/src/shared/ticket/domain/TicketRepository.ts
+++ b/src/shared/ticket/domain/TicketRepository.ts
@@ -1,0 +1,19 @@
+/**
+ * Port for single-use ticket consumption.
+ *
+ * A ticket is a short-lived token stored in Redis that maps to a userId.
+ * Consuming it atomically reads and deletes the entry so it can only be
+ * used once. Callers that receive a non-null value MAY trust the userId
+ * returned; callers that receive null MUST reject the authenticated action.
+ */
+export interface TicketRepository {
+  /**
+   * Consumes the ticket identified by the given UUID.
+   *
+   * Returns the userId associated with the ticket if it exists, or null if:
+   * - the uuid fails UUID format validation (no storage operation issued)
+   * - no ticket with that key exists in the store
+   * - the backing store is unavailable (fail-closed)
+   */
+  consume(uuid: string): Promise<string | null>;
+}

--- a/src/shared/ticket/infrastructure/redis/RedisTicketRepository.test.ts
+++ b/src/shared/ticket/infrastructure/redis/RedisTicketRepository.test.ts
@@ -1,0 +1,70 @@
+import { Redis } from "@shared/db/redis/infrastructure/Redis";
+import { RedisTicketRepository } from "./RedisTicketRepository";
+
+jest.mock("@shared/db/redis/infrastructure/Redis", () => ({
+  Redis: {
+    getInstance: jest.fn(),
+  },
+}));
+
+const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+const makeRedisInstance = (getdelResult: string | null) => ({
+  getdel: jest.fn().mockResolvedValue(getdelResult),
+});
+
+describe("RedisTicketRepository", () => {
+  let repo: RedisTicketRepository;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    repo = new RedisTicketRepository();
+  });
+
+  describe("consume()", () => {
+    it("returns the userId when the ticket exists (hit)", async () => {
+      const redisInstance = makeRedisInstance("user-abc");
+      (Redis.getInstance as jest.Mock).mockReturnValue(redisInstance);
+
+      const result = await repo.consume(VALID_UUID);
+
+      expect(result).toBe("user-abc");
+    });
+
+    it("returns null when the ticket does not exist (miss)", async () => {
+      const redisInstance = makeRedisInstance(null);
+      (Redis.getInstance as jest.Mock).mockReturnValue(redisInstance);
+
+      const result = await repo.consume(VALID_UUID);
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null without calling getdel when UUID format is invalid", async () => {
+      const redisInstance = makeRedisInstance("user-xyz");
+      (Redis.getInstance as jest.Mock).mockReturnValue(redisInstance);
+
+      const result = await repo.consume("not-a-uuid");
+
+      expect(redisInstance.getdel).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it("returns null when Redis is unavailable (fail-closed)", async () => {
+      (Redis.getInstance as jest.Mock).mockReturnValue(undefined);
+
+      const result = await repo.consume(VALID_UUID);
+
+      expect(result).toBeNull();
+    });
+
+    it("calls getdel with key ticket:<uuid>", async () => {
+      const redisInstance = makeRedisInstance("user-789");
+      (Redis.getInstance as jest.Mock).mockReturnValue(redisInstance);
+
+      await repo.consume(VALID_UUID);
+
+      expect(redisInstance.getdel).toHaveBeenCalledWith(`ticket:${VALID_UUID}`);
+    });
+  });
+});

--- a/src/shared/ticket/infrastructure/redis/RedisTicketRepository.ts
+++ b/src/shared/ticket/infrastructure/redis/RedisTicketRepository.ts
@@ -1,0 +1,34 @@
+import { Redis } from "@shared/db/redis/infrastructure/Redis";
+import { TicketRepository } from "../../domain/TicketRepository";
+
+/**
+ * Matches the canonical UUID v4 format: xxxxxxxx-xxxx-4xxx-[89ab]xxx-xxxxxxxxxxxx.
+ * Validated BEFORE any Redis operation to prevent key injection.
+ */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Redis adapter for single-use ticket consumption.
+ *
+ * Security properties:
+ *  - UUID format validated before any Redis call (prevents key injection)
+ *  - GETDEL is atomic: reads and deletes in one operation (replay prevention)
+ *  - Fail-closed: returns null whenever Redis is unavailable (ranked status never granted)
+ */
+export class RedisTicketRepository implements TicketRepository {
+  async consume(uuid: string): Promise<string | null> {
+    if (!UUID_RE.test(uuid)) {
+      return null;
+    }
+
+    const redis = Redis.getInstance();
+    if (!redis) {
+      return null;
+    }
+
+    const userId = await redis.getdel(`ticket:${uuid}`);
+
+    return userId ?? null;
+  }
+}

--- a/src/test-support/mocks/socket/SocketMock.ts
+++ b/src/test-support/mocks/socket/SocketMock.ts
@@ -5,6 +5,7 @@ import { ISocket } from "@shared/socket/domain/ISocket";
 export class SocketMock implements ISocket {
 	id = faker.string.uuid();
 	roomId = 0;
+	resolvedUserId?: string;
 	remoteAddress = faker.internet.ip();
 	closed = false;
 


### PR DESCRIPTION
## Description / Descripción

Adds the foundation for ranked-by-ticket authentication on the WS game server:
- an optional `resolvedUserId` field on the socket abstraction (`ISocket` + `WebSocketClientSocket`), and
- a `TicketRepository` port with a Redis adapter (`RedisTicketRepository`) that consumes single-use tickets via atomic `GETDEL`, with UUID pre-validation and fail-closed behavior when Redis is unavailable.

Purely additive — the TCP / game-password path is untouched. First of a small chain of PRs; later ones wire the WS handshake, the ranked user resolver, and the join strategy.

## Related Issue(s) / Issue(s) relacionado(s)

N/A

## Checklist

- [x] My code follows the project style and guidelines
- [x] I have added tests or examples if needed
- [ ] I have updated documentation if needed — N/A
- [x] The PR title is descriptive

## Additional Notes / Notas adicionales

- 100% additive (+156 / -0), TCP path untouched.
- Strict TDD; full suite 506/506 green.
- Security: UUID pre-validation before `GETDEL`, single-use via atomic `GETDEL`, fail-closed when Redis is unavailable.