### PR TITLE
feat(ticket): log consume rejections for ranked-auth observability

### DIFF
--- a/src/shared/ticket/infrastructure/redis/RedisTicketRepository.ts
+++ b/src/shared/ticket/infrastructure/redis/RedisTicketRepository.ts
@@ -1,4 +1,5 @@
 import { Redis } from "@shared/db/redis/infrastructure/Redis";
+import LoggerFactory from "@shared/logger/infrastructure/LoggerFactory";
 import { TicketRepository } from "../../domain/TicketRepository";
 
 /**
@@ -15,22 +16,42 @@ const UUID_RE =
  *  - UUID format validated before any Redis call (prevents key injection)
  *  - GETDEL is atomic: reads and deletes in one operation (replay prevention)
  *  - Fail-closed: returns null whenever Redis is unavailable (ranked status never granted)
+ *
+ * Every rejection is logged with its reason so ranked-auth failures are
+ * diagnosable in production (the consume result is otherwise just null).
  */
 export class RedisTicketRepository implements TicketRepository {
+  private readonly logger = LoggerFactory.getLogger({ file: "RedisTicketRepository" });
+
   async consume(uuid: string): Promise<string | null> {
     if (!UUID_RE.test(uuid)) {
+      this.logger.warn("Ticket consume rejected: token is not a valid UUID v4", {
+        uuidPreview: uuid.slice(0, 8),
+      });
       return null;
     }
 
     const redis = Redis.getInstance();
     if (!redis) {
+      this.logger.warn("Ticket consume rejected: no Redis instance available");
       return null;
     }
 
     try {
       const userId = await redis.getdel(`ticket:${uuid}`);
-      return userId ?? null;
-    } catch {
+      if (userId == null) {
+        this.logger.warn(
+          "Ticket consume rejected: key not found (expired, already consumed, or issued against a different Redis)",
+          { key: `ticket:${uuid}` },
+        );
+        return null;
+      }
+      this.logger.info("Ticket consumed", { key: `ticket:${uuid}`, userId });
+      return userId;
+    } catch (error) {
+      this.logger.error("Ticket consume rejected: Redis error (fail-closed)", {
+        error: error instanceof Error ? error.message : String(error),
+      });
       return null; // fail-closed: Redis error never grants ranked status
     }
   }


### PR DESCRIPTION
## Description / Descripción

`ticket.consume()` devolvía `null` pelado en cada fallo, así que los rechazos de autenticación ranked eran **indiagnosticables en producción**. Ahora cada rechazo se loguea con su motivo (UUID inválido, sin instancia de Redis, key no encontrada, error de Redis) + una línea `info` en el consumo exitoso.

Estos logs arrancaron como instrumentación temporal `TICKET_DIAG` mientras depurábamos el handshake ranked; se **promueven a logging estructurado permanente** porque el motivo es genuinamente útil en producción.

## Related Issue(s) / Issue(s) relacionado(s)

Sin issue formal. Surge de la depuración del flujo de tickets ranked (el `consume` devolvía `null` sin explicar por qué).

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [x] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

- **Comportamiento sin cambios**: mismo fail-closed, mismos `return null`. Solo se agregan logs (`userId ?? null` ≡ el `if/return`).
- Suite completa **561/561**, `tsc --noEmit` y `eslint` limpios. El test existente de `RedisTicketRepository` valida comportamiento (no strings de log), así que pasa sin cambios.
