### PR TITLE
build(compose): add Valkey service to the dev docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,5 +19,21 @@ services:
       timeout: 5s
       retries: 5
 
+  valkey:
+    image: valkey/valkey:9.0-alpine
+    container_name: evolution-valkey
+    ports:
+      - "6379:6379"
+    volumes:
+      - valkey_data:/data
+    restart: unless-stopped
+    healthcheck:
+      test: [ "CMD", "valkey-cli", "ping" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    command: valkey-server --appendonly yes
+
 volumes:
   postgres_data:
+  valkey_data:


### PR DESCRIPTION
## Description / Descripción

Adds a **Valkey** (Redis-compatible) service to the dev `docker-compose.yaml`, mirroring the production compose. The server's ticket store (`GETDEL ticket:<uuid>`) needs a Redis-compatible instance; until now only prod had one, so the ticket flow couldn't be exercised locally. Port `6379` is exposed so a locally-run server connects via `REDIS_URI=redis://localhost:6379`.

## Related Issue(s) / Issue(s) relacionado(s)

N/A

## Checklist

- [x] My code follows the project style and guidelines
- [ ] I have added tests or examples if needed — N/A (infra)
- [ ] I have updated documentation if needed — N/A
- [x] The PR title is descriptive

## Additional Notes / Notas adicionales

- Mirrors prod: `valkey/valkey:9.0-alpine`, `--appendonly yes`, `valkey-cli ping` healthcheck.
- To use locally: set `USE_REDIS=true` and `REDIS_URI=redis://localhost:6379` in your `.env`.
- No `requirepass` (matches prod; Redis auth hardening is tracked separately).