### PR TITLE
fix(deck): encode deck error code so the client shows the specific error

### DIFF
--- a/src/shared/deck/domain/errors/encodeDeckErrorCode.test.ts
+++ b/src/shared/deck/domain/errors/encodeDeckErrorCode.test.ts
@@ -1,0 +1,46 @@
+import { DeckErrorType } from "ygopro-msg-encode";
+
+import { encodeDeckErrorCode } from "./encodeDeckErrorCode";
+
+// Decode exactly the way the client (and ygopro-msg-encode contract) does:
+// DeckErrorType lives in the high 4 bits, the offending card id in the low 28.
+const decodeType = (code: number): number => (code >>> 28) & 0xf;
+const decodeCardId = (code: number): number => code & 0x0fffffff;
+
+describe("encodeDeckErrorCode", () => {
+	it.each([
+		DeckErrorType.LFLIST, // 1
+		DeckErrorType.OCGONLY, // 2
+		DeckErrorType.TCGONLY, // 3
+		DeckErrorType.UNKNOWNCARD, // 4
+		DeckErrorType.CARDCOUNT, // 5
+		DeckErrorType.MAINCOUNT, // 6
+		DeckErrorType.EXTRACOUNT, // 7
+		DeckErrorType.SIDECOUNT, // 8
+	])("packs type %i into the high 4 bits (cardId 0)", (type) => {
+		const code = encodeDeckErrorCode(type, 0);
+		expect(decodeType(code)).toBe(type);
+		expect(decodeCardId(code)).toBe(0);
+	});
+
+	it("packs both the type and a real offending card id", () => {
+		const cardId = 12345678; // fits in 28 bits
+		const code = encodeDeckErrorCode(DeckErrorType.LFLIST, cardId);
+		expect(decodeType(code)).toBe(DeckErrorType.LFLIST);
+		expect(decodeCardId(code)).toBe(cardId);
+	});
+
+	it("stays an unsigned 32-bit int when bit 31 is set (type=8 SIDECOUNT)", () => {
+		const code = encodeDeckErrorCode(DeckErrorType.SIDECOUNT, 999);
+		expect(code).toBeGreaterThan(0); // NOT a negative int32
+		expect(Number.isInteger(code)).toBe(true);
+		expect(decodeType(code)).toBe(DeckErrorType.SIDECOUNT);
+		expect(decodeCardId(code)).toBe(999);
+	});
+
+	it("masks a card id that overflows 28 bits without corrupting the type", () => {
+		const code = encodeDeckErrorCode(DeckErrorType.MAINCOUNT, 0xffffffff);
+		expect(decodeType(code)).toBe(DeckErrorType.MAINCOUNT);
+		expect(decodeCardId(code)).toBe(0x0fffffff);
+	});
+});

--- a/src/shared/deck/domain/errors/encodeDeckErrorCode.ts
+++ b/src/shared/deck/domain/errors/encodeDeckErrorCode.ts
@@ -1,0 +1,19 @@
+import { YGOProLFListError, YGOProLFListErrorReason } from "ygopro-lflist-encode";
+
+/**
+ * Encodes a deck error into the u32 `code` field of STOC_ERROR_MSG.
+ *
+ * Delegates to ygopro-lflist-encode's `YGOProLFListError.toPayload()` — the same
+ * encoder SRVPro2 uses — so the bit layout stays canonical and shared across the
+ * ecosystem instead of being re-implemented here:
+ *   bits 31-28 → deck error type (YGOProLFListErrorReason / DeckErrorType 1..9)
+ *   bits 27-0  → offending card id (0 when not applicable)
+ *
+ * The client decodes it back with `(code >>> 28) & 0xf` for the type and
+ * `code & 0x0FFFFFFF` for the card id. Sending the type unshifted (the old bug)
+ * made the client read type 0 and fall back to a generic "invalid deck" message
+ * with no offending card.
+ */
+export function encodeDeckErrorCode(type: number, cardId: number): number {
+	return new YGOProLFListError(type as YGOProLFListErrorReason, cardId).toPayload();
+}

--- a/src/ygopro/room/domain/states/YGOProSideDeckingState.test.ts
+++ b/src/ygopro/room/domain/states/YGOProSideDeckingState.test.ts
@@ -1,0 +1,134 @@
+import { EventEmitter } from "stream";
+
+import { Commands } from "@shared/messages/Commands";
+import { ClientMessage } from "@shared/messages/MessageProcessor";
+import { Logger } from "@shared/logger/domain/Logger";
+
+import { YGOProClient } from "../../../client/domain/YGOProClient";
+import { YGOProRoom } from "../YGOProRoom";
+import { YGOProSideDeckingState } from "./YGOProSideDeckingState";
+import { YGOProDeckCreator } from "@ygopro/deck/application/YGOProDeckCreator";
+import { YGOProDeckValidator } from "@ygopro/deck/domain/YGOProDeckValidator";
+import { BanListDeckError } from "@shared/deck/domain/errors/BanListDeckError";
+import { NotOfficialCardError } from "@shared/deck/domain/errors/NotOfficialCardError";
+import { encodeDeckErrorCode } from "@shared/deck/domain/errors/encodeDeckErrorCode";
+
+import { ErrorMessageType } from "ygopro-msg-encode";
+
+// ---- helpers ----
+
+// A minimal CTOS_UPDATE_DECK payload: mainCount, sideCount, then card codes.
+const makeDeckPayload = (): Buffer => {
+	const main = [0x00000001, 0x00000002];
+	const side: number[] = [];
+	const buf = Buffer.alloc(4 + 4 + (main.length + side.length) * 4);
+	let offset = 0;
+	buf.writeUInt32LE(main.length, offset);
+	offset += 4;
+	buf.writeUInt32LE(side.length, offset);
+	offset += 4;
+	for (const code of [...main, ...side]) {
+		buf.writeUInt32LE(code, offset);
+		offset += 4;
+	}
+	return buf;
+};
+
+const makeClientMessage = (data: Buffer): ClientMessage =>
+	({ data, previousMessage: Buffer.alloc(0) } as unknown as ClientMessage);
+
+describe("YGOProSideDeckingState.handleUpdateDeck — deck error code is encoded", () => {
+	let eventEmitter: EventEmitter;
+	let mockLogger: jest.Mocked<Logger>;
+	let mockDeckCreator: jest.Mocked<YGOProDeckCreator>;
+	let mockDeckValidator: jest.Mocked<YGOProDeckValidator>;
+	let mockRoom: jest.Mocked<YGOProRoom>;
+	let mockPlayer: jest.Mocked<YGOProClient>;
+
+	const errorMessageMock = () =>
+		mockRoom.messageSender.errorMessage as unknown as jest.Mock;
+
+	beforeEach(() => {
+		eventEmitter = new EventEmitter();
+
+		mockLogger = {
+			child: jest.fn().mockReturnThis(),
+			info: jest.fn(),
+			warn: jest.fn(),
+			error: jest.fn(),
+			debug: jest.fn(),
+		} as unknown as jest.Mocked<Logger>;
+
+		mockDeckCreator = { build: jest.fn() } as unknown as jest.Mocked<YGOProDeckCreator>;
+		mockDeckValidator = {
+			validate: jest.fn().mockReturnValue(null),
+		} as unknown as jest.Mocked<YGOProDeckValidator>;
+
+		mockRoom = {
+			players: [], // empty → constructor schedules no side-deck timers
+			banListHash: 0,
+			hostInfo: { rule: 0 }, // referenced by the warn() log on the error paths
+			useExtendedCardPool: false,
+			shouldValidateDeck: jest.fn().mockReturnValue(true),
+			notReadyUnsafe: jest.fn(),
+			setDecksToPlayerUnsafe: jest.fn(),
+			messageSender: {
+				errorMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+			},
+		} as unknown as jest.Mocked<YGOProRoom>;
+
+		mockPlayer = {
+			isSpectator: false,
+			position: 0,
+			deck: { isSideDeckValid: jest.fn().mockReturnValue(true) },
+			logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+			sendMessageToClient: jest.fn(),
+		} as unknown as jest.Mocked<YGOProClient>;
+
+		new YGOProSideDeckingState(
+			eventEmitter,
+			mockLogger,
+			mockDeckCreator,
+			mockDeckValidator,
+			mockRoom,
+		);
+	});
+
+	const emitUpdateDeck = (): Promise<void> => {
+		const message = makeClientMessage(makeDeckPayload());
+		return new Promise((resolve) => {
+			setImmediate(() => resolve());
+			eventEmitter.emit(Commands.UPDATE_DECK as unknown as string, message, mockRoom, mockPlayer);
+		});
+	};
+
+	it("sends DECKERROR with the encoded code when build returns a DeckError", async () => {
+		const deckError = new BanListDeckError(12345); // type=CARD_BANLISTED(1), code=12345
+		mockDeckCreator.build.mockResolvedValue(deckError as never);
+
+		await emitUpdateDeck();
+
+		expect(errorMessageMock()).toHaveBeenCalledWith(
+			ErrorMessageType.DECKERROR,
+			encodeDeckErrorCode(deckError.type, deckError.code),
+		);
+		expect(errorMessageMock()).not.toHaveBeenCalledWith(
+			ErrorMessageType.DECKERROR,
+			deckError.type, // the old bug: raw unshifted type
+		);
+	});
+
+	it("sends DECKERROR with the encoded code when validation fails", async () => {
+		const fakeDeck = { allCards: [{ code: 12345 }] };
+		const deckError = new NotOfficialCardError(12345); // type=CARD_UNOFFICIAL(0xa), code=12345
+		mockDeckCreator.build.mockResolvedValue(fakeDeck as never);
+		mockDeckValidator.validate.mockReturnValue(deckError);
+
+		await emitUpdateDeck();
+
+		expect(errorMessageMock()).toHaveBeenCalledWith(
+			ErrorMessageType.DECKERROR,
+			encodeDeckErrorCode(deckError.type, deckError.code),
+		);
+	});
+});

--- a/src/ygopro/room/domain/states/YGOProSideDeckingState.ts
+++ b/src/ygopro/room/domain/states/YGOProSideDeckingState.ts
@@ -6,6 +6,7 @@ import { RoomState } from "@edopro/room/domain/RoomState";
 import { YGOProDeckCreator } from "@ygopro/deck/application/YGOProDeckCreator";
 import { YGOProDeckValidator } from "@ygopro/deck/domain/YGOProDeckValidator";
 import { DeckError } from "@shared/deck/domain/errors/DeckError";
+import { encodeDeckErrorCode } from "@shared/deck/domain/errors/encodeDeckErrorCode";
 
 import { Commands } from "@shared/messages/Commands";
 import { ClientMessage } from "@shared/messages/MessageProcessor";
@@ -209,7 +210,7 @@ export class YGOProSideDeckingState extends RoomState {
 		if (deckOrError instanceof DeckError) {
 			this.logger.warn(`Deck build error: type=0x${deckOrError.type.toString(16)}, code=${deckOrError.code}, rule=${room.hostInfo.rule}, extendedPool=${room.useExtendedCardPool}`);
 			room.notReadyUnsafe(player);
-			player.sendMessageToClient(room.messageSender.errorMessage(ErrorMessageType.DECKERROR, deckOrError.type));
+			player.sendMessageToClient(room.messageSender.errorMessage(ErrorMessageType.DECKERROR, encodeDeckErrorCode(deckOrError.type, deckOrError.code)));
 			return;
 		}
 
@@ -219,7 +220,7 @@ export class YGOProSideDeckingState extends RoomState {
 			const failedCard = deck.allCards.find((c) => Number(c.code) === hasError.code);
 			this.logger.warn(`Deck validation error: type=0x${hasError.type.toString(16)}, code=${hasError.code}, cardOt=${failedCard?.variant ?? "N/A"}, rule=${room.hostInfo.rule}, extendedPool=${room.useExtendedCardPool}`);
 			room.notReadyUnsafe(player);
-			player.sendMessageToClient(room.messageSender.errorMessage(ErrorMessageType.DECKERROR, hasError.type));
+			player.sendMessageToClient(room.messageSender.errorMessage(ErrorMessageType.DECKERROR, encodeDeckErrorCode(hasError.type, hasError.code)));
 			return;
 		}
 

--- a/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
@@ -12,6 +12,8 @@ import { YGOProWaitingState } from "./YGOProWaitingState";
 import { YGOProDeckCreator } from "@ygopro/deck/application/YGOProDeckCreator";
 import { YGOProDeckValidator } from "@ygopro/deck/domain/YGOProDeckValidator";
 import { NotOfficialCardError } from "@shared/deck/domain/errors/NotOfficialCardError";
+import { BanListDeckError } from "@shared/deck/domain/errors/BanListDeckError";
+import { encodeDeckErrorCode } from "@shared/deck/domain/errors/encodeDeckErrorCode";
 import { RankedUserResolver } from "../../application/RankedUserResolver";
 import { ISocket } from "@shared/socket/domain/ISocket";
 import { ErrorMessageType } from "ygopro-msg-encode";
@@ -205,6 +207,42 @@ describe("YGOProWaitingState.handleUpdateDeck", () => {
 
 			expect(mockRoom.shouldValidateDeck).not.toHaveBeenCalled();
 			expect(mockDeckValidator.validate).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("deck error code is encoded (DeckErrorType in high 4 bits)", () => {
+		const errorMessageMock = () =>
+			mockRoom.messageSender.errorMessage as unknown as jest.Mock;
+
+		it("sends DECKERROR with the encoded code when build returns a DeckError", async () => {
+			const deckError = new BanListDeckError(12345); // type=CARD_BANLISTED(1), code=12345
+			mockDeckCreator.build.mockResolvedValue(deckError as never);
+
+			await emitUpdateDeck(mockPlayer);
+
+			expect(errorMessageMock()).toHaveBeenCalledWith(
+				ErrorMessageType.DECKERROR,
+				encodeDeckErrorCode(deckError.type, deckError.code),
+			);
+			// Must NOT be the old bug (raw unshifted type)
+			expect(errorMessageMock()).not.toHaveBeenCalledWith(
+				ErrorMessageType.DECKERROR,
+				deckError.type,
+			);
+		});
+
+		it("sends DECKERROR with the encoded code when validation fails", async () => {
+			const fakeDeck = { allCards: [{ code: 12345 }] };
+			const deckError = new NotOfficialCardError(12345); // type=CARD_UNOFFICIAL(0xa), code=12345
+			mockDeckCreator.build.mockResolvedValue(fakeDeck as never);
+			mockDeckValidator.validate.mockReturnValue(deckError);
+
+			await emitUpdateDeck(mockPlayer);
+
+			expect(errorMessageMock()).toHaveBeenCalledWith(
+				ErrorMessageType.DECKERROR,
+				encodeDeckErrorCode(deckError.type, deckError.code),
+			);
 		});
 	});
 });

--- a/src/ygopro/room/domain/states/YGOProWaitingState.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.ts
@@ -19,6 +19,7 @@ import {
 import { YGOProDeckCreator } from "@ygopro/deck/application/YGOProDeckCreator";
 import { YGOProDeckValidator } from "@ygopro/deck/domain/YGOProDeckValidator";
 import { DeckError } from "@shared/deck/domain/errors/DeckError";
+import { encodeDeckErrorCode } from "@shared/deck/domain/errors/encodeDeckErrorCode";
 import { YGOProRoomState } from "../YGOProRoomState";
 import MercuryBanListMemoryRepository from "@ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository";
 
@@ -214,7 +215,7 @@ export class YGOProWaitingState extends YGOProRoomState {
 		if (deckOrError instanceof DeckError) {
 			this.logger.warn(`Deck build error: type=0x${deckOrError.type.toString(16)}, code=${deckOrError.code}, rule=${room.hostInfo.rule}, extendedPool=${room.useExtendedCardPool}`);
 			room.notReadyUnsafe(player);
-			player.sendMessageToClient(room.messageSender.errorMessage(ErrorMessageType.DECKERROR, deckOrError.type));
+			player.sendMessageToClient(room.messageSender.errorMessage(ErrorMessageType.DECKERROR, encodeDeckErrorCode(deckOrError.type, deckOrError.code)));
 			return;
 		}
 
@@ -232,7 +233,7 @@ export class YGOProWaitingState extends YGOProRoomState {
 			const failedCard = deck.allCards.find((c) => Number(c.code) === hasError.code);
 			this.logger.warn(`Deck validation error: type=0x${hasError.type.toString(16)}, code=${hasError.code}, cardOt=${failedCard?.variant ?? "N/A"}, rule=${room.hostInfo.rule}, extendedPool=${room.useExtendedCardPool}`);
 			room.notReadyUnsafe(player);
-			player.sendMessageToClient(room.messageSender.errorMessage(ErrorMessageType.DECKERROR, hasError.type));
+			player.sendMessageToClient(room.messageSender.errorMessage(ErrorMessageType.DECKERROR, encodeDeckErrorCode(hasError.type, hasError.code)));
 			return;
 		}
 


### PR DESCRIPTION
## Description / Descripción

Al rechazar un deck inválido, el server enviaba `STOC_ERROR_MSG` con el `DeckErrorType` crudo como `code` (ej. `6`). El cliente decodifica el subtipo de los 4 bits altos (`code >>> 28`) y la carta ofensora de los 28 bits bajos, así que un type crudo se leía como subtipo `0` → mensaje **genérico** ("deck inválido"), sin detalle ni carta.

Ahora el `code` se codifica con `YGOProLFListError.toPayload()` de `ygopro-lflist-encode` — `(((type & 0xF) << 28) | (cardId & 0x0FFFFFFF)) >>> 0` — **el mismo encoder que usa SRVPro2**. Cableado en los 4 sitios de rechazo de deck (`YGOProWaitingState`, `YGOProSideDeckingState`).

## Related Issue(s) / Issue(s) relacionado(s)

Sin issue formal. Bug detectado revisando el flujo de errores de deck: el cliente mostraba "deck inválido" genérico, sin el subtipo (banlist / conteo / etc.) ni la carta ofensora.

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [x] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

- TDD: RED → GREEN. Suite completa **576/576**, `tsc --noEmit` y `eslint` limpios.
- Usa la librería compartida `ygopro-lflist-encode ^1.0.3` (ya en deps, **misma versión que SRVPro2**) vía un helper thin `encodeDeckErrorCode` — single source of truth del encoding, sin lógica de bits a mano.
- **El cliente NO necesita cambios** — ya decodifica con `>>> 28`. Con el fix recibe el subtipo correcto y la carta ofensora, y muestra el mensaje específico.
- Los `DeckErrorType` del server 1..8 coinciden 1:1 con `YGOProLFListErrorReason`. Los tipos 9+ (sin equivalente en el cliente) caen en genérico — **no es regresión** (hoy TODO es genérico).
- Alcance: path activo `src/ygopro/`; no se tocó el muerto `src/edopro/`.
