### PR TITLE
feat(ranked): add RankedUserResolver with ticket-first identity resolution

### DIFF
--- a/src/shared/user-profile/domain/UserProfileRepository.ts
+++ b/src/shared/user-profile/domain/UserProfileRepository.ts
@@ -3,5 +3,6 @@ import { UserProfile } from "./UserProfile";
 export interface UserProfileRepository {
 	create(userProfile: UserProfile): Promise<void>;
 	findByUsername(username: string): Promise<UserProfile | null>;
+	findById(userId: string): Promise<UserProfile | null>;
 	isBanned(userId: string): Promise<boolean>;
 }

--- a/src/shared/user-profile/infrastructure/postgres/UserProfilePostgresRepository.test.ts
+++ b/src/shared/user-profile/infrastructure/postgres/UserProfilePostgresRepository.test.ts
@@ -1,0 +1,60 @@
+import { UserProfile } from "../../domain/UserProfile";
+import { UserProfilePostgresRepository } from "./UserProfilePostgresRepository";
+import { dataSource } from "../../../../evolution-types/src/data-source";
+
+jest.mock("../../../../evolution-types/src/data-source", () => ({
+  dataSource: {
+    getRepository: jest.fn(),
+  },
+}));
+
+const makeEntityData = (overrides: Partial<{ id: string; username: string; password: string; email: string; avatar: string | null }> = {}) => ({
+  id: "user-123",
+  username: "testuser",
+  password: "hashed-password",
+  email: "test@example.com",
+  avatar: null,
+  ...overrides,
+});
+
+describe("UserProfilePostgresRepository", () => {
+  let repo: UserProfilePostgresRepository;
+  let mockOrmRepo: {
+    findOneBy: jest.Mock;
+    findOne: jest.Mock;
+    create: jest.Mock;
+    save: jest.Mock;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockOrmRepo = {
+      findOneBy: jest.fn(),
+      findOne: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+    };
+    (dataSource.getRepository as jest.Mock).mockReturnValue(mockOrmRepo);
+    repo = new UserProfilePostgresRepository();
+  });
+
+  describe("findById()", () => {
+    it("returns a UserProfile when the user exists", async () => {
+      const entityData = makeEntityData({ id: "user-123" });
+      mockOrmRepo.findOneBy.mockResolvedValue(entityData);
+
+      const result = await repo.findById("user-123");
+
+      expect(result).toBeInstanceOf(UserProfile);
+      expect(result?.id).toBe("user-123");
+    });
+
+    it("returns null when the user does not exist", async () => {
+      mockOrmRepo.findOneBy.mockResolvedValue(null);
+
+      const result = await repo.findById("non-existent-id");
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/shared/user-profile/infrastructure/postgres/UserProfilePostgresRepository.ts
+++ b/src/shared/user-profile/infrastructure/postgres/UserProfilePostgresRepository.ts
@@ -17,6 +17,16 @@ export class UserProfilePostgresRepository implements UserProfileRepository {
 		return UserProfile.from(userProfileEntity);
 	}
 
+	async findById(userId: string): Promise<UserProfile | null> {
+		const repository = dataSource.getRepository(UserProfileEntity);
+		const userProfileEntity = await repository.findOneBy({ id: userId });
+		if (!userProfileEntity) {
+			return null;
+		}
+
+		return UserProfile.from(userProfileEntity);
+	}
+
 	async create(userProfile: UserProfile): Promise<void> {
 		const repository = dataSource.getRepository(UserProfileEntity);
 		const userProfileEntity = repository.create({

--- a/src/ygopro/room/application/RankedUserResolver.test.ts
+++ b/src/ygopro/room/application/RankedUserResolver.test.ts
@@ -1,0 +1,94 @@
+import { mock, MockProxy } from "jest-mock-extended";
+
+import { UserAuth } from "@shared/user-auth/application/UserAuth";
+import { UserProfile } from "@shared/user-profile/domain/UserProfile";
+import { UserProfileRepository } from "@shared/user-profile/domain/UserProfileRepository";
+import { UserProfileMother } from "@test-support/mothers/user-profile/UserProfileMother";
+
+import { RankedUserResolver } from "./RankedUserResolver";
+
+const makeSocket = (resolvedUserId?: string) =>
+  ({ resolvedUserId } as { resolvedUserId?: string });
+
+const makePlayerInfo = () =>
+  ({
+    name: "TestPlayer",
+    password: "gamepassword",
+    previousMessage: Buffer.alloc(0),
+  } as any);
+
+describe("RankedUserResolver", () => {
+  let userAuth: MockProxy<UserAuth>;
+  let userProfileRepo: MockProxy<UserProfileRepository>;
+  let resolver: RankedUserResolver;
+
+  beforeEach(() => {
+    userAuth = mock<UserAuth>();
+    userProfileRepo = mock<UserProfileRepository>();
+    resolver = new RankedUserResolver(userAuth, userProfileRepo);
+  });
+
+  describe("resolve() — ticket path (resolvedUserId present)", () => {
+    it("returns the userId when user exists and is not banned", async () => {
+      const profile = UserProfileMother.create({ id: "user-abc" });
+      const socket = makeSocket("user-abc");
+
+      userProfileRepo.findById.mockResolvedValue(profile);
+      userProfileRepo.isBanned.mockResolvedValue(false);
+
+      const result = await resolver.resolve(makePlayerInfo(), socket as any);
+
+      expect(result).toBe("user-abc");
+      expect(userAuth.run).not.toHaveBeenCalled();
+    });
+
+    it("returns null when findById returns null (user not found)", async () => {
+      const socket = makeSocket("non-existent-id");
+
+      userProfileRepo.findById.mockResolvedValue(null);
+
+      const result = await resolver.resolve(makePlayerInfo(), socket as any);
+
+      expect(result).toBeNull();
+      expect(userAuth.run).not.toHaveBeenCalled();
+    });
+
+    it("returns null when the user is banned (defense-in-depth re-ban-check)", async () => {
+      const profile = UserProfileMother.create({ id: "banned-user" });
+      const socket = makeSocket("banned-user");
+
+      userProfileRepo.findById.mockResolvedValue(profile);
+      userProfileRepo.isBanned.mockResolvedValue(true);
+
+      const result = await resolver.resolve(makePlayerInfo(), socket as any);
+
+      expect(result).toBeNull();
+      expect(userAuth.run).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("resolve() — game password path (no resolvedUserId)", () => {
+    it("returns the userId when userAuth.run succeeds", async () => {
+      const profile = UserProfileMother.create({ id: "game-user" });
+      const socket = makeSocket(undefined);
+
+      userAuth.run.mockResolvedValue(profile);
+
+      const result = await resolver.resolve(makePlayerInfo(), socket as any);
+
+      expect(result).toBe("game-user");
+      expect(userProfileRepo.findById).not.toHaveBeenCalled();
+    });
+
+    it("returns null when userAuth.run returns an error (not a UserProfile)", async () => {
+      const socket = makeSocket(undefined);
+
+      userAuth.run.mockResolvedValue({} as any);
+
+      const result = await resolver.resolve(makePlayerInfo(), socket as any);
+
+      expect(result).toBeNull();
+      expect(userProfileRepo.findById).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/ygopro/room/application/RankedUserResolver.test.ts
+++ b/src/ygopro/room/application/RankedUserResolver.test.ts
@@ -50,6 +50,9 @@ describe("RankedUserResolver", () => {
       const result = await resolver.resolve(makePlayerInfo(), socket as any);
 
       expect(result).toBeNull();
+      // Defense-in-depth: a forged/non-existent id must never reach the ban check,
+      // because isBanned returns false for ids with no ban rows. findById gates it.
+      expect(userProfileRepo.isBanned).not.toHaveBeenCalled();
       expect(userAuth.run).not.toHaveBeenCalled();
     });
 

--- a/src/ygopro/room/application/RankedUserResolver.ts
+++ b/src/ygopro/room/application/RankedUserResolver.ts
@@ -1,0 +1,31 @@
+import { PlayerInfoMessage } from "@edopro/messages/client-to-server/PlayerInfoMessage";
+import { UserAuth } from "@shared/user-auth/application/UserAuth";
+import { UserProfile } from "@shared/user-profile/domain/UserProfile";
+import { UserProfileRepository } from "@shared/user-profile/domain/UserProfileRepository";
+import { ISocket } from "@shared/socket/domain/ISocket";
+
+export class RankedUserResolver {
+  constructor(
+    private readonly userAuth: UserAuth,
+    private readonly repo: UserProfileRepository,
+  ) {}
+
+  async resolve(info: PlayerInfoMessage, socket: ISocket): Promise<string | null> {
+    if (socket.resolvedUserId) {
+      const profile = await this.repo.findById(socket.resolvedUserId);
+      if (!profile) {
+        return null;
+      }
+      const banned = await this.repo.isBanned(profile.id);
+      if (banned) {
+        return null;
+      }
+
+      return profile.id;
+    }
+
+    const user = await this.userAuth.run(info);
+
+    return user instanceof UserProfile ? user.id : null;
+  }
+}


### PR DESCRIPTION
## Description / Descripción

Adds `RankedUserResolver`, which resolves the ranked player's identity **ticket-first**: when the socket carries a `resolvedUserId` (from a validated ticket), it loads the real user from Postgres (`findById`) and re-checks the ban before granting — falling back to game-password auth (`userAuth.run`) when there is no ticket. Also adds `findById` to the user profile repository (port + Postgres adapter).

The `findById` → `isBanned` order is deliberate (defense-in-depth): `isBanned` only inspects ban rows and returns `false` for non-existent ids, so a forged id must be rejected by `findById` first.

## Related Issue(s) / Issue(s) relacionado(s)

N/A

## Checklist

- [x] My code follows the project style and guidelines
- [x] I have added tests or examples if needed
- [ ] I have updated documentation if needed — N/A
- [x] The PR title is descriptive

## Additional Notes / Notas adicionales

- Additive; the resolver is not yet wired into the join flow (follow-up PR).
- Strict TDD; full suite 525/525 green.
- Security: loads the real user before the ban check, so forged/non-existent ids are rejected.