### PR TITLE
fix(ranked): require room password on ticket-authenticated joins

### DIFF
--- a/src/ygopro/room/application/join-strategies/TicketJoinStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/TicketJoinStrategy.test.ts
@@ -179,7 +179,7 @@ describe("TicketJoinStrategy", () => {
 			emitSpy.mockRestore();
 		});
 
-		it("joins an existing room without password check", async () => {
+		it("joins an existing room when the room password matches (both empty)", async () => {
 			// Pre-create a ranked room
 			const emitter = new EventEmitter();
 			const { YGOProRoom } = await import("../../domain/YGOProRoom");
@@ -207,6 +207,78 @@ describe("TicketJoinStrategy", () => {
 			const ctx = makeCtx({
 				socket: makeSocket("ticket-user") as never,
 				eventEmitter: emitter,
+			});
+
+			await strategy.handle(ctx);
+
+			expect(emitSpy).toHaveBeenCalledWith("JOIN", expect.anything(), ctx.socket);
+		});
+
+		it("rejects the join when the existing room password does NOT match", async () => {
+			const { YGOProRoom } = await import("../../domain/YGOProRoom");
+			const { MessageRepositoryMock } = await import(
+				"@test-support/mocks/MessageRepositoryMock"
+			);
+			const { LoggerMock } = await import("@test-support/mocks/logger/LoggerMock");
+			const { PlayerInfoMessageMother } = await import(
+				"@test-support/mothers/PlayerInfoMessageMother"
+			);
+
+			const existingRoom = YGOProRoom.create(
+				7777,
+				"TESTROOM#secret",
+				new LoggerMock(),
+				new EventEmitter(),
+				PlayerInfoMessageMother.create(),
+				"sock-orig",
+				new MessageRepositoryMock(),
+				true,
+			);
+			YGOProRoomList.addRoom(existingRoom);
+			const emitSpy = jest.spyOn(existingRoom, "emit").mockImplementation(() => undefined);
+
+			const socket = makeSocket("ticket-user");
+			const ctx = makeCtx({
+				socket: socket as never,
+				command: "TESTROOM",
+				password: "",
+				rawPass: "TESTROOM",
+			});
+
+			await strategy.handle(ctx);
+
+			expect(socket.destroy).toHaveBeenCalled();
+			expect(emitSpy).not.toHaveBeenCalled();
+		});
+
+		it("joins an existing room when a non-empty room password matches", async () => {
+			const { YGOProRoom } = await import("../../domain/YGOProRoom");
+			const { MessageRepositoryMock } = await import(
+				"@test-support/mocks/MessageRepositoryMock"
+			);
+			const { LoggerMock } = await import("@test-support/mocks/logger/LoggerMock");
+			const { PlayerInfoMessageMother } = await import(
+				"@test-support/mothers/PlayerInfoMessageMother"
+			);
+
+			const existingRoom = YGOProRoom.create(
+				7778,
+				"TESTROOM#secret",
+				new LoggerMock(),
+				new EventEmitter(),
+				PlayerInfoMessageMother.create(),
+				"sock-orig",
+				new MessageRepositoryMock(),
+				true,
+			);
+			YGOProRoomList.addRoom(existingRoom);
+			const emitSpy = jest.spyOn(existingRoom, "emit").mockImplementation(() => undefined);
+
+			const ctx = makeCtx({
+				socket: makeSocket("ticket-user") as never,
+				command: "TESTROOM",
+				password: "secret",
+				rawPass: "TESTROOM#secret",
 			});
 
 			await strategy.handle(ctx);

--- a/src/ygopro/room/application/join-strategies/TicketJoinStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/TicketJoinStrategy.ts
@@ -14,6 +14,11 @@ import YGOProRoomList from "../../infrastructure/YGOProRoomList";
  * - checkIfUserCanJoin is intentionally skipped: the ban-check happens
  *   later inside RankedUserResolver (injected in YGOProWaitingState).
  * - JOIN is emitted directly.
+ *
+ * The ticket only replaces the username:password LOGIN credential — it does
+ * NOT bypass the per-room password (the "command#password" room key). An
+ * existing room with a password must still be joined with the matching key,
+ * exactly like DefaultJoinStrategy, so private rooms stay private.
  */
 export class TicketJoinStrategy implements JoinStrategy {
 	matches(ctx: JoinContext): boolean {
@@ -22,12 +27,20 @@ export class TicketJoinStrategy implements JoinStrategy {
 
 	async handle(ctx: JoinContext): Promise<void> {
 		const room = this._findOrCreateRankedRoom(ctx);
+		if (!room) {
+			ctx.logger.info("JOIN_GAME rejected: wrong password");
+			ctx.socket.destroy();
+			return;
+		}
 		room.emit("JOIN", ctx.message, ctx.socket);
 	}
 
-	private _findOrCreateRankedRoom(ctx: JoinContext): YGOProRoom {
+	private _findOrCreateRankedRoom(ctx: JoinContext): YGOProRoom | null {
 		const existingRoom = YGOProRoomList.findByName(ctx.command);
 		if (existingRoom) {
+			if (existingRoom.password !== ctx.password) {
+				return null;
+			}
 			return existingRoom;
 		}
 


### PR DESCRIPTION
## Description / Descripción

**EN:** Ticket-authenticated joins resolved an existing room by name and emitted `JOIN` **without comparing the per-room password**, so any ticket holder could enter a password-protected room without its key. The game ticket replaces the `username:password` **login** credential only — not the per-room `command#password` key.

This makes `TicketJoinStrategy` mirror `DefaultJoinStrategy`: when the existing room password does not match, the join is rejected and the socket destroyed. Rooms with no password (the ranked-ticket case) keep joining freely, so spectating ranked is unaffected.

**ES:** Los joins autenticados por ticket resolvían una sala existente por nombre y emitían `JOIN` **sin comparar la contraseña de la sala**, así que cualquiera con ticket podía entrar a una sala protegida sin su clave. El game ticket reemplaza solo la credencial de **login** `username:password`, no la clave de sala `command#password`.

Ahora `TicketJoinStrategy` se comporta como `DefaultJoinStrategy`: si la contraseña de la sala no coincide, el join se rechaza y se cierra el socket. Las salas sin contraseña (el caso ranked-ticket) siguen entrando libremente, por lo que espectar ranked no se ve afectado.

### Behavior / Comportamiento

| Scenario / Escenario | Before / Antes | After / Después |
|---|---|---|
| Ticket join to room with matching password | ✅ joins | ✅ joins |
| Ticket join to room with **wrong/missing** password | ⚠️ **joins (bypass)** | ✅ rejected (socket destroyed) |
| Ticket join to room **without** password (ranked) | ✅ joins | ✅ joins |
| Spectating an in-progress ranked game | ✅ works | ✅ works |

## Related Issue(s) / Issue(s) relacionado(s)

N/A

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [x] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

**EN:** Followed TDD — a failing test was added first (join rejected on password mismatch), then the fix. Full suite green: **58 suites / 554 tests**. `npm run lint` clean.

**ES:** Se siguió TDD — primero un test que falla (join rechazado si la contraseña no coincide), luego el fix. Suite completo en verde: **58 suites / 554 tests**. `npm run lint` limpio.
