### PR TITLE
fix(reconnect): revoke reconnection tokens on room teardown to stop TokenIndex leak

### DIFF
--- a/src/edopro/room/application/FinishDuelHandler.test.ts
+++ b/src/edopro/room/application/FinishDuelHandler.test.ts
@@ -78,6 +78,7 @@ describe("FinishDuelHandler", () => {
       clearSpectatorCache: jest.fn(),
       players: [mockClient1, mockClient2],
       spectators: [mockSpectator],
+      clients: [mockClient1, mockClient2, mockSpectator],
       score: "0-0",
       firstToPlay: 0,
       replay: mockReplay,

--- a/src/edopro/room/infrastructure/RoomList.test.ts
+++ b/src/edopro/room/infrastructure/RoomList.test.ts
@@ -1,0 +1,86 @@
+import RoomList from "./RoomList";
+import { Room } from "../domain/Room";
+import { TokenIndex } from "@shared/room/domain/TokenIndex";
+import { YgoClient } from "@shared/client/domain/YgoClient";
+
+interface FakeClient {
+	reconnectionToken: string | null;
+	clearReconnectionToken: jest.Mock;
+}
+
+const makeClient = (token: string | null = null): FakeClient => {
+	const client: FakeClient = {
+		reconnectionToken: token,
+		clearReconnectionToken: jest.fn(() => {
+			client.reconnectionToken = null;
+		}),
+	};
+	return client;
+};
+
+const makeRoom = (id: number, clients: FakeClient[] = []): Room =>
+	({
+		id,
+		clients,
+		destroy: jest.fn(),
+	}) as unknown as Room;
+
+const flushRooms = (): void => {
+	const rooms = RoomList.getRooms();
+	rooms.splice(0, rooms.length);
+};
+
+describe("RoomList.deleteRoom", () => {
+	beforeEach(() => {
+		TokenIndex.getInstance().clear();
+		flushRooms();
+	});
+
+	afterEach(() => {
+		TokenIndex.getInstance().clear();
+		flushRooms();
+	});
+
+	it("revokes every client's reconnection token from the global index", () => {
+		const client = makeClient("deadbeefdeadbeefdeadbeefdeadbeef");
+		const room = makeRoom(1, [client]);
+		TokenIndex.getInstance().register(
+			client.reconnectionToken!,
+			client as unknown as YgoClient,
+			room.id,
+		);
+		RoomList.addRoom(room);
+
+		RoomList.deleteRoom(room);
+
+		expect(
+			TokenIndex.getInstance().find("deadbeefdeadbeefdeadbeefdeadbeef"),
+		).toBeUndefined();
+		expect(client.clearReconnectionToken).toHaveBeenCalled();
+	});
+
+	it("leaves tokens belonging to OTHER rooms untouched", () => {
+		const room = makeRoom(1, [makeClient()]);
+		const otherToken = "cafebabecafebabecafebabecafebabe";
+		TokenIndex.getInstance().register(
+			otherToken,
+			makeClient(otherToken) as unknown as YgoClient,
+			9999,
+		);
+		RoomList.addRoom(room);
+
+		RoomList.deleteRoom(room);
+
+		expect(TokenIndex.getInstance().find(otherToken)).toBeDefined();
+	});
+
+	it("destroys the room and removes it from the list", () => {
+		const room = makeRoom(2);
+		RoomList.addRoom(room);
+
+		RoomList.deleteRoom(room);
+
+		expect(room.destroy).toHaveBeenCalled();
+		expect(RoomList.getRooms().find((r) => r.id === 2)).toBeUndefined();
+	});
+});

--- a/src/edopro/room/infrastructure/RoomList.ts
+++ b/src/edopro/room/infrastructure/RoomList.ts
@@ -1,3 +1,5 @@
+import { ReconnectionTokenIssuer } from "@shared/room/application/reconnect/ReconnectionTokenIssuer";
+
 import { type Room } from "../domain/Room";
 
 const rooms: Room[] = [];
@@ -11,7 +13,17 @@ export default {
 		return rooms;
 	},
 
+	// deleteRoom is the single funnel through which every edopro room is torn down
+	// (DisconnectHandler, FinishDuelHandler and Room itself all route here), so it
+	// is also where we revoke the players' reconnection tokens. Without this they
+	// leak into the global in-memory TokenIndex (no TTL) for the life of the
+	// process, pointing at destroyed clients. ygopro does the equivalent in
+	// FinalizeYGOProRoom — edopro has no such application-level teardown, so the
+	// infrastructure funnel is the natural home here.
 	deleteRoom(room: Room): void {
+		room.clients.forEach((client) => {
+			ReconnectionTokenIssuer.revoke(client);
+		});
 		room.destroy();
 		const index = rooms.findIndex((item) => item.id === room.id);
 		if (index !== -1) {

--- a/src/shared/room/application/reconnect/ReconnectionTokenIssuer.test.ts
+++ b/src/shared/room/application/reconnect/ReconnectionTokenIssuer.test.ts
@@ -9,6 +9,9 @@ const makeClient = (name = "P"): YgoClient => {
 		setReconnectionToken: jest.fn((value: string) => {
 			token = value;
 		}),
+		clearReconnectionToken: jest.fn(() => {
+			token = null;
+		}),
 		get reconnectionToken() {
 			return token;
 		},
@@ -68,6 +71,27 @@ describe("ReconnectionTokenIssuer", () => {
 			ReconnectionTokenIssuer.rotate(client, 3);
 
 			expect(client.reconnectionToken).toMatch(/^[0-9a-f]{32}$/);
+		});
+	});
+
+	describe("revoke", () => {
+		it("unregisters the client's token from the index and clears it on the client", () => {
+			const client = makeClient();
+			ReconnectionTokenIssuer.issue(client, 5);
+			const token = client.reconnectionToken!;
+			expect(TokenIndex.getInstance().find(token)).toBeDefined();
+
+			ReconnectionTokenIssuer.revoke(client);
+
+			expect(TokenIndex.getInstance().find(token)).toBeUndefined();
+			expect(client.reconnectionToken).toBeNull();
+		});
+
+		it("is a no-op when the client has no token", () => {
+			const client = makeClient();
+
+			expect(() => ReconnectionTokenIssuer.revoke(client)).not.toThrow();
+			expect(client.reconnectionToken).toBeNull();
 		});
 	});
 

--- a/src/shared/room/application/reconnect/ReconnectionTokenIssuer.ts
+++ b/src/shared/room/application/reconnect/ReconnectionTokenIssuer.ts
@@ -34,6 +34,19 @@ export class ReconnectionTokenIssuer {
 		return this.issue(client, roomId);
 	}
 
+	// Revoke the client's current token: de-register it from the global index and
+	// clear it on the client. Idempotent — safe to call on a client with no token.
+	// Called on room teardown so tokens never outlive their room: TokenIndex is an
+	// in-memory singleton with no TTL, so without this every finished match would
+	// leak its players' tokens (and leave them pointing at destroyed clients).
+	static revoke(client: YgoClient): void {
+		const token = client.reconnectionToken;
+		if (token) {
+			TokenIndex.getInstance().unregister(token);
+		}
+		client.clearReconnectionToken();
+	}
+
 	// Resolve a token to its owning client, but only if it belongs to `roomId`
 	// and passes the subtree's client-type guard. Returns null otherwise so the
 	// caller can reject the reconnect attempt.

--- a/src/ygopro/room/application/FinalizeYGOProRoom.test.ts
+++ b/src/ygopro/room/application/FinalizeYGOProRoom.test.ts
@@ -28,6 +28,8 @@ import { FinalizeYGOProRoom } from "./FinalizeYGOProRoom";
 import MercuryRoomList from "../infrastructure/YGOProRoomList";
 import WebSocketSingleton from "../../../web-socket-server/WebSocketSingleton";
 import { YGOProRoomMother } from "@test-support/mothers/room/YGOProRoomMother";
+import { TokenIndex } from "@shared/room/domain/TokenIndex";
+import { YgoClient } from "@shared/client/domain/YgoClient";
 
 // ---------- helpers ----------
 
@@ -60,12 +62,18 @@ const makeDeps = (overrides: Partial<WindbotModuleDeps> = {}): WindbotModuleDeps
 interface FakeClient {
 	socket: ReturnType<typeof makeSocket>;
 	destroy: jest.Mock;
+	reconnectionToken: string | null;
+	clearReconnectionToken: jest.Mock;
 }
 
 const makeClient = (socket = makeSocket()): FakeClient => {
 	const client: FakeClient = {
 		socket,
 		destroy: jest.fn(() => socket.destroy()),
+		reconnectionToken: null,
+		clearReconnectionToken: jest.fn(() => {
+			client.reconnectionToken = null;
+		}),
 	};
 	return client;
 };
@@ -87,11 +95,13 @@ describe("FinalizeYGOProRoom.run()", () => {
 
 	beforeEach(() => {
 		(mockInstance.broadcast as jest.Mock).mockClear();
+		TokenIndex.getInstance().clear();
 	});
 
 	afterEach(() => {
 		WindbotModule.resetForTests();
 		jest.restoreAllMocks();
+		TokenIndex.getInstance().clear();
 		const rooms = MercuryRoomList.getRooms();
 		while (rooms.length) {
 			MercuryRoomList.deleteRoom(rooms[0]);
@@ -168,5 +178,29 @@ describe("FinalizeYGOProRoom.run()", () => {
 	it("does not throw when windbot is not initialized", () => {
 		const room = createRoomInList();
 		expect(() => FinalizeYGOProRoom.run(room)).not.toThrow();
+	});
+
+	it("revokes every client's reconnection token from the global index", () => {
+		const client = makeClient(makeSocket(true));
+		const room = createRoomInList([client]);
+		const token = "deadbeefdeadbeefdeadbeefdeadbeef";
+		client.reconnectionToken = token;
+		TokenIndex.getInstance().register(token, client as unknown as YgoClient, room.id);
+
+		FinalizeYGOProRoom.run(room);
+
+		expect(TokenIndex.getInstance().find(token)).toBeUndefined();
+		expect(client.clearReconnectionToken).toHaveBeenCalled();
+	});
+
+	it("leaves tokens belonging to OTHER rooms untouched", () => {
+		const client = makeClient(makeSocket(true));
+		const room = createRoomInList([client]);
+		const otherToken = "cafebabecafebabecafebabecafebabe";
+		TokenIndex.getInstance().register(otherToken, makeClient() as unknown as YgoClient, 9999);
+
+		FinalizeYGOProRoom.run(room);
+
+		expect(TokenIndex.getInstance().find(otherToken)).toBeDefined();
 	});
 });

--- a/src/ygopro/room/application/FinalizeYGOProRoom.ts
+++ b/src/ygopro/room/application/FinalizeYGOProRoom.ts
@@ -3,6 +3,7 @@ import { YGOProClient } from "@ygopro/client/domain/YGOProClient";
 import { YGOProRoom } from "../domain/YGOProRoom";
 import MercuryRoomList from "@ygopro/room/infrastructure/YGOProRoomList";
 import WebSocketSingleton from "../../../web-socket-server/WebSocketSingleton";
+import { ReconnectionTokenIssuer } from "@shared/room/application/reconnect/ReconnectionTokenIssuer";
 
 /**
  * Canonical teardown for a YGOPro room. Centralizes the sequence previously
@@ -11,8 +12,10 @@ import WebSocketSingleton from "../../../web-socket-server/WebSocketSingleton";
  * Order is significant:
  *   1. finalizing = true — aborts any in-flight windbot retry loop before anything else.
  *   2. windbot token cleanup — no-op when windbot is uninitialized or disabled.
- *   3. close any still-open client sockets — MercuryRoomList.deleteRoom does NOT do this,
- *      so an orphaned bot would otherwise keep its socket alive.
+ *   3. revoke each client's reconnection token + close any still-open socket —
+ *      MercuryRoomList.deleteRoom does NOT do either, so without this an orphaned
+ *      bot keeps its socket alive AND every player's token leaks into the global
+ *      in-memory TokenIndex (which has no TTL) for the lifetime of the process.
  *   4. delete the room from the list.
  *   5. broadcast REMOVE-ROOM so the real-time room list updates.
  */
@@ -23,6 +26,7 @@ export class FinalizeYGOProRoom {
 		WindbotModule.cleanupRoomIfEnabled(room.id);
 
 		(room.clients as YGOProClient[]).forEach((client) => {
+			ReconnectionTokenIssuer.revoke(client);
 			if (!client.socket.closed) {
 				client.destroy();
 			}


### PR DESCRIPTION
## Description / Descripción

Fixes a memory leak in the shared reconnection-token layer: reconnection tokens were only unregistered on **rotation** (a successful reconnect), so the token a player still held when a duel/room ended leaked into the global in-memory `TokenIndex` (which has **no TTL**) for the lifetime of the process, left pointing at destroyed clients.

The fix adds `ReconnectionTokenIssuer.revoke()` to the shared layer (de-register from the index + clear the token on the client; idempotent) and calls it for every client at room teardown — the single funnel in each subtree:
- **ygopro:** `FinalizeYGOProRoom.run` (canonical teardown funnel).
- **edopro:** `RoomList.deleteRoom` (single delete funnel; this subtree has no application-level teardown like ygopro's, so the infrastructure funnel is the natural home — documented in code).

`YgoClient.clearReconnectionToken()` was previously dead code; it is now used.

## Related Issue(s) / Issue(s) relacionado(s)

N/A — found during a code audit of the ygopro duel reconnect/disconnect flow.

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [ ] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

Built strictly TDD (RED → GREEN) per subtree.

| File | Change |
|------|--------|
| `src/shared/.../ReconnectionTokenIssuer.ts` | New `revoke(client)` — unregister from `TokenIndex` + `clearReconnectionToken` (idempotent). |
| `src/ygopro/.../FinalizeYGOProRoom.ts` | Revoke each client's token during teardown. |
| `src/edopro/.../RoomList.ts` | Revoke each client's token in `deleteRoom` (the edopro teardown funnel). |
| `*.test.ts` | New `RoomList.test.ts`; extended `ReconnectionTokenIssuer`, `FinalizeYGOProRoom` and `FinishDuelHandler` tests. |

Adding the `room.clients` iteration to `deleteRoom` surfaced an incomplete mock in `FinishDuelHandler.test.ts` (it stubbed `players`/`spectators` but not the `clients` getter, which is never `undefined` on a real `Room`). Fixed the mock rather than adding a defensive `?? []` in production code.

**Local verification:** `npm run lint` ✓ · `tsc --noEmit` ✓ · `npm test` → 73 suites, 660 tests ✓