### PR TITLE
feat(ws): accept game-ticket via ?ticket= query param on the WS handshake

### DIFF
--- a/src/socket-server/HandshakeTicketAuthenticator.test.ts
+++ b/src/socket-server/HandshakeTicketAuthenticator.test.ts
@@ -4,12 +4,13 @@ import { mock, MockProxy } from "jest-mock-extended";
 import { TicketRepository } from "@shared/ticket/domain/TicketRepository";
 import { HandshakeTicketAuthenticator } from "./HandshakeTicketAuthenticator";
 
-const makeRequest = (authHeader?: string | string[]): IncomingMessage =>
+const makeRequest = (authHeader?: string | string[], url?: string): IncomingMessage =>
   ({
     headers:
       authHeader !== undefined
         ? { authorization: authHeader }
         : {},
+    url,
   } as unknown as IncomingMessage);
 
 describe("HandshakeTicketAuthenticator", () => {
@@ -54,6 +55,41 @@ describe("HandshakeTicketAuthenticator", () => {
 
   it("returns anonymous when Authorization header does not start with 'Bearer '", async () => {
     const result = await authenticator.authenticate(makeRequest("Basic dXNlcjpwYXNz"));
+
+    expect(result).toEqual({ status: "anonymous" });
+    expect(tickets.consume).not.toHaveBeenCalled();
+  });
+
+  it("returns authenticated when the ticket is provided via the ?ticket= query param", async () => {
+    tickets.consume.mockResolvedValue("user-789");
+
+    const result = await authenticator.authenticate(makeRequest(undefined, "/?ticket=query-token"));
+
+    expect(result).toEqual({ status: "authenticated", userId: "user-789" });
+    expect(tickets.consume).toHaveBeenCalledWith("query-token");
+  });
+
+  it("returns rejected when the query-param ticket consume returns null", async () => {
+    tickets.consume.mockResolvedValue(null);
+
+    const result = await authenticator.authenticate(makeRequest(undefined, "/?ticket=unknown"));
+
+    expect(result).toEqual({ status: "rejected" });
+  });
+
+  it("prefers the Bearer header over the query param when both are present", async () => {
+    tickets.consume.mockResolvedValue("user-123");
+
+    const result = await authenticator.authenticate(
+      makeRequest("Bearer header-token", "/?ticket=query-token"),
+    );
+
+    expect(result).toEqual({ status: "authenticated", userId: "user-123" });
+    expect(tickets.consume).toHaveBeenCalledWith("header-token");
+  });
+
+  it("returns anonymous when neither header nor query ticket is present", async () => {
+    const result = await authenticator.authenticate(makeRequest(undefined, "/game"));
 
     expect(result).toEqual({ status: "anonymous" });
     expect(tickets.consume).not.toHaveBeenCalled();

--- a/src/socket-server/HandshakeTicketAuthenticator.ts
+++ b/src/socket-server/HandshakeTicketAuthenticator.ts
@@ -11,7 +11,7 @@ export class HandshakeTicketAuthenticator {
   constructor(private readonly tickets: TicketRepository) {}
 
   async authenticate(request: IncomingMessage): Promise<HandshakeAuthResult> {
-    const token = this.extractBearer(request);
+    const token = this.extractToken(request);
     if (token === undefined) return { status: "anonymous" };
     const userId = await this.tickets.consume(token);
     return userId === null
@@ -19,9 +19,23 @@ export class HandshakeTicketAuthenticator {
       : { status: "authenticated", userId };
   }
 
+  private extractToken(request: IncomingMessage): string | undefined {
+    // Header first (desktop clients). Browsers can't set custom WS handshake
+    // headers, so fall back to the ?ticket= query param. The ticket is
+    // single-use + 30s TTL, so leaving it in a URL/log is not a real risk.
+    return this.extractBearer(request) ?? this.extractQueryTicket(request);
+  }
+
   private extractBearer(request: IncomingMessage): string | undefined {
     const raw = request.headers["authorization"];
     const header = typeof raw === "string" ? raw : undefined;
     return header !== undefined && header.startsWith("Bearer ") ? header.slice(7) : undefined;
+  }
+
+  private extractQueryTicket(request: IncomingMessage): string | undefined {
+    if (request.url === undefined) return undefined;
+    // request.url is relative (e.g. "/?ticket=abc"); the base is only for parsing.
+    const ticket = new URL(request.url, "http://placeholder").searchParams.get("ticket");
+    return ticket ?? undefined;
   }
 }


### PR DESCRIPTION
## Description / Descripción

The browser WebSocket API cannot set custom handshake headers, so a web client cannot deliver the ranked ticket via `Authorization: Bearer`. This makes `HandshakeTicketAuthenticator` also read the ticket from the `?ticket=<uuid>` query param, while keeping the header for desktop clients. **Header takes precedence; the query param is the fallback.** Single functional file changed.

## Related Issue(s) / Issue(s) relacionado(s)

N/A

## Checklist

- [x] My code follows the project style and guidelines
- [x] I have added tests or examples if needed
- [ ] I have updated documentation if needed — N/A
- [x] The PR title is descriptive

## Additional Notes / Notas adicionales

- Single-use ticket + 30s TTL + GETDEL make the ticket appearing in a URL/log irrelevant (consumed on first use).
- Desktop (header) path unchanged — no regression.
- Does not touch the duel protocol or the TCP legacy path.
- Strict TDD; full suite 552/552 green.