### PR TITLE
fix(chat): include spectator name in Mercury chat messages

### DIFF
--- a/src/edopro/room/domain/RoomState.test.ts
+++ b/src/edopro/room/domain/RoomState.test.ts
@@ -1,0 +1,84 @@
+import { EventEmitter } from "stream";
+
+import { RoomState } from "./RoomState";
+import { Commands } from "../../../shared/messages/Commands";
+import { RoomType } from "src/shared/room/domain/RoomType";
+
+// RoomState is abstract but declares no abstract members — a bare concrete
+// subclass is enough to exercise the inherited CHAT handler (registered in the
+// constructor). handleChat/handleMercuryChat are private, so we drive them
+// through the "CHAT" event, exactly as the runtime does.
+class TestRoomState extends RoomState {}
+
+const makeSocket = () => ({
+	send: jest.fn(),
+	destroy: jest.fn(),
+	close: jest.fn(),
+});
+
+const makeChatMessage = (text: string) => ({
+	data: Buffer.from(text, "utf16le"),
+	previousMessage: Buffer.alloc(0),
+});
+
+const makeMercuryRoom = (socket: { send: jest.Mock }) =>
+	({
+		roomType: RoomType.MERCURY,
+		isPositionSwapped: false,
+		clients: [{ socket }],
+	} as unknown as never);
+
+describe("RoomState — Mercury spectator chat (Option A: server prefixes name)", () => {
+	let eventEmitter: EventEmitter;
+
+	beforeEach(() => {
+		eventEmitter = new EventEmitter();
+		new TestRoomState(eventEmitter);
+	});
+
+	it("prefixes the spectator's name to the chat msg in a Mercury room", () => {
+		const socket = makeSocket();
+		const room = makeMercuryRoom(socket);
+		const spectator = {
+			name: "Duelista 5863",
+			isSpectator: true,
+			position: 7,
+			team: 3,
+		} as unknown as never;
+
+		eventEmitter.emit(
+			Commands.CHAT as unknown as string,
+			makeChatMessage("hola"),
+			room,
+			spectator,
+		);
+
+		expect(socket.send).toHaveBeenCalled();
+		const sent = socket.send.mock.calls[0][0] as Buffer;
+		// The outgoing STOC_CHAT msg must carry "Name: text" (UTF-16LE on the wire).
+		expect(sent.includes(Buffer.from("Duelista 5863: hola", "utf16le"))).toBe(true);
+	});
+
+	it("does NOT prefix a name for a duelist (player) chat", () => {
+		const socket = makeSocket();
+		const room = makeMercuryRoom(socket);
+		const player = {
+			name: "Jugador A",
+			isSpectator: false,
+			position: 0,
+			team: 0,
+		} as unknown as never;
+
+		eventEmitter.emit(
+			Commands.CHAT as unknown as string,
+			makeChatMessage("hola"),
+			room,
+			player,
+		);
+
+		expect(socket.send).toHaveBeenCalled();
+		const sent = socket.send.mock.calls[0][0] as Buffer;
+		expect(sent.includes(Buffer.from("Jugador A: hola", "utf16le"))).toBe(false);
+		expect(sent.includes(Buffer.from("hola", "utf16le"))).toBe(true);
+	});
+});

--- a/src/edopro/room/domain/RoomState.ts
+++ b/src/edopro/room/domain/RoomState.ts
@@ -175,8 +175,15 @@ export abstract class RoomState {
 				: client.position;
 
 		const content = BufferToUTF16(message.data, message.data.length);
+		// STOC_CHAT (opcode 0x19) only carries player_type + msg — there is no name field,
+		// and every spectator shares player_type=7, so the client cannot tell which spectator
+		// spoke (it would fall back to a duelist's identity). Prefix the spectator's name into
+		// the text so the client can attribute the message to the right person.
+		const outgoing = client.isSpectator
+			? `${client.name.replace(/\0/g, "").trim()}: ${content}`
+			: content;
 		const chatMessage = Buffer.from(
-			new YGOProStocChat().fromPartial({ player_type: playerType, msg: content }).toFullPayload()
+			new YGOProStocChat().fromPartial({ player_type: playerType, msg: outgoing }).toFullPayload()
 		);
 
 		room.clients.forEach((_client: YgoClient) => {


### PR DESCRIPTION
## Description / Descripción

En partidas Mercury, el chat de un ESPECTADOR se atribuía al jugador del seat 0 (aparecía, por ejemplo, como "Jugador A"). El opcode `STOC_CHAT` (0x19) solo transporta `player_type` + `msg`, y todos los espectadores comparten `player_type = 7` (OBSERVER), así que el cliente no tenía un nombre con el cual atribuir el mensaje y caía en la identidad de un duelista.

Este PR hace que el server **incluya el nombre del espectador** en el texto del chat (`handleMercuryChat`), para que el cliente pueda mostrar `"Nombre: mensaje"`. Los duelistas no cambian. Replica lo que la ruta NO-Mercury ya hace vía `SpectatorMessageClientMessage`.

## Related Issue(s) / Issue(s) relacionado(s)

Sin issue formal. Bug encontrado depurando el flujo de chat de espectadores en salas Mercury (confirmado con logs: el server resolvía correctamente al espectador, pero enviaba `player_type = 7` anónimo, sin nombre).

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [x] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

- TDD: RED → GREEN. Suite completa **561/561**, `tsc --noEmit` y `eslint` limpios.
- **Fix de dos partes:** este PR cubre la mitad del server. El cliente web debe, en paralelo, dejar de atribuir el chat de `player_type = 7` al jugador del seat 0 (no usar `playerNames.local` ni asumir `isSelf` por `player_type === 7`) y renderizar el `msg` tal cual (ahora llega con `"Nombre: "` prefijado) con estilo de espectador, sin duplicar la etiqueta.
- Alcance acotado: solo afecta el chat de espectadores en rooms Mercury; los duelistas quedan igual.
