### PR TITLE
feat(ws): validate single-use ticket on the WebSocket handshake

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { HostServer } from "./socket-server/HostServer";
 import { WSHostServer } from "./socket-server/WSHostServer";
 import { YGOProServer } from "./socket-server/YGOProServer";
 import { WSYGOProServer } from "./socket-server/WSYGOProServer";
+import { RedisTicketRepository } from "./shared/ticket/infrastructure/redis/RedisTicketRepository";
 import WebSocketSingleton from "./web-socket-server/WebSocketSingleton";
 import { WindbotModule } from "./ygopro/windbot/application/WindbotModule";
 import { FileBotlistRepository } from "./ygopro/windbot/infrastructure/FileBotlistRepository";
@@ -35,7 +36,7 @@ async function start(): Promise<void> {
 
   const server = new Server(logger);
   const ygoproServer = new YGOProServer(logger);
-  const wsYgoproServer = new WSYGOProServer(logger);
+  const wsYgoproServer = new WSYGOProServer(logger, new RedisTicketRepository());
 
   const hostServer = new HostServer(logger);
   const wsHostServer = new WSHostServer(logger);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { HostServer } from "./socket-server/HostServer";
 import { WSHostServer } from "./socket-server/WSHostServer";
 import { YGOProServer } from "./socket-server/YGOProServer";
 import { WSYGOProServer } from "./socket-server/WSYGOProServer";
+import { HandshakeTicketAuthenticator } from "./socket-server/HandshakeTicketAuthenticator";
 import { RedisTicketRepository } from "./shared/ticket/infrastructure/redis/RedisTicketRepository";
 import WebSocketSingleton from "./web-socket-server/WebSocketSingleton";
 import { WindbotModule } from "./ygopro/windbot/application/WindbotModule";
@@ -36,7 +37,7 @@ async function start(): Promise<void> {
 
   const server = new Server(logger);
   const ygoproServer = new YGOProServer(logger);
-  const wsYgoproServer = new WSYGOProServer(logger, new RedisTicketRepository());
+  const wsYgoproServer = new WSYGOProServer(logger, new HandshakeTicketAuthenticator(new RedisTicketRepository()));
 
   const hostServer = new HostServer(logger);
   const wsHostServer = new WSHostServer(logger);

--- a/src/socket-server/HandshakeTicketAuthenticator.test.ts
+++ b/src/socket-server/HandshakeTicketAuthenticator.test.ts
@@ -1,0 +1,61 @@
+import { IncomingMessage } from "http";
+import { mock, MockProxy } from "jest-mock-extended";
+
+import { TicketRepository } from "@shared/ticket/domain/TicketRepository";
+import { HandshakeTicketAuthenticator } from "./HandshakeTicketAuthenticator";
+
+const makeRequest = (authHeader?: string | string[]): IncomingMessage =>
+  ({
+    headers:
+      authHeader !== undefined
+        ? { authorization: authHeader }
+        : {},
+  } as unknown as IncomingMessage);
+
+describe("HandshakeTicketAuthenticator", () => {
+  let tickets: MockProxy<TicketRepository>;
+  let authenticator: HandshakeTicketAuthenticator;
+
+  beforeEach(() => {
+    tickets = mock<TicketRepository>();
+    authenticator = new HandshakeTicketAuthenticator(tickets);
+  });
+
+  it("returns anonymous when Authorization header is absent", async () => {
+    const result = await authenticator.authenticate(makeRequest());
+
+    expect(result).toEqual({ status: "anonymous" });
+    expect(tickets.consume).not.toHaveBeenCalled();
+  });
+
+  it("returns authenticated with userId when Bearer token resolves to a userId", async () => {
+    tickets.consume.mockResolvedValue("user-123");
+
+    const result = await authenticator.authenticate(makeRequest("Bearer valid-token"));
+
+    expect(result).toEqual({ status: "authenticated", userId: "user-123" });
+    expect(tickets.consume).toHaveBeenCalledWith("valid-token");
+  });
+
+  it("returns rejected when Bearer token consume returns null", async () => {
+    tickets.consume.mockResolvedValue(null);
+
+    const result = await authenticator.authenticate(makeRequest("Bearer unknown-token"));
+
+    expect(result).toEqual({ status: "rejected" });
+  });
+
+  it("returns anonymous when Authorization header is an array (non-string)", async () => {
+    const result = await authenticator.authenticate(makeRequest(["Bearer token1", "Bearer token2"]));
+
+    expect(result).toEqual({ status: "anonymous" });
+    expect(tickets.consume).not.toHaveBeenCalled();
+  });
+
+  it("returns anonymous when Authorization header does not start with 'Bearer '", async () => {
+    const result = await authenticator.authenticate(makeRequest("Basic dXNlcjpwYXNz"));
+
+    expect(result).toEqual({ status: "anonymous" });
+    expect(tickets.consume).not.toHaveBeenCalled();
+  });
+});

--- a/src/socket-server/HandshakeTicketAuthenticator.ts
+++ b/src/socket-server/HandshakeTicketAuthenticator.ts
@@ -1,0 +1,27 @@
+import { IncomingMessage } from "http";
+
+import { TicketRepository } from "../shared/ticket/domain/TicketRepository";
+
+export type HandshakeAuthResult =
+  | { status: "anonymous" }
+  | { status: "authenticated"; userId: string }
+  | { status: "rejected" };
+
+export class HandshakeTicketAuthenticator {
+  constructor(private readonly tickets: TicketRepository) {}
+
+  async authenticate(request: IncomingMessage): Promise<HandshakeAuthResult> {
+    const token = this.extractBearer(request);
+    if (token === undefined) return { status: "anonymous" };
+    const userId = await this.tickets.consume(token);
+    return userId === null
+      ? { status: "rejected" }
+      : { status: "authenticated", userId };
+  }
+
+  private extractBearer(request: IncomingMessage): string | undefined {
+    const raw = request.headers["authorization"];
+    const header = typeof raw === "string" ? raw : undefined;
+    return header !== undefined && header.startsWith("Bearer ") ? header.slice(7) : undefined;
+  }
+}

--- a/src/socket-server/WSYGOProServer.test.ts
+++ b/src/socket-server/WSYGOProServer.test.ts
@@ -5,6 +5,7 @@ import { WebSocket, WebSocketServer } from "ws";
 import { Logger } from "@shared/logger/domain/Logger";
 import { TicketRepository } from "@shared/ticket/domain/TicketRepository";
 import { WebSocketClientSocket } from "../shared/socket/domain/WebSocketClientSocket";
+import { MessageEmitter } from "../edopro/MessageEmitter";
 import { WSYGOProServer } from "./WSYGOProServer";
 
 // --- Infrastructure mocks (prevent DB connections and port binding) ---
@@ -150,6 +151,26 @@ describe("WSYGOProServer", () => {
 
       resolveConsume("user-123");
       await handlerPromise;
+    });
+
+    it("does not pump buffered messages after rejecting an invalid ticket", async () => {
+      const handleMessage = jest.fn();
+      (MessageEmitter as unknown as jest.Mock).mockImplementation(() => ({ handleMessage }));
+      ticketRepo.consume.mockResolvedValue(null);
+
+      let pumpCallback!: (data: Buffer) => Promise<void>;
+      mockClientSocket.onMessage.mockImplementation((cb: (d: Buffer) => Promise<void>) => {
+        pumpCallback = cb;
+      });
+
+      await connectionCallback(makeRawSocket(), makeRequest(`Bearer ${VALID_UUID}`));
+
+      void pumpCallback(Buffer.from("00", "hex"));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockClientSocket.close).toHaveBeenCalled();
+      expect(handleMessage).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/socket-server/WSYGOProServer.test.ts
+++ b/src/socket-server/WSYGOProServer.test.ts
@@ -3,9 +3,9 @@ import { mock, MockProxy } from "jest-mock-extended";
 import { WebSocket, WebSocketServer } from "ws";
 
 import { Logger } from "@shared/logger/domain/Logger";
-import { TicketRepository } from "@shared/ticket/domain/TicketRepository";
 import { WebSocketClientSocket } from "../shared/socket/domain/WebSocketClientSocket";
 import { MessageEmitter } from "../edopro/MessageEmitter";
+import { HandshakeTicketAuthenticator } from "./HandshakeTicketAuthenticator";
 import { WSYGOProServer } from "./WSYGOProServer";
 
 // --- Infrastructure mocks (prevent DB connections and port binding) ---
@@ -28,8 +28,6 @@ jest.mock("@ygopro/room/infrastructure/YGOProMessageRepository");
 
 // ---------------------------------------------------------------------------
 
-const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
-
 const makeRawSocket = (): WebSocket =>
   ({
     on: jest.fn(),
@@ -40,15 +38,15 @@ const makeRawSocket = (): WebSocket =>
     readyState: 1, // WebSocket.OPEN
   } as unknown as WebSocket);
 
-const makeRequest = (authHeader?: string): IncomingMessage =>
+const makeRequest = (): IncomingMessage =>
   ({
-    headers: authHeader !== undefined ? { authorization: authHeader } : {},
+    headers: {},
   } as unknown as IncomingMessage);
 
 // ---------------------------------------------------------------------------
 
 describe("WSYGOProServer", () => {
-  let ticketRepo: MockProxy<TicketRepository>;
+  let handshakeAuth: MockProxy<HandshakeTicketAuthenticator>;
   let logger: MockProxy<Logger>;
   let mockClientSocket: {
     resolvedUserId?: string;
@@ -86,84 +84,86 @@ describe("WSYGOProServer", () => {
 
     logger = mock<Logger>();
     logger.child.mockReturnValue(logger);
-    ticketRepo = mock<TicketRepository>();
+    handshakeAuth = mock<HandshakeTicketAuthenticator>();
 
-    const server = new WSYGOProServer(logger, ticketRepo);
+    const server = new WSYGOProServer(logger, handshakeAuth);
     server.initialize();
   });
 
   describe("connection handler — ticket authentication", () => {
     it("sets resolvedUserId on the socket when Bearer token resolves to a userId", async () => {
-      ticketRepo.consume.mockResolvedValue("user-123");
+      handshakeAuth.authenticate.mockResolvedValue({ status: "authenticated", userId: "user-123" });
 
-      await connectionCallback(makeRawSocket(), makeRequest(`Bearer ${VALID_UUID}`));
+      await connectionCallback(makeRawSocket(), makeRequest());
 
-      expect(ticketRepo.consume).toHaveBeenCalledWith(VALID_UUID);
+      expect(handshakeAuth.authenticate).toHaveBeenCalled();
       expect(mockClientSocket.resolvedUserId).toBe("user-123");
       expect(mockClientSocket.close).not.toHaveBeenCalled();
     });
 
     it("closes the socket when consume returns null", async () => {
-      ticketRepo.consume.mockResolvedValue(null);
+      handshakeAuth.authenticate.mockResolvedValue({ status: "rejected" });
 
-      await connectionCallback(makeRawSocket(), makeRequest(`Bearer ${VALID_UUID}`));
+      await connectionCallback(makeRawSocket(), makeRequest());
 
       expect(mockClientSocket.close).toHaveBeenCalled();
       expect(mockClientSocket.resolvedUserId).toBeUndefined();
     });
 
     it("closes the socket when Bearer token is not a valid UUID (repo returns null per its contract)", async () => {
-      ticketRepo.consume.mockResolvedValue(null);
+      handshakeAuth.authenticate.mockResolvedValue({ status: "rejected" });
 
-      await connectionCallback(makeRawSocket(), makeRequest("Bearer not-a-uuid"));
+      await connectionCallback(makeRawSocket(), makeRequest());
 
       expect(mockClientSocket.close).toHaveBeenCalled();
     });
 
     it("closes the socket when Redis is unavailable (consume returns null fail-closed)", async () => {
-      ticketRepo.consume.mockResolvedValue(null);
+      handshakeAuth.authenticate.mockResolvedValue({ status: "rejected" });
 
-      await connectionCallback(makeRawSocket(), makeRequest(`Bearer ${VALID_UUID}`));
+      await connectionCallback(makeRawSocket(), makeRequest());
 
       expect(mockClientSocket.close).toHaveBeenCalled();
     });
 
-    it("does not call consume and does not close when Authorization header is absent", async () => {
+    it("does not call authenticate and does not close when Authorization header is absent", async () => {
+      handshakeAuth.authenticate.mockResolvedValue({ status: "anonymous" });
+
       await connectionCallback(makeRawSocket(), makeRequest());
 
-      expect(ticketRepo.consume).not.toHaveBeenCalled();
+      expect(handshakeAuth.authenticate).toHaveBeenCalled();
       expect(mockClientSocket.resolvedUserId).toBeUndefined();
       expect(mockClientSocket.close).not.toHaveBeenCalled();
     });
 
     it("registers the message pump before the ticket check resolves (no message-race)", async () => {
-      let resolveConsume!: (value: string | null) => void;
-      ticketRepo.consume.mockReturnValue(
-        new Promise<string | null>((resolve) => {
-          resolveConsume = resolve;
+      let resolveAuth!: (value: { status: "authenticated"; userId: string }) => void;
+      handshakeAuth.authenticate.mockReturnValue(
+        new Promise<{ status: "authenticated"; userId: string }>((resolve) => {
+          resolveAuth = resolve;
         })
       );
 
-      const handlerPromise = connectionCallback(makeRawSocket(), makeRequest(`Bearer ${VALID_UUID}`));
+      const handlerPromise = connectionCallback(makeRawSocket(), makeRequest());
 
-      // The pump must be registered synchronously before consume resolves
+      // The pump must be registered synchronously before authenticate resolves
       expect(mockClientSocket.onMessage).toHaveBeenCalled();
 
-      resolveConsume("user-123");
+      resolveAuth({ status: "authenticated", userId: "user-123" });
       await handlerPromise;
     });
 
     it("does not pump buffered messages after rejecting an invalid ticket", async () => {
       const handleMessage = jest.fn();
       (MessageEmitter as unknown as jest.Mock).mockImplementation(() => ({ handleMessage }));
-      ticketRepo.consume.mockResolvedValue(null);
+      handshakeAuth.authenticate.mockResolvedValue({ status: "rejected" });
 
       let pumpCallback!: (data: Buffer) => Promise<void>;
       mockClientSocket.onMessage.mockImplementation((cb: (d: Buffer) => Promise<void>) => {
         pumpCallback = cb;
       });
 
-      await connectionCallback(makeRawSocket(), makeRequest(`Bearer ${VALID_UUID}`));
+      await connectionCallback(makeRawSocket(), makeRequest());
 
       void pumpCallback(Buffer.from("00", "hex"));
       await Promise.resolve();

--- a/src/socket-server/WSYGOProServer.test.ts
+++ b/src/socket-server/WSYGOProServer.test.ts
@@ -1,0 +1,155 @@
+import { IncomingMessage } from "http";
+import { mock, MockProxy } from "jest-mock-extended";
+import { WebSocket, WebSocketServer } from "ws";
+
+import { Logger } from "@shared/logger/domain/Logger";
+import { TicketRepository } from "@shared/ticket/domain/TicketRepository";
+import { WebSocketClientSocket } from "../shared/socket/domain/WebSocketClientSocket";
+import { WSYGOProServer } from "./WSYGOProServer";
+
+// --- Infrastructure mocks (prevent DB connections and port binding) ---
+jest.mock("ws");
+jest.mock("http", () => ({ createServer: jest.fn().mockReturnValue({}) }));
+jest.mock("crypto", () => ({ randomUUID: jest.fn().mockReturnValue("test-socket-uuid") }));
+jest.mock("src/config", () => ({
+  config: { servers: { mercury: { wsPort: 7800 } } },
+}));
+jest.mock("src/shared/user-auth/application/CheckIfUserCanJoin");
+jest.mock("src/shared/user-auth/application/UserAuth");
+jest.mock("src/shared/user-profile/infrastructure/postgres/UserProfilePostgresRepository");
+jest.mock("../edopro/MessageEmitter");
+jest.mock("../shared/room/application/DisconnectHandler");
+jest.mock("../shared/room/application/RoomFinder");
+jest.mock("../shared/socket/domain/WebSocketClientSocket");
+jest.mock("@ygopro/room/application/YGOProGameCreatorHandler");
+jest.mock("@ygopro/room/application/YGOProJoinHandler");
+jest.mock("@ygopro/room/infrastructure/YGOProMessageRepository");
+
+// ---------------------------------------------------------------------------
+
+const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+const makeRawSocket = (): WebSocket =>
+  ({
+    on: jest.fn(),
+    off: jest.fn(),
+    send: jest.fn(),
+    close: jest.fn(),
+    terminate: jest.fn(),
+    readyState: 1, // WebSocket.OPEN
+  } as unknown as WebSocket);
+
+const makeRequest = (authHeader?: string): IncomingMessage =>
+  ({
+    headers: authHeader !== undefined ? { authorization: authHeader } : {},
+  } as unknown as IncomingMessage);
+
+// ---------------------------------------------------------------------------
+
+describe("WSYGOProServer", () => {
+  let ticketRepo: MockProxy<TicketRepository>;
+  let logger: MockProxy<Logger>;
+  let mockClientSocket: {
+    resolvedUserId?: string;
+    close: jest.Mock;
+    onMessage: jest.Mock;
+    onClose: jest.Mock;
+    id?: string;
+    remoteAddress: string;
+  };
+  let mockWssInstance: { on: jest.Mock; options: { server: { listen: jest.Mock } } };
+  let connectionCallback: (rawSocket: WebSocket, req: IncomingMessage) => Promise<void>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Fake socket instance returned each time `new WebSocketClientSocket(raw)` is called
+    mockClientSocket = {
+      resolvedUserId: undefined,
+      close: jest.fn(),
+      onMessage: jest.fn(),
+      onClose: jest.fn(),
+      id: undefined,
+      remoteAddress: "127.0.0.1",
+    };
+    (WebSocketClientSocket as unknown as jest.Mock).mockImplementation(() => mockClientSocket);
+
+    // Fake WebSocketServer that captures the "connection" handler
+    mockWssInstance = {
+      on: jest.fn((event: string, cb: (...args: unknown[]) => void) => {
+        if (event === "connection") connectionCallback = cb as typeof connectionCallback;
+      }),
+      options: { server: { listen: jest.fn() } },
+    };
+    (WebSocketServer as unknown as jest.Mock).mockImplementation(() => mockWssInstance);
+
+    logger = mock<Logger>();
+    logger.child.mockReturnValue(logger);
+    ticketRepo = mock<TicketRepository>();
+
+    const server = new WSYGOProServer(logger, ticketRepo);
+    server.initialize();
+  });
+
+  describe("connection handler — ticket authentication", () => {
+    it("sets resolvedUserId on the socket when Bearer token resolves to a userId", async () => {
+      ticketRepo.consume.mockResolvedValue("user-123");
+
+      await connectionCallback(makeRawSocket(), makeRequest(`Bearer ${VALID_UUID}`));
+
+      expect(ticketRepo.consume).toHaveBeenCalledWith(VALID_UUID);
+      expect(mockClientSocket.resolvedUserId).toBe("user-123");
+      expect(mockClientSocket.close).not.toHaveBeenCalled();
+    });
+
+    it("closes the socket when consume returns null", async () => {
+      ticketRepo.consume.mockResolvedValue(null);
+
+      await connectionCallback(makeRawSocket(), makeRequest(`Bearer ${VALID_UUID}`));
+
+      expect(mockClientSocket.close).toHaveBeenCalled();
+      expect(mockClientSocket.resolvedUserId).toBeUndefined();
+    });
+
+    it("closes the socket when Bearer token is not a valid UUID (repo returns null per its contract)", async () => {
+      ticketRepo.consume.mockResolvedValue(null);
+
+      await connectionCallback(makeRawSocket(), makeRequest("Bearer not-a-uuid"));
+
+      expect(mockClientSocket.close).toHaveBeenCalled();
+    });
+
+    it("closes the socket when Redis is unavailable (consume returns null fail-closed)", async () => {
+      ticketRepo.consume.mockResolvedValue(null);
+
+      await connectionCallback(makeRawSocket(), makeRequest(`Bearer ${VALID_UUID}`));
+
+      expect(mockClientSocket.close).toHaveBeenCalled();
+    });
+
+    it("does not call consume and does not close when Authorization header is absent", async () => {
+      await connectionCallback(makeRawSocket(), makeRequest());
+
+      expect(ticketRepo.consume).not.toHaveBeenCalled();
+      expect(mockClientSocket.resolvedUserId).toBeUndefined();
+      expect(mockClientSocket.close).not.toHaveBeenCalled();
+    });
+
+    it("registers the message pump before the ticket check resolves (no message-race)", async () => {
+      let resolveConsume!: (value: string | null) => void;
+      ticketRepo.consume.mockReturnValue(
+        new Promise<string | null>((resolve) => {
+          resolveConsume = resolve;
+        })
+      );
+
+      const handlerPromise = connectionCallback(makeRawSocket(), makeRequest(`Bearer ${VALID_UUID}`));
+
+      // The pump must be registered synchronously before consume resolves
+      expect(mockClientSocket.onMessage).toHaveBeenCalled();
+
+      resolveConsume("user-123");
+      await handlerPromise;
+    });
+  });
+});

--- a/src/socket-server/WSYGOProServer.ts
+++ b/src/socket-server/WSYGOProServer.ts
@@ -12,7 +12,7 @@ import { Logger } from "../shared/logger/domain/Logger";
 import { DisconnectHandler } from "../shared/room/application/DisconnectHandler";
 import { RoomFinder } from "../shared/room/application/RoomFinder";
 import { WebSocketClientSocket } from "../shared/socket/domain/WebSocketClientSocket";
-import { TicketRepository } from "../shared/ticket/domain/TicketRepository";
+import { HandshakeTicketAuthenticator } from "./HandshakeTicketAuthenticator";
 import { YGOProGameCreatorHandler } from "@ygopro/room/application/YGOProGameCreatorHandler";
 import { YGOProJoinHandler } from "@ygopro/room/application/YGOProJoinHandler";
 import { YGOProMessageRepository } from "@ygopro/room/infrastructure/YGOProMessageRepository";
@@ -23,11 +23,11 @@ export class WSYGOProServer {
 	private readonly roomFinder: RoomFinder;
 	private readonly userAuth: UserAuth;
 	private readonly checkIfUserCanJoin: CheckIfUseCanJoin;
-	private readonly ticketRepo: TicketRepository;
+	private readonly handshakeAuth: HandshakeTicketAuthenticator;
 
-	constructor(logger: Logger, ticketRepo: TicketRepository) {
+	constructor(logger: Logger, handshakeAuth: HandshakeTicketAuthenticator) {
 		this.logger = logger;
-		this.ticketRepo = ticketRepo;
+		this.handshakeAuth = handshakeAuth;
 		this.roomFinder = new RoomFinder();
 		const server = createServer();
 		this.wss = new WebSocketServer({ server });
@@ -100,28 +100,16 @@ export class WSYGOProServer {
 				disconnectHandler.run(address);
 			});
 
-			// Extract Bearer token from the HTTP upgrade request headers
-			const rawAuthHeader = request.headers["authorization"];
-			const authHeader = typeof rawAuthHeader === "string" ? rawAuthHeader : undefined;
-			const bearer =
-				authHeader !== undefined && authHeader.startsWith("Bearer ")
-					? authHeader.slice(7)
-					: undefined;
-
-			let rejected = false;
-			if (bearer !== undefined) {
-				const userId = await this.ticketRepo.consume(bearer);
-				if (userId === null) {
-					ygoClientSocket.close();
-					rejected = true;
-				} else {
-					ygoClientSocket.resolvedUserId = userId;
-				}
+			const auth = await this.handshakeAuth.authenticate(request);
+			if (auth.status === "authenticated") {
+				ygoClientSocket.resolvedUserId = auth.userId;
 			}
-
+			if (auth.status === "rejected") {
+				ygoClientSocket.close();
+			}
 			// Ungate the pump — but never for a rejected connection, so a frame
 			// buffered during the ticket check is not dispatched to a closed socket.
-			if (!rejected) {
+			if (auth.status !== "rejected") {
 				resolveReady();
 			}
 		});

--- a/src/socket-server/WSYGOProServer.ts
+++ b/src/socket-server/WSYGOProServer.ts
@@ -1,5 +1,5 @@
 import { randomUUID as uuidv4 } from "crypto";
-import { createServer } from "http";
+import { createServer, IncomingMessage } from "http";
 import { WebSocketServer, WebSocket } from "ws";
 import { config } from "src/config";
 import { CheckIfUseCanJoin } from "src/shared/user-auth/application/CheckIfUserCanJoin";
@@ -12,6 +12,7 @@ import { Logger } from "../shared/logger/domain/Logger";
 import { DisconnectHandler } from "../shared/room/application/DisconnectHandler";
 import { RoomFinder } from "../shared/room/application/RoomFinder";
 import { WebSocketClientSocket } from "../shared/socket/domain/WebSocketClientSocket";
+import { TicketRepository } from "../shared/ticket/domain/TicketRepository";
 import { YGOProGameCreatorHandler } from "@ygopro/room/application/YGOProGameCreatorHandler";
 import { YGOProJoinHandler } from "@ygopro/room/application/YGOProJoinHandler";
 import { YGOProMessageRepository } from "@ygopro/room/infrastructure/YGOProMessageRepository";
@@ -22,9 +23,11 @@ export class WSYGOProServer {
 	private readonly roomFinder: RoomFinder;
 	private readonly userAuth: UserAuth;
 	private readonly checkIfUserCanJoin: CheckIfUseCanJoin;
+	private readonly ticketRepo: TicketRepository;
 
-	constructor(logger: Logger) {
+	constructor(logger: Logger, ticketRepo: TicketRepository) {
 		this.logger = logger;
+		this.ticketRepo = ticketRepo;
 		this.roomFinder = new RoomFinder();
 		const server = createServer();
 		this.wss = new WebSocketServer({ server });
@@ -39,7 +42,7 @@ export class WSYGOProServer {
 			this.logger.info(`Mercury WebSocket Server listen in port ${port}`);
 		});
 
-		this.wss.on("connection", (socket: WebSocket) => {
+		this.wss.on("connection", async (socket: WebSocket, request: IncomingMessage) => {
 			const ygoClientSocket = new WebSocketClientSocket(socket);
 			const eventEmitter = new EventEmitter();
 			const messageRepository = new YGOProMessageRepository();
@@ -75,10 +78,19 @@ export class WSYGOProServer {
 				joinGameListener,
 			);
 
-			ygoClientSocket.onMessage((data: Buffer) => {
+			// Gate: register the pump BEFORE awaiting the ticket check so that
+			// the first PlayerInfo / JoinGame binary frame is never dropped if it
+			// arrives while Redis is still being queried.
+			let resolveReady!: () => void;
+			const ready = new Promise<void>((resolve) => {
+				resolveReady = resolve;
+			});
+
+			ygoClientSocket.onMessage(async (data: Buffer) => {
 				connectionLogger.debug(
 					`Incoming message handle by Mercury WS Server: ${data.toString("hex")}`,
 				);
+				await ready;
 				messageEmitter.handleMessage(data);
 			});
 
@@ -87,6 +99,26 @@ export class WSYGOProServer {
 				const disconnectHandler = new DisconnectHandler(ygoClientSocket, this.roomFinder);
 				disconnectHandler.run(address);
 			});
+
+			// Extract Bearer token from the HTTP upgrade request headers
+			const rawAuthHeader = request.headers["authorization"];
+			const authHeader = typeof rawAuthHeader === "string" ? rawAuthHeader : undefined;
+			const bearer =
+				authHeader !== undefined && authHeader.startsWith("Bearer ")
+					? authHeader.slice(7)
+					: undefined;
+
+			if (bearer !== undefined) {
+				const userId = await this.ticketRepo.consume(bearer);
+				if (userId === null) {
+					ygoClientSocket.close();
+				} else {
+					ygoClientSocket.resolvedUserId = userId;
+				}
+			}
+
+			// Ungate the pump — from this point any buffered or future message is processed
+			resolveReady();
 		});
 	}
 }

--- a/src/socket-server/WSYGOProServer.ts
+++ b/src/socket-server/WSYGOProServer.ts
@@ -108,17 +108,22 @@ export class WSYGOProServer {
 					? authHeader.slice(7)
 					: undefined;
 
+			let rejected = false;
 			if (bearer !== undefined) {
 				const userId = await this.ticketRepo.consume(bearer);
 				if (userId === null) {
 					ygoClientSocket.close();
+					rejected = true;
 				} else {
 					ygoClientSocket.resolvedUserId = userId;
 				}
 			}
 
-			// Ungate the pump — from this point any buffered or future message is processed
-			resolveReady();
+			// Ungate the pump — but never for a rejected connection, so a frame
+			// buffered during the ticket check is not dispatched to a closed socket.
+			if (!rejected) {
+				resolveReady();
+			}
 		});
 	}
 }


### PR DESCRIPTION
## Description / Descripción

Wires single-use ticket validation into the WebSocket handshake. The connection handler now reads the `Authorization: Bearer` header, consumes the ticket via `GETDEL`, and either sets `resolvedUserId` on the socket or closes the connection (fail-closed). The message pump is gated behind a `ready` promise so the first binary frame is never dropped while the ticket is being checked — and is never released for a rejected connection.

Builds on the ticket repository foundation. Later PRs wire the ranked user resolver and the join strategy.

## Related Issue(s) / Issue(s) relacionado(s)

N/A

## Checklist

- [x] My code follows the project style and guidelines
- [x] I have added tests or examples if needed
- [ ] I have updated documentation if needed — N/A
- [x] The PR title is descriptive

## Additional Notes / Notas adicionales

- Bearer header only (no query string); fail-closed when the ticket is invalid/expired or Redis is unavailable.
- Header absent → normal flow; TCP / game-password path untouched.
- Strict TDD; full suite 513/513 green.