### PR TITLE
fix(join): send ranked-reject JOINERROR with the ygopro serializer

### DIFF
--- a/src/edopro/room/application/JoinHandler.ts
+++ b/src/edopro/room/application/JoinHandler.ts
@@ -81,6 +81,9 @@ export class JoinHandler implements JoinMessageHandler {
 
 		if (room.ranked) {
 			if (!(await this.checkIfUseCanJoin.check(playerInfoMessage, this.socket))) {
+				// CheckIfUseCanJoin no longer sends the JOINERROR itself (its wire format is
+				// client-specific). edopro/desktop clients use the @edopro ErrorClientMessage.
+				this.socket.send(ErrorClientMessage.create(ErrorMessages.JOIN_ERROR));
 				return;
 			}
 		}

--- a/src/edopro/room/application/Reconnect.test.ts
+++ b/src/edopro/room/application/Reconnect.test.ts
@@ -36,6 +36,7 @@ describe("Reconnect", () => {
 
     mockSocket = {
       id: "socket-id",
+      send: jest.fn(),
     } as unknown as jest.Mocked<ISocket>;
 
     mockPlayer = {

--- a/src/edopro/room/application/Reconnect.ts
+++ b/src/edopro/room/application/Reconnect.ts
@@ -7,6 +7,8 @@ import { Client } from "../../client/domain/Client";
 import { JoinGameMessage } from "../../messages/client-to-server/JoinGameMessage";
 import { PlayerInfoMessage } from "../../messages/client-to-server/PlayerInfoMessage";
 import { JoinGameClientMessage } from "../../messages/server-to-client/JoinGameClientMessage";
+import { ErrorClientMessage } from "../../messages/server-to-client/ErrorClientMessage";
+import { ErrorMessages } from "../../messages/server-to-client/error-messages/ErrorMessages";
 import { Room } from "../domain/Room";
 
 export class Reconnect {
@@ -20,15 +22,10 @@ export class Reconnect {
 		room: Room
 	): Promise<void> {
 		if (room.ranked && !(await this.checkIfUseCanJoin.check(playerInfoMessage, socket))) {
+			// CheckIfUseCanJoin no longer sends the JOINERROR itself (its wire format is
+			// client-specific). edopro/desktop clients use the @edopro ErrorClientMessage.
+			socket.send(ErrorClientMessage.create(ErrorMessages.JOIN_ERROR));
 			return;
-
-			// if (!player.socket.id || !player.socket.closed) {
-			// 	socket.send(ServerErrorClientMessage.create("Ya el jugador se encuentra en la partida."));
-			// 	socket.send(ErrorClientMessage.create(ErrorMessages.JOIN_ERROR));
-			// 	socket.destroy();
-
-			// 	return;
-			// }
 		}
 
 		player.setSocket(socket, room.players as Client[], room);

--- a/src/shared/user-auth/application/CheckIfUserCanJoin.ts
+++ b/src/shared/user-auth/application/CheckIfUserCanJoin.ts
@@ -1,6 +1,4 @@
 import { PlayerInfoMessage } from "@edopro/messages/client-to-server/PlayerInfoMessage";
-import { ErrorMessages } from "@edopro/messages/server-to-client/error-messages/ErrorMessages";
-import { ErrorClientMessage } from "@edopro/messages/server-to-client/ErrorClientMessage";
 import { ISocket } from "src/shared/socket/domain/ISocket";
 import { UserProfile } from "src/shared/user-profile/domain/UserProfile";
 
@@ -9,11 +7,20 @@ import { UserAuth } from "./UserAuth";
 export class CheckIfUseCanJoin {
 	constructor(private readonly userAuth: UserAuth) {}
 
+	/**
+	 * Validates the player against the user store. On failure it sends the auth
+	 * detail (ServerErrorMessage, which the web client ignores) and returns false,
+	 * but it does NOT send the STOC_ERROR_MSG/JOINERROR itself: that frame's wire
+	 * format is client-specific. ygopro/web callers must serialize it through the
+	 * ygopro repository (8-byte body, code at offset 4); edopro callers use
+	 * ErrorClientMessage. Each caller sends the JOINERROR in its own format after a
+	 * false result, so the web client no longer receives the 5-byte @edopro frame
+	 * it cannot decode.
+	 */
 	async check(playerInfo: PlayerInfoMessage, socket: ISocket): Promise<boolean> {
 		const user = await this.userAuth.run(playerInfo);
 		if (!(user instanceof UserProfile)) {
 			socket.send(user as Buffer);
-			socket.send(ErrorClientMessage.create(ErrorMessages.JOIN_ERROR));
 
 			return false;
 		}

--- a/src/ygopro/room/application/join-strategies/DefaultJoinStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/DefaultJoinStrategy.test.ts
@@ -1,5 +1,7 @@
 import { EventEmitter } from "stream";
 
+import { ErrorMessageType } from "ygopro-msg-encode";
+
 import { JoinContext } from "./JoinStrategy";
 import { DefaultJoinStrategy } from "./DefaultJoinStrategy";
 import { YGOProRoom } from "../../domain/YGOProRoom";
@@ -175,6 +177,42 @@ describe("DefaultJoinStrategy", () => {
 
 			expect(socket.close).toHaveBeenCalled();
 			expect(emitSpy).not.toHaveBeenCalledWith("JOIN", expect.anything(), expect.anything());
+		});
+
+		it("sends the JOINERROR via messageRepository (ygopro 8-byte format) on ranked reject", async () => {
+			const emitter = new EventEmitter();
+			const room = YGOProRoom.create(
+				7778,
+				"RANKEDROOM2",
+				makeLogger() as never,
+				emitter,
+				{ name: "TestPlayer", password: "", previousMessage: Buffer.alloc(0) } as never,
+				"sock-original",
+				makeMessageRepository() as never,
+				true,
+			);
+			YGOProRoomList.addRoom(room);
+			jest.spyOn(room, "emit").mockImplementation(() => undefined);
+
+			const socket = makeSocket();
+			const ctxMessageRepo = makeMessageRepository();
+			const ctx = makeCtx({
+				rawPass: "RANKEDROOM2",
+				command: "RANKEDROOM2",
+				password: "",
+				socket: socket as never,
+				eventEmitter: emitter,
+				messageRepository: ctxMessageRepo as never,
+				checkIfUserCanJoin: { check: jest.fn().mockResolvedValue(false) } as never,
+			});
+
+			await strategy.handle(ctx);
+
+			// The reject must serialize the JOINERROR through the ygopro repository (same
+			// path as DECKERROR → YGOProStocErrorMsg, 8-byte body with code at offset 4),
+			// NOT the @edopro ErrorClientMessage (5-byte body) the web client cannot decode.
+			expect(ctxMessageRepo.errorMessage).toHaveBeenCalledWith(ErrorMessageType.JOINERROR, 0);
+			expect(socket.send).toHaveBeenCalled();
 		});
 
 		it("does NOT close the socket on the happy ranked path (check passes)", async () => {

--- a/src/ygopro/room/application/join-strategies/DefaultJoinStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/DefaultJoinStrategy.ts
@@ -1,5 +1,7 @@
 import { generateUniqueId } from "src/utils/generateUniqueId";
 
+import { ErrorMessageType } from "ygopro-msg-encode";
+
 import { JoinContext, JoinStrategy } from "./JoinStrategy";
 import { YGOProRoom } from "../../domain/YGOProRoom";
 import YGOProRoomList from "../../infrastructure/YGOProRoomList";
@@ -27,10 +29,15 @@ export class DefaultJoinStrategy implements JoinStrategy {
 		}
 
 		if (room.ranked && !(await ctx.checkIfUserCanJoin.check(ctx.playerInfo, ctx.socket))) {
-			// checkIfUserCanJoin already sent the JOIN_ERROR. Close the socket so the
-			// client gets a real disconnect instead of a live-but-useless connection it
-			// would keep reusing (the handshake — where the ticket travels — never re-runs
-			// otherwise). close() is graceful: the queued error frame is flushed first.
+			// Send the JOINERROR with the ygopro serializer (YGOProStocErrorMsg → 8-byte
+			// body, code at offset 4), the same path DECKERROR uses. checkIfUserCanJoin no
+			// longer sends it because the @edopro ErrorClientMessage it used has a 5-byte
+			// body the web client cannot decode ("Data too short: need 8 bytes, got 5").
+			ctx.socket.send(ctx.messageRepository.errorMessage(ErrorMessageType.JOINERROR, 0));
+			// Close the socket so the client gets a real disconnect instead of a
+			// live-but-useless connection it would keep reusing (the handshake — where the
+			// ticket travels — never re-runs otherwise). close() is graceful: the queued
+			// error frame is flushed first.
 			ctx.socket.close();
 			return;
 		}


### PR DESCRIPTION
## Description / Descripción

Al rechazar un join anónimo a una sala ranked, el cliente **web** no podía decodificar el `JOINERROR` (consola: `"Data too short: need 8 bytes, got 5 bytes"`) y el aviso nunca aparecía.

**Causa raíz:** `CheckIfUseCanJoin.check()` (en `src/shared`) mandaba el error vía `ErrorClientMessage` de `@edopro`, cuyo body de `STOC_ERROR_MSG` es `[msg:1][code:4]` = **5 bytes**, sin los 3 bytes de padding (struct alignment del `int` de ygopro). El cliente (`YGOProStocErrorMsg`) espera `[msg:1][pad:3][code:4]` = **8 bytes**, con `code` en offset 4. El `DECKERROR` ya funcionaba porque pasa por `YGOProMessageRepository.errorMessage()`.

**Fix (separar validación de presentación):** `CheckIfUseCanJoin` deja de mandar el `JOINERROR` (su formato depende del cliente) — solo manda el detalle de auth y devuelve `false`. Cada caller manda el `JOINERROR` en su formato:
- `DefaultJoinStrategy` (ygopro/web): `messageRepository.errorMessage(JOINERROR, 0)` → 8 bytes ✓
- `Reconnect` + `JoinHandler` (edopro/desktop): `ErrorClientMessage` → preservado (5 bytes)

## Related Issue(s) / Issue(s) relacionado(s)

Sin issue formal. Evidencia en vivo del cliente web (`"need 8 bytes, got 5 bytes"`). Misma familia que el fix del deck error (#263).

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [x] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

- TDD: RED → GREEN. Suite completa **577/577**, `tsc --noEmit` y `eslint` limpios.
- **Path edopro preservado**: `Reconnect`/`JoinHandler` reponen el `ErrorClientMessage` (el desktop sigue recibiendo su error en el formato de 5 bytes que espera). `CheckIfUseCanJoin` está en `src/shared`, por eso el cuidado de no cambiar el comportamiento de ambos paths.
- El `socket.send(user as Buffer)` (detalle de auth, proto `0xf3`) sigue en `check()`; el web lo ignora como "unknown STOC".
