### PR TITLE
fix(join): close socket on join rejections that send a message

### DIFF
--- a/src/ygopro/room/application/join-strategies/AIJoinTokenStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/AIJoinTokenStrategy.test.ts
@@ -20,6 +20,7 @@ const makeLogger = () => ({
 
 const makeSocket = () => ({
 	id: "sock-bot",
+	close: jest.fn(),
 	destroy: jest.fn(),
 	send: jest.fn(),
 });

--- a/src/ygopro/room/application/join-strategies/AIJoinTokenStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/AIJoinTokenStrategy.ts
@@ -43,7 +43,9 @@ export class AIJoinTokenStrategy implements JoinStrategy {
 			// Invalid / expired / already-consumed token → reject, no new room
 			const errorBuf = ctx.messageRepository.errorMessage(ErrorMessageType.JOINERROR, 0);
 			ctx.socket.send(errorBuf);
-			ctx.socket.destroy();
+			// close() (not destroy()): flush the JOINERROR frame before tearing down,
+			// consistent with the other join error paths.
+			ctx.socket.close();
 			return;
 		}
 
@@ -52,7 +54,9 @@ export class AIJoinTokenStrategy implements JoinStrategy {
 			// Room disappeared (e.g. was destroyed during HTTP retry failure) — reject cleanly
 			const errorBuf = ctx.messageRepository.errorMessage(ErrorMessageType.JOINERROR, 0);
 			ctx.socket.send(errorBuf);
-			ctx.socket.destroy();
+			// close() (not destroy()): flush the JOINERROR frame before tearing down,
+			// consistent with the other join error paths.
+			ctx.socket.close();
 			return;
 		}
 

--- a/src/ygopro/room/application/join-strategies/DefaultJoinStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/DefaultJoinStrategy.test.ts
@@ -19,6 +19,7 @@ const makeLogger = () => ({
 const makeSocket = () => ({
 	id: "sock-1",
 	destroy: jest.fn(),
+	close: jest.fn(),
 	send: jest.fn(),
 });
 
@@ -138,6 +139,75 @@ describe("DefaultJoinStrategy", () => {
 			await strategy.handle(ctx);
 
 			expect(emitSpy).toHaveBeenCalledWith("JOIN", expect.anything(), ctx.socket);
+		});
+
+		it("closes the socket and does NOT emit JOIN when the ranked room rejects the user", async () => {
+			// Ranked room created via rankedOverride=true (8th arg)
+			const emitter = new EventEmitter();
+			const logger = makeLogger();
+			const messageRepo = makeMessageRepository();
+			const room = YGOProRoom.create(
+				7777,
+				"RANKEDROOM",
+				logger as never,
+				emitter,
+				{ name: "TestPlayer", password: "", previousMessage: Buffer.alloc(0) } as never,
+				"sock-original",
+				messageRepo as never,
+				true,
+			);
+			YGOProRoomList.addRoom(room);
+
+			const emitSpy = jest.spyOn(room, "emit").mockImplementation(() => undefined);
+
+			const socket = makeSocket();
+			const ctx = makeCtx({
+				rawPass: "RANKEDROOM",
+				command: "RANKEDROOM",
+				password: "",
+				socket: socket as never,
+				eventEmitter: emitter,
+				// check() returns false → user cannot join the ranked room
+				checkIfUserCanJoin: { check: jest.fn().mockResolvedValue(false) } as never,
+			});
+
+			await strategy.handle(ctx);
+
+			expect(socket.close).toHaveBeenCalled();
+			expect(emitSpy).not.toHaveBeenCalledWith("JOIN", expect.anything(), expect.anything());
+		});
+
+		it("does NOT close the socket on the happy ranked path (check passes)", async () => {
+			const emitter = new EventEmitter();
+			const logger = makeLogger();
+			const messageRepo = makeMessageRepository();
+			const room = YGOProRoom.create(
+				6666,
+				"RANKEDOK",
+				logger as never,
+				emitter,
+				{ name: "TestPlayer", password: "", previousMessage: Buffer.alloc(0) } as never,
+				"sock-original",
+				messageRepo as never,
+				true,
+			);
+			YGOProRoomList.addRoom(room);
+
+			jest.spyOn(room, "emit").mockImplementation(() => undefined);
+
+			const socket = makeSocket();
+			const ctx = makeCtx({
+				rawPass: "RANKEDOK",
+				command: "RANKEDOK",
+				password: "",
+				socket: socket as never,
+				eventEmitter: emitter,
+				checkIfUserCanJoin: { check: jest.fn().mockResolvedValue(true) } as never,
+			});
+
+			await strategy.handle(ctx);
+
+			expect(socket.close).not.toHaveBeenCalled();
 		});
 
 		it("creates a new room when none exists and adds it to the list", async () => {

--- a/src/ygopro/room/application/join-strategies/DefaultJoinStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/DefaultJoinStrategy.ts
@@ -27,6 +27,11 @@ export class DefaultJoinStrategy implements JoinStrategy {
 		}
 
 		if (room.ranked && !(await ctx.checkIfUserCanJoin.check(ctx.playerInfo, ctx.socket))) {
+			// checkIfUserCanJoin already sent the JOIN_ERROR. Close the socket so the
+			// client gets a real disconnect instead of a live-but-useless connection it
+			// would keep reusing (the handshake — where the ticket travels — never re-runs
+			// otherwise). close() is graceful: the queued error frame is flushed first.
+			ctx.socket.close();
 			return;
 		}
 

--- a/src/ygopro/room/application/join-strategies/SocketCloseOnError.test.ts
+++ b/src/ygopro/room/application/join-strategies/SocketCloseOnError.test.ts
@@ -1,19 +1,25 @@
 /**
- * socket.destroy() called after error sends.
+ * socket.close() called after error sends.
  *
- * WARNING-3 / SUGGESTION-3 from verify-pr4:
- * Both WindBotJoinStrategy and AIJoinTokenStrategy call ctx.socket.send(errorBuf)
- * on error paths but do NOT call ctx.socket.destroy(). The original DefaultJoinStrategy
- * wrong-password path calls socket.destroy(). This test enforces the fix.
+ * Invariant: error paths that send a message to the client (e.g. JOINERROR) MUST
+ * close the socket AFTER the send — using close() (graceful), NOT destroy().
+ *
+ * Why close() and not destroy():
+ *   destroy() → ws.terminate() is abrupt and can drop the queued error frame, so the
+ *   client never receives the JOINERROR it needs to react to. close() → ws.close()
+ *   performs the closing handshake and flushes queued frames first, so the error is
+ *   delivered AND the socket is torn down (no live-but-rejected connection the client
+ *   keeps reusing). Pure-rejection paths with no message (wrong password) still use
+ *   destroy() — see DefaultJoinStrategy / TicketJoinStrategy.
  *
  * Covered error paths:
  *   WindBotJoinStrategy:
- *     1. Tag-mode rejection → send + destroy
- *     2. requestBot failure → send + destroy
+ *     1. Tag-mode rejection → send + close
+ *     2. requestBot failure → send + close
  *
  *   AIJoinTokenStrategy:
- *     3. Invalid token → send + destroy
- *     4. Room disappeared (findById returns undefined) → send + destroy
+ *     3. Invalid token → send + close
+ *     4. Room disappeared (findById returns undefined) → send + close
  */
 
 import { EventEmitter } from "stream";
@@ -39,6 +45,7 @@ const makeLogger = () => ({
 
 const makeSocket = () => ({
 	id: "sock-test",
+	close: jest.fn(),
 	destroy: jest.fn(),
 	send: jest.fn(),
 	closed: false,
@@ -108,7 +115,7 @@ const makeCtx = (rawPass: string, overrides: Partial<JoinContext> = {}): JoinCon
 
 // ---------- tests ----------
 
-describe("socket.destroy() after error send (WARNING-3 fix)", () => {
+describe("socket.close() after error send", () => {
 	let waitingSpy: jest.SpyInstance;
 	let emitSpy: jest.SpyInstance;
 
@@ -128,7 +135,7 @@ describe("socket.destroy() after error send (WARNING-3 fix)", () => {
 	});
 
 	describe("WindBotJoinStrategy — error paths", () => {
-		it("calls socket.destroy() after send() on tag-mode rejection", async () => {
+		it("calls socket.close() after send() on tag-mode rejection", async () => {
 			const fakeRoom = {
 				isTag: true,
 				id: 42,
@@ -149,10 +156,11 @@ describe("socket.destroy() after error send (WARNING-3 fix)", () => {
 			await strategy.handle(ctx);
 
 			expect(socket.send).toHaveBeenCalled();
-			expect(socket.destroy).toHaveBeenCalled();
+			expect(socket.close).toHaveBeenCalled();
+			expect(socket.destroy).not.toHaveBeenCalled();
 		});
 
-		it("calls socket.destroy() after send() on requestBot failure", async () => {
+		it("calls socket.close() after send() on requestBot failure", async () => {
 			const provider = {
 				requestJoin: jest.fn().mockRejectedValue(new WindbotUnreachableError("Anna", 10)),
 			};
@@ -170,10 +178,11 @@ describe("socket.destroy() after error send (WARNING-3 fix)", () => {
 			await new Promise((r) => setImmediate(r));
 
 			expect(socket.send).toHaveBeenCalled();
-			expect(socket.destroy).toHaveBeenCalled();
+			expect(socket.close).toHaveBeenCalled();
+			expect(socket.destroy).not.toHaveBeenCalled();
 		});
 
-		it("destroy() is called AFTER send() on tag-mode rejection (order matters)", async () => {
+		it("close() is called AFTER send() on tag-mode rejection (order matters)", async () => {
 			const fakeRoom = {
 				isTag: true,
 				id: 42,
@@ -192,18 +201,18 @@ describe("socket.destroy() after error send (WARNING-3 fix)", () => {
 			const socket = {
 				...makeSocket(),
 				send: jest.fn().mockImplementation(() => { callOrder.push("send"); }),
-				destroy: jest.fn().mockImplementation(() => { callOrder.push("destroy"); }),
+				close: jest.fn().mockImplementation(() => { callOrder.push("close"); }),
 			};
 			const ctx = makeCtx("AI", { socket: socket as never });
 
 			await strategy.handle(ctx);
 
-			expect(callOrder).toEqual(["send", "destroy"]);
+			expect(callOrder).toEqual(["send", "close"]);
 		});
 	});
 
 	describe("AIJoinTokenStrategy — error paths", () => {
-		it("calls socket.destroy() after send() on invalid token", async () => {
+		it("calls socket.close() after send() on invalid token", async () => {
 			const mod = makeModule();
 			const strategy = new AIJoinTokenStrategy(mod);
 
@@ -213,10 +222,11 @@ describe("socket.destroy() after error send (WARNING-3 fix)", () => {
 			await strategy.handle(ctx);
 
 			expect(socket.send).toHaveBeenCalled();
-			expect(socket.destroy).toHaveBeenCalled();
+			expect(socket.close).toHaveBeenCalled();
+			expect(socket.destroy).not.toHaveBeenCalled();
 		});
 
-		it("calls socket.destroy() after send() when room not found", async () => {
+		it("calls socket.close() after send() when room not found", async () => {
 			const tokenStore = WindbotTokenStore.createForTests();
 			const token = tokenStore.register(99999, "Anna", "Anna.ydk");
 
@@ -230,10 +240,11 @@ describe("socket.destroy() after error send (WARNING-3 fix)", () => {
 			await strategy.handle(ctx);
 
 			expect(socket.send).toHaveBeenCalled();
-			expect(socket.destroy).toHaveBeenCalled();
+			expect(socket.close).toHaveBeenCalled();
+			expect(socket.destroy).not.toHaveBeenCalled();
 		});
 
-		it("destroy() is called AFTER send() on invalid token (order)", async () => {
+		it("close() is called AFTER send() on invalid token (order)", async () => {
 			const mod = makeModule();
 			const strategy = new AIJoinTokenStrategy(mod);
 
@@ -241,16 +252,16 @@ describe("socket.destroy() after error send (WARNING-3 fix)", () => {
 			const socket = {
 				...makeSocket(),
 				send: jest.fn().mockImplementation(() => { callOrder.push("send"); }),
-				destroy: jest.fn().mockImplementation(() => { callOrder.push("destroy"); }),
+				close: jest.fn().mockImplementation(() => { callOrder.push("close"); }),
 			};
 			const ctx = makeCtx("AIJOIN#nosuchtoken", { socket: socket as never });
 
 			await strategy.handle(ctx);
 
-			expect(callOrder).toEqual(["send", "destroy"]);
+			expect(callOrder).toEqual(["send", "close"]);
 		});
 
-		it("does NOT call socket.destroy() on the HAPPY path (valid token, room found)", async () => {
+		it("does NOT close the socket on the HAPPY path (valid token, room found)", async () => {
 			const tokenStore = WindbotTokenStore.createForTests();
 
 			// Create a real room in the list
@@ -283,8 +294,9 @@ describe("socket.destroy() after error send (WARNING-3 fix)", () => {
 
 			await strategy.handle(ctx);
 
-			// Happy path: no error sent, no destroy
+			// Happy path: no error sent, no close, no destroy
 			expect(socket.send).not.toHaveBeenCalled();
+			expect(socket.close).not.toHaveBeenCalled();
 			expect(socket.destroy).not.toHaveBeenCalled();
 		});
 	});

--- a/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.test.ts
@@ -20,6 +20,7 @@ const makeLogger = () => ({
 
 const makeSocket = () => ({
 	id: "sock-test",
+	close: jest.fn(),
 	destroy: jest.fn(),
 	send: jest.fn(),
 });
@@ -368,7 +369,7 @@ describe("WindBotJoinStrategy", () => {
 		});
 
 		describe("requestBot failure path", () => {
-			it("sends error to human and destroys socket when requestBot throws", async () => {
+			it("sends error to human and closes socket when requestBot throws", async () => {
 				const provider = {
 					requestJoin: jest.fn().mockRejectedValue(new WindbotUnreachableError("Anna", 10)),
 				};

--- a/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.ts
@@ -63,7 +63,10 @@ export class WindBotJoinStrategy implements JoinStrategy {
 		if (room.isTag) {
 			const errorBuf = ctx.messageRepository.errorMessage(ErrorMessageType.JOINERROR, 0);
 			ctx.socket.send(errorBuf);
-			ctx.socket.destroy();
+			// close() (not destroy()): graceful close flushes the queued JOINERROR frame
+			// to the human before tearing the socket down. destroy()/terminate() is abrupt
+			// and can drop it. (destroy() stays only for message-less rejects, e.g. wrong password.)
+			ctx.socket.close();
 			// Room was NOT added to the list — no cleanup needed
 			return;
 		}
@@ -103,7 +106,8 @@ export class WindBotJoinStrategy implements JoinStrategy {
 
 				const errorBuf = ctx.messageRepository.errorMessage(ErrorMessageType.JOINERROR, 0);
 				ctx.socket.send(errorBuf);
-				ctx.socket.destroy();
+				// close() flushes the JOINERROR to the human before tearing down.
+				ctx.socket.close();
 			});
 	}
 }

--- a/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
@@ -246,6 +246,7 @@ describe("YGOProWaitingState.handleJoin", () => {
 			remoteAddress: "127.0.0.1",
 			closed: false,
 			send: jest.fn(),
+			close: jest.fn(),
 			destroy: jest.fn(),
 			removeAllListeners: jest.fn(),
 		} as unknown as jest.Mocked<ISocket>);
@@ -312,6 +313,41 @@ describe("YGOProWaitingState.handleJoin", () => {
 
 			expect(mockSocket.send).toHaveBeenCalled();
 			expect(mockRoom.createPlayerUnsafe).not.toHaveBeenCalled();
+		});
+
+		it("closes the socket when resolver returns null", async () => {
+			mockRoom = makeMockRoom(true);
+			mockResolver.resolve.mockResolvedValue(null);
+
+			await emitJoin(mockRoom, mockSocket);
+
+			expect(mockSocket.close).toHaveBeenCalled();
+		});
+
+		it("closes the socket AFTER sending JOINERROR (order matters)", async () => {
+			mockRoom = makeMockRoom(true);
+			mockResolver.resolve.mockResolvedValue(null);
+
+			const callOrder: string[] = [];
+			mockSocket.send.mockImplementation(() => {
+				callOrder.push("send");
+			});
+			mockSocket.close.mockImplementation(() => {
+				callOrder.push("close");
+			});
+
+			await emitJoin(mockRoom, mockSocket);
+
+			expect(callOrder).toEqual(["send", "close"]);
+		});
+
+		it("does NOT close the socket when resolver returns a userId", async () => {
+			mockRoom = makeMockRoom(true);
+			mockResolver.resolve.mockResolvedValue("user-123");
+
+			await emitJoin(mockRoom, mockSocket);
+
+			expect(mockSocket.close).not.toHaveBeenCalled();
 		});
 
 		it("creates the player with the userId returned by resolver", async () => {

--- a/src/ygopro/room/domain/states/YGOProWaitingState.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.ts
@@ -106,6 +106,11 @@ export class YGOProWaitingState extends YGOProRoomState {
 				const resolvedId = await this.resolver.resolve(playerInfoMessage, socket);
 				if (!resolvedId) {
 					socket.send(room.messageSender.errorMessage(ErrorMessageType.JOINERROR));
+					// Close after the error is queued so the client disconnects cleanly and
+					// re-runs the handshake (with a fresh ticket) on retry, instead of staying
+					// stuck on a live socket the server has already rejected. close() flushes
+					// the JOINERROR frame before tearing down (unlike destroy()/terminate()).
+					socket.close();
 
 					return null;
 				}


### PR DESCRIPTION
## Description / Descripción

Al rechazar un join que envía un `JOINERROR`, el server dejaba el socket abierto (camino ranked) o lo terminaba de forma abrupta (caminos windbot/ai). Un socket abierto dejaba al cliente creyendo que seguía conectado, así que los reintentos nunca rehacían el handshake del WebSocket (donde viaja el `?ticket=`) y el cliente quedaba "pegado". Un `terminate()` abrupto, además, podía descartar el frame del `JOINERROR` antes de que llegara al cliente.

Solución: usar `socket.close()` (graceful — flushea el frame de error en cola y luego cierra) en todos los caminos de error de join que envían un mensaje:

- `DefaultJoinStrategy`: rechazo ranked tras fallar `checkIfUserCanJoin`
- `YGOProWaitingState`: el resolver devuelve `null`
- `WindBotJoinStrategy`: rechazo tag-mode + fallo de `requestBot`
- `AIJoinTokenStrategy`: token inválido + room inexistente

Los rechazos sin mensaje (password incorrecta en `DefaultJoinStrategy` / `TicketJoinStrategy`) mantienen `destroy()`: no hay frame que flushear y libera recursos más rápido.

## Related Issue(s) / Issue(s) relacionado(s)

Sin issue formal. Bug detectado depurando el flujo de join ranked por ticket: un jugador anónimo (sin ticket) rechazado de una sala ranked quedaba "pegado" en los reintentos porque el socket nunca se cerraba.

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [x] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

- TDD: RED → GREEN en cada cambio. Suite completa **559/559**, `tsc --noEmit` y `eslint` limpios.
- Se renombró `SocketDestroyOnError.test.ts` → `SocketCloseOnError.test.ts` (la invariante ahora es "cerrar con `close()` cuando el path envía un mensaje al cliente").
- **Alcance:** este PR arregla el síntoma del lado servidor (cliente pegado tras el rechazo + no depender de que el cliente respete el `JOIN_ERROR`). La causa de fondo —que el frontend adjunte el `?ticket=` en el handshake del WebSocket— es del lado cliente y queda fuera de este repositorio.
