### PR TITLE
feat(ranked): wire ticket-authenticated ranked join end-to-end

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { JoinStrategyRegistry } from "./ygopro/room/application/join-strategies/
 import { AIJoinTokenStrategy } from "./ygopro/room/application/join-strategies/AIJoinTokenStrategy";
 import { WindBotJoinStrategy } from "./ygopro/room/application/join-strategies/WindBotJoinStrategy";
 import { DefaultJoinStrategy } from "./ygopro/room/application/join-strategies/DefaultJoinStrategy";
+import { TicketJoinStrategy } from "./ygopro/room/application/join-strategies/TicketJoinStrategy";
 
 // YGOPro protocol version (same as DuelRecord.ts — must stay in sync)
 const YGOPRO_VERSION = 0x1362;
@@ -65,8 +66,19 @@ async function start(): Promise<void> {
   hostServer.initialize();
   wsHostServer.initialize();
 
+  // Base strategy chain — always registered, with or without windbot.
+  // Priority order (no windbot):
+  //   1. TicketJoinStrategy — sockets with a resolved ticket userId (ranked-by-ticket)
+  //   2. DefaultJoinStrategy — game password / unranked fallback
+  const baseChain = [new TicketJoinStrategy(), new DefaultJoinStrategy()];
+  JoinStrategyRegistry.setStrategies(baseChain);
+
   // Windbot bootstrap — ONLY when ENABLE_WINDBOT=true.
-  // When disabled, this block is never entered: existing join behaviour is byte-for-byte unchanged.
+  // When enabled, AI/wind strategies are prepended to the base chain:
+  //   1. AIJoinTokenStrategy — AIJOIN# prefix (reverse-connecting bot)
+  //   2. WindBotJoinStrategy — blank / AI / AI#name (human requesting bot)
+  //   3. TicketJoinStrategy  — ticket-authenticated ranked join
+  //   4. DefaultJoinStrategy — game password / unranked fallback
   // config.windbot is parsed (and validated for fail-fast) at module load time in src/config/index.ts.
   if (config.windbot.enabled) {
     logger.info("Windbot enabled — initializing WindbotModule");
@@ -80,15 +92,11 @@ async function start(): Promise<void> {
     });
     WindbotModule.init({ enabled: true, repo, tokenStore, provider });
 
-    // Wire the strategy chain in priority order:
-    //   1. AIJoinTokenStrategy — AIJOIN# prefix (reverse-connecting bot)
-    //   2. WindBotJoinStrategy — blank / AI / AI#name (human requesting bot)
-    //   3. DefaultJoinStrategy — anything else (unchanged fallback)
     const module = WindbotModule.getInstance();
     JoinStrategyRegistry.setStrategies([
       new AIJoinTokenStrategy(module),
       new WindBotJoinStrategy(module),
-      new DefaultJoinStrategy(),
+      ...baseChain,
     ]);
     logger.info("WindbotModule and JoinStrategyRegistry initialised");
   }

--- a/src/ygopro/room/application/join-strategies/JoinStrategyRegistry.test.ts
+++ b/src/ygopro/room/application/join-strategies/JoinStrategyRegistry.test.ts
@@ -1,5 +1,7 @@
 import { JoinContext, JoinStrategy } from "./JoinStrategy";
 import { JoinStrategyRegistry } from "./JoinStrategyRegistry";
+import { TicketJoinStrategy } from "./TicketJoinStrategy";
+import { DefaultJoinStrategy } from "./DefaultJoinStrategy";
 
 const makeCtx = (rawPass = ""): JoinContext =>
 	({
@@ -79,6 +81,55 @@ describe("JoinStrategyRegistry", () => {
 			JoinStrategyRegistry.reset();
 			const instance = JoinStrategyRegistry.getInstance();
 			expect(instance).toBeDefined();
+		});
+	});
+
+	describe("bootstrap — base chain [TicketJoinStrategy, DefaultJoinStrategy]", () => {
+		const makeCtxWithTicket = (rawPass = "ROOM"): JoinContext =>
+			({
+				rawPass,
+				command: rawPass.split("#")[0],
+				password: rawPass.split("#")[1] ?? "",
+				socket: { resolvedUserId: "some-user-id" },
+			} as unknown as JoinContext);
+
+		const makeCtxWithoutTicket = (rawPass = "ROOM"): JoinContext =>
+			({
+				rawPass,
+				command: rawPass.split("#")[0],
+				password: rawPass.split("#")[1] ?? "",
+				socket: { resolvedUserId: undefined },
+			} as unknown as JoinContext);
+
+		beforeEach(() => {
+			// Simulate the always-on base chain (what index.ts sets up without windbot)
+			JoinStrategyRegistry.setStrategies([
+				new TicketJoinStrategy(),
+				new DefaultJoinStrategy(),
+			]);
+		});
+
+		it("base chain contains TicketJoinStrategy and DefaultJoinStrategy", () => {
+			const instance = JoinStrategyRegistry.getInstance();
+			// Socket without resolvedUserId — TicketJoinStrategy should NOT match
+			// so the registry falls through to DefaultJoinStrategy
+			const ctx = makeCtxWithoutTicket();
+			const resolved = instance.resolve(ctx);
+			expect(resolved).toBeInstanceOf(DefaultJoinStrategy);
+		});
+
+		it("socket with resolvedUserId routes to TicketJoinStrategy", () => {
+			const instance = JoinStrategyRegistry.getInstance();
+			const ctx = makeCtxWithTicket();
+			const resolved = instance.resolve(ctx);
+			expect(resolved).toBeInstanceOf(TicketJoinStrategy);
+		});
+
+		it("socket without resolvedUserId routes to DefaultJoinStrategy", () => {
+			const instance = JoinStrategyRegistry.getInstance();
+			const ctx = makeCtxWithoutTicket();
+			const resolved = instance.resolve(ctx);
+			expect(resolved).toBeInstanceOf(DefaultJoinStrategy);
 		});
 	});
 });

--- a/src/ygopro/room/application/join-strategies/TicketJoinStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/TicketJoinStrategy.test.ts
@@ -1,0 +1,217 @@
+import { EventEmitter } from "stream";
+
+import { JoinContext } from "./JoinStrategy";
+import { TicketJoinStrategy } from "./TicketJoinStrategy";
+import { JoinStrategyRegistry } from "./JoinStrategyRegistry";
+import YGOProRoomList from "../../infrastructure/YGOProRoomList";
+
+// ---- helpers ----
+
+const makeLogger = () => ({
+	child: jest.fn().mockReturnThis(),
+	info: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn(),
+	debug: jest.fn(),
+});
+
+const makeSocket = (resolvedUserId?: string) => ({
+	id: "sock-1",
+	resolvedUserId,
+	destroy: jest.fn(),
+	send: jest.fn(),
+});
+
+const makeMessageRepository = () => ({
+	errorMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+});
+
+const makeCheckIfUserCanJoin = () => ({
+	check: jest.fn().mockResolvedValue(true),
+});
+
+const makeClientMessage = (): { data: Buffer; previousMessage: Buffer } => ({
+	data: Buffer.alloc(0),
+	previousMessage: Buffer.alloc(0),
+});
+
+const makeCtx = (overrides: Partial<JoinContext> = {}): JoinContext =>
+	({
+		rawPass: "TESTROOM",
+		command: "TESTROOM",
+		password: "",
+		playerInfo: {
+			name: "TicketPlayer",
+			password: null,
+			previousMessage: Buffer.alloc(0),
+		},
+		socket: makeSocket("some-user-id"),
+		socketId: "sock-1",
+		eventEmitter: new EventEmitter(),
+		messageRepository: makeMessageRepository(),
+		logger: makeLogger(),
+		checkIfUserCanJoin: makeCheckIfUserCanJoin(),
+		message: makeClientMessage(),
+		...overrides,
+	} as unknown as JoinContext);
+
+// ---- tests ----
+
+describe("TicketJoinStrategy", () => {
+	let strategy: TicketJoinStrategy;
+
+	beforeEach(() => {
+		strategy = new TicketJoinStrategy();
+		// Clear room list between tests
+		const rooms = YGOProRoomList.getRooms();
+		while (rooms.length) {
+			YGOProRoomList.deleteRoom(rooms[0]);
+		}
+	});
+
+	afterEach(() => {
+		JoinStrategyRegistry.reset();
+	});
+
+	describe("matches()", () => {
+		it("returns true when socket has resolvedUserId set", () => {
+			const ctx = makeCtx({ socket: makeSocket("user-abc") as never });
+			expect(strategy.matches(ctx)).toBe(true);
+		});
+
+		it("returns false when socket has no resolvedUserId", () => {
+			const ctx = makeCtx({ socket: makeSocket(undefined) as never });
+			expect(strategy.matches(ctx)).toBe(false);
+		});
+
+		it("returns false when socket resolvedUserId is empty string", () => {
+			const ctx = makeCtx({ socket: makeSocket("") as never });
+			expect(strategy.matches(ctx)).toBe(false);
+		});
+	});
+
+	describe("handle()", () => {
+		it("creates a ranked room (ranked=true) for a socket with resolvedUserId", async () => {
+			const emitter = new EventEmitter();
+			const waitingSpy = jest
+				.spyOn(
+					(await import("../../domain/YGOProRoom")).YGOProRoom.prototype,
+					"waiting",
+				)
+				.mockImplementation(() => undefined);
+			const emitSpy = jest
+				.spyOn(
+					(await import("../../domain/YGOProRoom")).YGOProRoom.prototype,
+					"emit",
+				)
+				.mockImplementation(() => undefined);
+
+			const ctx = makeCtx({
+				socket: makeSocket("ticket-user") as never,
+				eventEmitter: emitter,
+			});
+
+			await strategy.handle(ctx);
+
+			const room = YGOProRoomList.findByName("TESTROOM");
+			expect(room).not.toBeNull();
+			expect(room?.ranked).toBe(true);
+
+			waitingSpy.mockRestore();
+			emitSpy.mockRestore();
+		});
+
+		it("emits JOIN on the room", async () => {
+			const emitter = new EventEmitter();
+			const waitingSpy = jest
+				.spyOn(
+					(await import("../../domain/YGOProRoom")).YGOProRoom.prototype,
+					"waiting",
+				)
+				.mockImplementation(() => undefined);
+			const emitSpy = jest
+				.spyOn(
+					(await import("../../domain/YGOProRoom")).YGOProRoom.prototype,
+					"emit",
+				)
+				.mockImplementation(() => undefined);
+
+			const ctx = makeCtx({
+				socket: makeSocket("ticket-user") as never,
+				eventEmitter: emitter,
+			});
+
+			await strategy.handle(ctx);
+
+			expect(emitSpy).toHaveBeenCalledWith("JOIN", expect.anything(), ctx.socket);
+
+			waitingSpy.mockRestore();
+			emitSpy.mockRestore();
+		});
+
+		it("does NOT call checkIfUserCanJoin", async () => {
+			const emitter = new EventEmitter();
+			const waitingSpy = jest
+				.spyOn(
+					(await import("../../domain/YGOProRoom")).YGOProRoom.prototype,
+					"waiting",
+				)
+				.mockImplementation(() => undefined);
+			const emitSpy = jest
+				.spyOn(
+					(await import("../../domain/YGOProRoom")).YGOProRoom.prototype,
+					"emit",
+				)
+				.mockImplementation(() => undefined);
+
+			const checkIfUserCanJoin = makeCheckIfUserCanJoin();
+			const ctx = makeCtx({
+				socket: makeSocket("ticket-user") as never,
+				eventEmitter: emitter,
+				checkIfUserCanJoin: checkIfUserCanJoin as never,
+			});
+
+			await strategy.handle(ctx);
+
+			expect(checkIfUserCanJoin.check).not.toHaveBeenCalled();
+
+			waitingSpy.mockRestore();
+			emitSpy.mockRestore();
+		});
+
+		it("joins an existing room without password check", async () => {
+			// Pre-create a ranked room
+			const emitter = new EventEmitter();
+			const { YGOProRoom } = await import("../../domain/YGOProRoom");
+			const { MessageRepositoryMock } = await import(
+				"@test-support/mocks/MessageRepositoryMock"
+			);
+			const { LoggerMock } = await import("@test-support/mocks/logger/LoggerMock");
+			const { PlayerInfoMessageMother } = await import(
+				"@test-support/mothers/PlayerInfoMessageMother"
+			);
+
+			const existingRoom = YGOProRoom.create(
+				7777,
+				"TESTROOM",
+				new LoggerMock(),
+				new EventEmitter(),
+				PlayerInfoMessageMother.create(),
+				"sock-orig",
+				new MessageRepositoryMock(),
+				true,
+			);
+			YGOProRoomList.addRoom(existingRoom);
+			const emitSpy = jest.spyOn(existingRoom, "emit").mockImplementation(() => undefined);
+
+			const ctx = makeCtx({
+				socket: makeSocket("ticket-user") as never,
+				eventEmitter: emitter,
+			});
+
+			await strategy.handle(ctx);
+
+			expect(emitSpy).toHaveBeenCalledWith("JOIN", expect.anything(), ctx.socket);
+		});
+	});
+});

--- a/src/ygopro/room/application/join-strategies/TicketJoinStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/TicketJoinStrategy.ts
@@ -1,0 +1,49 @@
+import { generateUniqueId } from "src/utils/generateUniqueId";
+
+import { JoinContext, JoinStrategy } from "./JoinStrategy";
+import { YGOProRoom } from "../../domain/YGOProRoom";
+import YGOProRoomList from "../../infrastructure/YGOProRoomList";
+
+/**
+ * TicketJoinStrategy — handles joins from sockets that were authenticated
+ * via a single-use WS handshake ticket (socket.resolvedUserId is set).
+ *
+ * When this strategy matches:
+ * - The room is created with rankedOverride=true, so it is always ranked
+ *   regardless of whether a game password is present in the command.
+ * - checkIfUserCanJoin is intentionally skipped: the ban-check happens
+ *   later inside RankedUserResolver (injected in YGOProWaitingState).
+ * - JOIN is emitted directly.
+ */
+export class TicketJoinStrategy implements JoinStrategy {
+	matches(ctx: JoinContext): boolean {
+		return Boolean(ctx.socket.resolvedUserId);
+	}
+
+	async handle(ctx: JoinContext): Promise<void> {
+		const room = this._findOrCreateRankedRoom(ctx);
+		room.emit("JOIN", ctx.message, ctx.socket);
+	}
+
+	private _findOrCreateRankedRoom(ctx: JoinContext): YGOProRoom {
+		const existingRoom = YGOProRoomList.findByName(ctx.command);
+		if (existingRoom) {
+			return existingRoom;
+		}
+
+		const room = YGOProRoom.create(
+			generateUniqueId(),
+			ctx.rawPass,
+			ctx.logger,
+			ctx.eventEmitter,
+			ctx.playerInfo,
+			ctx.socketId,
+			ctx.messageRepository,
+			true, // rankedOverride — ticket users always join ranked rooms
+		);
+		YGOProRoomList.addRoom(room);
+		room.waiting();
+
+		return room;
+	}
+}

--- a/src/ygopro/room/domain/YGOProRoom.test.ts
+++ b/src/ygopro/room/domain/YGOProRoom.test.ts
@@ -1,9 +1,15 @@
 import "reflect-metadata";
 
+import { EventEmitter } from "stream";
+
 import { GameMode } from "ygopro-msg-encode";
 import { YGOProRoomMother } from "@test-support/mothers/room/YGOProRoomMother";
+import { PlayerInfoMessageMother } from "@test-support/mothers/PlayerInfoMessageMother";
 import YGOProBanListMemoryRepository from "@ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository";
 import { YGOProBanList } from "@ygopro/ban-list/domain/YGOProBanList";
+import { YGOProRoom } from "./YGOProRoom";
+import { LoggerMock } from "@test-support/mocks/logger/LoggerMock";
+import { MessageRepositoryMock } from "@test-support/mocks/MessageRepositoryMock";
 
 function createBanList(name: string, hash: number): YGOProBanList {
   const banList = new YGOProBanList();
@@ -412,6 +418,36 @@ describe("YGOProRoom", () => {
       expect(room.hostInfo.duel_rule).toBe(2);
       expect(room.hostInfo.time_limit).toBe(450);
       expect(room.useExtendedCardPool).toBe(false);
+    });
+  });
+
+  describe("ranked override", () => {
+    it("creates a ranked room when rankedOverride is true even without a game password", () => {
+      const room = YGOProRoom.create(
+        1,
+        "TESTROOM",
+        new LoggerMock(),
+        new EventEmitter(),
+        PlayerInfoMessageMother.create(), // no password → ranked=false without override
+        "sock-1",
+        new MessageRepositoryMock(),
+        true, // rankedOverride
+      );
+      expect(room.ranked).toBe(true);
+    });
+
+    it("creates an unranked room when rankedOverride is absent and no game password", () => {
+      const room = YGOProRoom.create(
+        2,
+        "TESTROOM",
+        new LoggerMock(),
+        new EventEmitter(),
+        PlayerInfoMessageMother.create(), // no password → ranked=false
+        "sock-2",
+        new MessageRepositoryMock(),
+        // no rankedOverride
+      );
+      expect(room.ranked).toBe(false);
     });
   });
 

--- a/src/ygopro/room/domain/YGOProRoom.ts
+++ b/src/ygopro/room/domain/YGOProRoom.ts
@@ -7,6 +7,7 @@ import { RoomState } from "@edopro/room/domain/RoomState";
 import { Team } from "@shared/room/Team";
 import { UserAuth } from "@shared/user-auth/application/UserAuth";
 import { UserProfilePostgresRepository } from "@shared/user-profile/infrastructure/postgres/UserProfilePostgresRepository";
+import { RankedUserResolver } from "../application/RankedUserResolver";
 import { Logger } from "@shared/logger/domain/Logger";
 import { DeckRules, DuelState, YgoRoom } from "@shared/room/domain/YgoRoom";
 import { RoomType } from "@shared/room/domain/RoomType";
@@ -149,6 +150,7 @@ export class YGOProRoom extends YgoRoom {
     playerInfo: PlayerInfoMessage,
     createdBySocketId: string,
     messageRepository: MessageRepository,
+    rankedOverride?: boolean,
   ): YGOProRoom {
     let hostInfo: HostInfo = {
       lflist: MercuryBanListMemoryRepository.getFirstTCGIndex(),
@@ -220,7 +222,7 @@ export class YGOProRoom extends YgoRoom {
     });
 
     const teamCount = hostInfo.mode === GameMode.TAG ? 2 : 1;
-    const ranked = Boolean(playerInfo.password);
+    const ranked = rankedOverride ?? Boolean(playerInfo.password);
     const useExtendedCardPool = options.some((opt) => extendedCardPoolFormats.has(opt));
     const banList = MercuryBanListMemoryRepository.findLFListByIndex(
       hostInfo.lflist,
@@ -325,8 +327,13 @@ export class YGOProRoom extends YgoRoom {
 
   waiting(): void {
     this._roomState?.removeAllListener();
+    const userProfileRepo = new UserProfilePostgresRepository();
+    const resolver = new RankedUserResolver(
+      new UserAuth(userProfileRepo),
+      userProfileRepo,
+    );
     this._roomState = new YGOProWaitingState(
-      new UserAuth(new UserProfilePostgresRepository()),
+      resolver,
       this.emitter,
       this._logger,
       new YGOProDeckCreator(

--- a/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
@@ -1,5 +1,7 @@
 import { EventEmitter } from "stream";
 
+import { mock, MockProxy } from "jest-mock-extended";
+
 import { Commands } from "@shared/messages/Commands";
 import { ClientMessage } from "@shared/messages/MessageProcessor";
 import { Logger } from "@shared/logger/domain/Logger";
@@ -10,36 +12,59 @@ import { YGOProWaitingState } from "./YGOProWaitingState";
 import { YGOProDeckCreator } from "@ygopro/deck/application/YGOProDeckCreator";
 import { YGOProDeckValidator } from "@ygopro/deck/domain/YGOProDeckValidator";
 import { NotOfficialCardError } from "@shared/deck/domain/errors/NotOfficialCardError";
-import { UserAuth } from "@shared/user-auth/application/UserAuth";
+import { RankedUserResolver } from "../../application/RankedUserResolver";
+import { ISocket } from "@shared/socket/domain/ISocket";
+import { ErrorMessageType } from "ygopro-msg-encode";
+
+// ---- helpers ----
+
+// mercuryConfig.version = 4962 = 0x1362 → LE bytes: 0x62 0x13
+const makeJoinData = (): Buffer => {
+	const buf = Buffer.alloc(48);
+	buf.writeUInt16LE(4962, 0);
+	return buf;
+};
+
+// "Jaden" in UTF-16LE with no password separator (40 bytes)
+const PLAYER_INFO_HEX =
+	"4a006100640065006e00000000000000000000000000000000000000000000000000000000000000";
+
+const makeJoinMessage = (): ClientMessage =>
+	({
+		data: makeJoinData(),
+		previousMessage: Buffer.from(PLAYER_INFO_HEX, "hex"),
+	} as unknown as ClientMessage);
+
+const makeDeckPayload = (): Buffer => {
+	const main = [0x00000001, 0x00000002];
+	const side: number[] = [];
+	const buf = Buffer.alloc(4 + 4 + (main.length + side.length) * 4);
+	let offset = 0;
+	buf.writeUInt32LE(main.length, offset);
+	offset += 4;
+	buf.writeUInt32LE(side.length, offset);
+	offset += 4;
+	for (const code of [...main, ...side]) {
+		buf.writeUInt32LE(code, offset);
+		offset += 4;
+	}
+	return buf;
+};
+
+const makeClientMessage = (data: Buffer): ClientMessage =>
+	({
+		data,
+		previousMessage: Buffer.alloc(0),
+	} as unknown as ClientMessage);
 
 describe("YGOProWaitingState.handleUpdateDeck", () => {
 	let eventEmitter: EventEmitter;
 	let mockLogger: jest.Mocked<Logger>;
-	let mockUserAuth: jest.Mocked<UserAuth>;
+	let mockResolver: MockProxy<RankedUserResolver>;
 	let mockDeckCreator: jest.Mocked<YGOProDeckCreator>;
 	let mockDeckValidator: jest.Mocked<YGOProDeckValidator>;
 	let mockRoom: jest.Mocked<YGOProRoom>;
 	let mockPlayer: jest.Mocked<YGOProClient>;
-
-	const makeDeckPayload = (): Buffer => {
-		// Minimal valid YGOProCtosUpdateDeck payload (2 cards main, 0 side)
-		// Format: main_count (u32le) + side_count (u32le) + card codes (u32le each)
-		const main = [0x00000001, 0x00000002];
-		const side: number[] = [];
-		const buf = Buffer.alloc(4 + 4 + (main.length + side.length) * 4);
-		let offset = 0;
-		buf.writeUInt32LE(main.length, offset); offset += 4;
-		buf.writeUInt32LE(side.length, offset); offset += 4;
-		for (const code of [...main, ...side]) {
-			buf.writeUInt32LE(code, offset); offset += 4;
-		}
-		return buf;
-	};
-
-	const makeClientMessage = (data: Buffer): ClientMessage => ({
-		data,
-		previousMessage: Buffer.alloc(0),
-	} as unknown as ClientMessage);
 
 	beforeEach(() => {
 		eventEmitter = new EventEmitter();
@@ -52,7 +77,7 @@ describe("YGOProWaitingState.handleUpdateDeck", () => {
 			debug: jest.fn(),
 		} as unknown as jest.Mocked<Logger>;
 
-		mockUserAuth = {} as unknown as jest.Mocked<UserAuth>;
+		mockResolver = mock<RankedUserResolver>();
 
 		mockDeckCreator = {
 			build: jest.fn(),
@@ -92,7 +117,7 @@ describe("YGOProWaitingState.handleUpdateDeck", () => {
 		} as unknown as jest.Mocked<YGOProClient>;
 
 		new YGOProWaitingState(
-			mockUserAuth,
+			mockResolver,
 			eventEmitter,
 			mockLogger,
 			mockDeckCreator,
@@ -149,7 +174,6 @@ describe("YGOProWaitingState.handleUpdateDeck", () => {
 
 		it("should accept a deck that would normally fail validation", async () => {
 			const fakeDeck = { allCards: [{ code: 12345 }] };
-			// validator WOULD return an error — but it must not be called
 			mockDeckCreator.build.mockResolvedValue(fakeDeck as never);
 			mockDeckValidator.validate.mockReturnValue(new NotOfficialCardError(12345));
 
@@ -173,7 +197,6 @@ describe("YGOProWaitingState.handleUpdateDeck", () => {
 		});
 
 		it("isInternal check happens before validator — validator never invoked regardless of shouldValidateDeck()", async () => {
-			// Even if shouldValidateDeck returns true, validator must not run for internal clients
 			mockRoom.shouldValidateDeck.mockReturnValue(true);
 			const fakeDeck = { allCards: [] };
 			mockDeckCreator.build.mockResolvedValue(fakeDeck as never);
@@ -182,6 +205,148 @@ describe("YGOProWaitingState.handleUpdateDeck", () => {
 
 			expect(mockRoom.shouldValidateDeck).not.toHaveBeenCalled();
 			expect(mockDeckValidator.validate).not.toHaveBeenCalled();
+		});
+	});
+});
+
+describe("YGOProWaitingState.handleJoin", () => {
+	let eventEmitter: EventEmitter;
+	let mockLogger: jest.Mocked<Logger>;
+	let mockResolver: MockProxy<RankedUserResolver>;
+	let mockDeckCreator: jest.Mocked<YGOProDeckCreator>;
+	let mockDeckValidator: jest.Mocked<YGOProDeckValidator>;
+	let mockRoom: jest.Mocked<YGOProRoom>;
+	let mockSocket: jest.Mocked<ISocket>;
+
+	const makeMockRoom = (ranked: boolean): jest.Mocked<YGOProRoom> =>
+		({
+			mutex: {
+				runExclusive: jest.fn().mockImplementation(async (fn: () => Promise<void>) => fn()),
+			},
+			ranked,
+			players: [],
+			calculatePlaceUnsafe: jest.fn().mockReturnValue({ position: 0, team: 0 }),
+			createPlayerUnsafe: jest.fn().mockReturnValue({
+				name: "Jaden",
+				position: 0,
+				team: 0,
+			}),
+			addPlayerUnsafe: jest.fn(),
+			createSpectatorUnsafe: jest.fn().mockReturnValue({ name: "Jaden" }),
+			addSpectatorUnsafe: jest.fn(),
+			messageSender: {
+				errorMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+			},
+		} as unknown as jest.Mocked<YGOProRoom>);
+
+	const makeMockSocket = (resolvedUserId?: string): jest.Mocked<ISocket> =>
+		({
+			id: "sock-test",
+			resolvedUserId,
+			remoteAddress: "127.0.0.1",
+			closed: false,
+			send: jest.fn(),
+			destroy: jest.fn(),
+			removeAllListeners: jest.fn(),
+		} as unknown as jest.Mocked<ISocket>);
+
+	const emitJoin = (
+		room: jest.Mocked<YGOProRoom>,
+		socket: jest.Mocked<ISocket>,
+	): Promise<void> => {
+		const message = makeJoinMessage();
+		return new Promise((resolve) => {
+			setImmediate(() => resolve());
+			eventEmitter.emit("JOIN", message, room, socket);
+		});
+	};
+
+	beforeEach(() => {
+		eventEmitter = new EventEmitter();
+
+		mockLogger = {
+			child: jest.fn().mockReturnThis(),
+			info: jest.fn(),
+			warn: jest.fn(),
+			error: jest.fn(),
+			debug: jest.fn(),
+		} as unknown as jest.Mocked<Logger>;
+
+		mockResolver = mock<RankedUserResolver>();
+
+		mockDeckCreator = {
+			build: jest.fn(),
+		} as unknown as jest.Mocked<YGOProDeckCreator>;
+
+		mockDeckValidator = {
+			validate: jest.fn().mockReturnValue(null),
+		} as unknown as jest.Mocked<YGOProDeckValidator>;
+
+		mockRoom = makeMockRoom(false);
+		mockSocket = makeMockSocket();
+
+		new YGOProWaitingState(
+			mockResolver,
+			eventEmitter,
+			mockLogger,
+			mockDeckCreator,
+			mockDeckValidator,
+		);
+	});
+
+	describe("ranked room — resolver path", () => {
+		it("calls resolver.resolve() when the room is ranked", async () => {
+			mockRoom = makeMockRoom(true);
+			mockResolver.resolve.mockResolvedValue("user-123");
+
+			await emitJoin(mockRoom, mockSocket);
+
+			expect(mockResolver.resolve).toHaveBeenCalled();
+		});
+
+		it("sends JOINERROR and skips player creation when resolver returns null", async () => {
+			mockRoom = makeMockRoom(true);
+			mockResolver.resolve.mockResolvedValue(null);
+
+			await emitJoin(mockRoom, mockSocket);
+
+			expect(mockSocket.send).toHaveBeenCalled();
+			expect(mockRoom.createPlayerUnsafe).not.toHaveBeenCalled();
+		});
+
+		it("creates the player with the userId returned by resolver", async () => {
+			mockRoom = makeMockRoom(true);
+			mockResolver.resolve.mockResolvedValue("resolved-user");
+
+			await emitJoin(mockRoom, mockSocket);
+
+			expect(mockRoom.createPlayerUnsafe).toHaveBeenCalledWith(
+				mockSocket,
+				expect.any(String), // player name
+				"resolved-user",
+			);
+		});
+	});
+
+	describe("unranked room — no resolver call", () => {
+		it("does not call resolver.resolve() when the room is not ranked", async () => {
+			mockRoom = makeMockRoom(false);
+
+			await emitJoin(mockRoom, mockSocket);
+
+			expect(mockResolver.resolve).not.toHaveBeenCalled();
+		});
+
+		it("creates the player with null userId when room is not ranked", async () => {
+			mockRoom = makeMockRoom(false);
+
+			await emitJoin(mockRoom, mockSocket);
+
+			expect(mockRoom.createPlayerUnsafe).toHaveBeenCalledWith(
+				mockSocket,
+				expect.any(String),
+				null,
+			);
 		});
 	});
 });

--- a/src/ygopro/room/domain/states/YGOProWaitingState.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.ts
@@ -1,8 +1,5 @@
 import { EventEmitter } from "stream";
 
-import { UserAuth } from "@shared/user-auth/application/UserAuth";
-import { UserProfile } from "@shared/user-profile/domain/UserProfile";
-
 import { PlayerInfoMessage } from "@edopro/messages/client-to-server/PlayerInfoMessage";
 
 import { Commands } from "@shared/messages/Commands";
@@ -13,6 +10,7 @@ import { ISocket } from "@shared/socket/domain/ISocket";
 
 import { YGOProClient } from "../../../client/domain/YGOProClient";
 import { YGOProRoom } from "../YGOProRoom";
+import { RankedUserResolver } from "../../application/RankedUserResolver";
 
 import {
 	ErrorMessageType,
@@ -26,7 +24,7 @@ import MercuryBanListMemoryRepository from "@ygopro/ban-list/infrastructure/YGOP
 
 export class YGOProWaitingState extends YGOProRoomState {
 	constructor(
-		private readonly userAuth: UserAuth,
+		private readonly resolver: RankedUserResolver,
 		eventEmitter: EventEmitter,
 		private readonly logger: Logger,
 		private readonly deckCreator: YGOProDeckCreator,
@@ -105,13 +103,13 @@ export class YGOProWaitingState extends YGOProRoomState {
 			let userId: string | null = null;
 
 			if (room.ranked) {
-				const user = await this.userAuth.run(playerInfoMessage);
-				if (!(user instanceof UserProfile)) {
+				const resolvedId = await this.resolver.resolve(playerInfoMessage, socket);
+				if (!resolvedId) {
 					socket.send(room.messageSender.errorMessage(ErrorMessageType.JOINERROR));
 
 					return null;
 				}
-				userId = user.id;
+				userId = resolvedId;
 			}
 
 			const player = room.createPlayerUnsafe(socket, playerInfoMessage.name, userId);


### PR DESCRIPTION
## Description / Descripción

Wires the ranked-by-ticket flow end-to-end:
- `TicketJoinStrategy` — selected when the socket carries a `resolvedUserId` (from a validated ticket); creates a ranked room **without** the game password.
- `RankedUserResolver` injected into `YGOProWaitingState` — the join resolves identity ticket-first, with a game-password fallback.
- `rankedOverride` param on `YGOProRoom.create()` (`ranked = rankedOverride ?? Boolean(playerInfo.password)`).
- Join-strategy bootstrap restructured so the base chain `[TicketJoinStrategy, DefaultJoinStrategy]` is **always** registered (windbot prepends when enabled).

Completes the ticket-auth feature. A connection **without** a ticket keeps the exact game-password path as before.

## Related Issue(s) / Issue(s) relacionado(s)

N/A

## Checklist

- [x] My code follows the project style and guidelines
- [x] I have added tests or examples if needed
- [ ] I have updated documentation if needed — N/A
- [x] The PR title is descriptive

## Additional Notes / Notas adicionales

- Final PR of the chain. `UserAuth`, `TCPClientSocket`, `PlayerInfoMessage`, `DefaultJoinStrategy` unchanged (regression-safe).
- Strict TDD; full suite 542/542 green.
- The ticket path never reads the game password; a socket without a ticket never gets ranked via the ticket path.