### PR TITLE
feat(admission): add pure admission domain + credential resolver

### DIFF
--- a/src/shared/room/admission/domain/Admission.ts
+++ b/src/shared/room/admission/domain/Admission.ts
@@ -1,0 +1,17 @@
+import { PlayerCredential } from "./PlayerCredential";
+import { Seat } from "./Seat";
+
+/** Why a client was turned away entirely (not even allowed to watch). */
+export type AdmissionRejection = "ranked-requires-account";
+
+/**
+ * The outcome of asking "can this client be admitted, and how?".
+ *
+ * - `player`:    sit down to play — got both the door and a free seat.
+ * - `spectator`: watch from the stands — has the door, not the seat.
+ * - `rejected`:  not even allowed in.
+ */
+export type Admission =
+	| { readonly kind: "player"; readonly credential: PlayerCredential; readonly seat: Seat }
+	| { readonly kind: "spectator" }
+	| { readonly kind: "rejected"; readonly reason: AdmissionRejection };

--- a/src/shared/room/admission/domain/PlayerCredential.ts
+++ b/src/shared/room/admission/domain/PlayerCredential.ts
@@ -1,0 +1,14 @@
+/**
+ * Who is knocking at the room's door, and with which key.
+ *
+ * - `verified`: authenticated via the strong handshake ticket (evolution client).
+ * - `external`: authenticated via the legacy 4-char PIN carried in the nickname.
+ * - `guest`:    no valid credential — only a display name.
+ *
+ * `verified` and `external` carry the SAME account id; what differs is how
+ * strongly it was proven. `guest` carries no identity at all.
+ */
+export type PlayerCredential =
+  | { readonly kind: "verified"; readonly userId: string }
+  | { readonly kind: "external"; readonly userId: string }
+  | { readonly kind: "guest"; readonly name: string };

--- a/src/shared/room/admission/domain/RoomAdmission.test.ts
+++ b/src/shared/room/admission/domain/RoomAdmission.test.ts
@@ -1,0 +1,67 @@
+import { PlayerCredential } from "./PlayerCredential";
+import { RoomAdmission } from "./RoomAdmission";
+import { RoomLeague } from "./RoomLeague";
+import { Seat } from "./Seat";
+
+const verified: PlayerCredential = { kind: "verified", userId: "u-1" };
+const external: PlayerCredential = { kind: "external", userId: "u-2" };
+const guest: PlayerCredential = { kind: "guest", name: "Anon" };
+
+const freeSeat = new Seat(0, 0);
+
+describe("RoomAdmission.decide", () => {
+	const admission = new RoomAdmission();
+
+	describe("ranked rooms require an account even to watch", () => {
+		it("rejects a guest in a Verified room", () => {
+			const result = admission.decide(guest, { league: RoomLeague.Verified, freeSeat });
+			expect(result).toEqual({ kind: "rejected", reason: "ranked-requires-account" });
+		});
+
+		it("rejects a guest in an External room", () => {
+			const result = admission.decide(guest, { league: RoomLeague.External, freeSeat });
+			expect(result).toEqual({ kind: "rejected", reason: "ranked-requires-account" });
+		});
+	});
+
+	describe("segregation: a player only sits at its matching league", () => {
+		it("seats a verified player in a Verified room", () => {
+			const result = admission.decide(verified, { league: RoomLeague.Verified, freeSeat });
+			expect(result).toEqual({ kind: "player", credential: verified, seat: freeSeat });
+		});
+
+		it("seats an external player in an External room", () => {
+			const result = admission.decide(external, { league: RoomLeague.External, freeSeat });
+			expect(result).toEqual({ kind: "player", credential: external, seat: freeSeat });
+		});
+
+		it("an external (authenticated) in a Verified room only watches", () => {
+			const result = admission.decide(external, { league: RoomLeague.Verified, freeSeat });
+			expect(result).toEqual({ kind: "spectator" });
+		});
+
+		it("a verified (authenticated) in an External room only watches", () => {
+			const result = admission.decide(verified, { league: RoomLeague.External, freeSeat });
+			expect(result).toEqual({ kind: "spectator" });
+		});
+	});
+
+	describe("a matching player watches when the room is full", () => {
+		it("verified in a full Verified room → spectator", () => {
+			const result = admission.decide(verified, { league: RoomLeague.Verified, freeSeat: null });
+			expect(result).toEqual({ kind: "spectator" });
+		});
+	});
+
+	describe("casual rooms admit anyone with a free seat", () => {
+		it("seats a guest in casual", () => {
+			const result = admission.decide(guest, { league: RoomLeague.Casual, freeSeat });
+			expect(result).toEqual({ kind: "player", credential: guest, seat: freeSeat });
+		});
+
+		it("a guest watches a full casual room (never rejected)", () => {
+			const result = admission.decide(guest, { league: RoomLeague.Casual, freeSeat: null });
+			expect(result).toEqual({ kind: "spectator" });
+		});
+	});
+});

--- a/src/shared/room/admission/domain/RoomAdmission.ts
+++ b/src/shared/room/admission/domain/RoomAdmission.ts
@@ -1,0 +1,45 @@
+import { Admission } from "./Admission";
+import { PlayerCredential } from "./PlayerCredential";
+import { RoomLeague } from "./RoomLeague";
+import { Seat } from "./Seat";
+
+/**
+ * The minimum a room must expose for an admission decision — nothing about
+ * sockets, messages or persistence. Keeping the policy free of those is what
+ * makes it a pure, table-testable function.
+ */
+export interface AdmissionContext {
+	readonly league: RoomLeague;
+	readonly freeSeat: Seat | null;
+}
+
+/**
+ * The single source of truth for "can this client be admitted, and how?".
+ *
+ * Pure function, no side effects. The whole business contract lives in these
+ * three steps, in order:
+ *
+ *   1. Ranked rooms require an account even to WATCH → a guest is rejected.
+ *   2. A client only SITS in a league that matches its credential
+ *      (segregation); otherwise it watches.
+ *   3. With a matching credential, sit if there is a free seat, else watch.
+ *
+ * Mental model — two keys: the door (handled upstream + step 1) and the seat
+ * (steps 2-3). "Wrong method → watch" and "room full → watch" are the same
+ * thing: you have the door, not the seat.
+ */
+export class RoomAdmission {
+	decide(credential: PlayerCredential, context: AdmissionContext): Admission {
+		if (context.league.isRanked && credential.kind === "guest") {
+			return { kind: "rejected", reason: "ranked-requires-account" };
+		}
+
+		if (!context.league.admitsAsPlayer(credential)) {
+			return { kind: "spectator" };
+		}
+
+		return context.freeSeat
+			? { kind: "player", credential, seat: context.freeSeat }
+			: { kind: "spectator" };
+	}
+}

--- a/src/shared/room/admission/domain/RoomLeague.test.ts
+++ b/src/shared/room/admission/domain/RoomLeague.test.ts
@@ -1,0 +1,36 @@
+import { PlayerCredential } from "./PlayerCredential";
+import { RoomLeague } from "./RoomLeague";
+
+const verified: PlayerCredential = { kind: "verified", userId: "u-1" };
+const external: PlayerCredential = { kind: "external", userId: "u-2" };
+const guest: PlayerCredential = { kind: "guest", name: "Anon" };
+
+describe("RoomLeague", () => {
+	describe("isRanked", () => {
+		it("Verified and External are ranked, Casual is not", () => {
+			expect(RoomLeague.Verified.isRanked).toBe(true);
+			expect(RoomLeague.External.isRanked).toBe(true);
+			expect(RoomLeague.Casual.isRanked).toBe(false);
+		});
+	});
+
+	describe("admitsAsPlayer", () => {
+		it("Casual admits anyone", () => {
+			expect(RoomLeague.Casual.admitsAsPlayer(verified)).toBe(true);
+			expect(RoomLeague.Casual.admitsAsPlayer(external)).toBe(true);
+			expect(RoomLeague.Casual.admitsAsPlayer(guest)).toBe(true);
+		});
+
+		it("Verified admits ONLY verified credentials", () => {
+			expect(RoomLeague.Verified.admitsAsPlayer(verified)).toBe(true);
+			expect(RoomLeague.Verified.admitsAsPlayer(external)).toBe(false);
+			expect(RoomLeague.Verified.admitsAsPlayer(guest)).toBe(false);
+		});
+
+		it("External admits ONLY external credentials", () => {
+			expect(RoomLeague.External.admitsAsPlayer(external)).toBe(true);
+			expect(RoomLeague.External.admitsAsPlayer(verified)).toBe(false);
+			expect(RoomLeague.External.admitsAsPlayer(guest)).toBe(false);
+		});
+	});
+});

--- a/src/shared/room/admission/domain/RoomLeague.ts
+++ b/src/shared/room/admission/domain/RoomLeague.ts
@@ -1,0 +1,36 @@
+import { PlayerCredential } from "./PlayerCredential";
+
+/**
+ * The "league" a room belongs to — it decides who may SIT DOWN to play.
+ *
+ * - `Verified`: ranked, only ticket-authenticated players.
+ * - `External`: ranked, only PIN-authenticated players.
+ * - `Casual`:   anyone may play.
+ *
+ * The two ranked leagues are SEGREGATED: a player only sits at the league that
+ * matches how they authenticated. A mismatched-but-authenticated client is not
+ * rejected here — it falls back to spectating, a decision that belongs to
+ * RoomAdmission, not to the league itself.
+ */
+export class RoomLeague {
+	private constructor(private readonly kind: "verified" | "external" | "casual") {}
+
+	static readonly Verified = new RoomLeague("verified");
+	static readonly External = new RoomLeague("external");
+	static readonly Casual = new RoomLeague("casual");
+
+	get isRanked(): boolean {
+		return this.kind !== "casual";
+	}
+
+	admitsAsPlayer(credential: PlayerCredential): boolean {
+		switch (this.kind) {
+			case "casual":
+				return true;
+			case "verified":
+				return credential.kind === "verified";
+			case "external":
+				return credential.kind === "external";
+		}
+	}
+}

--- a/src/shared/room/admission/domain/Seat.ts
+++ b/src/shared/room/admission/domain/Seat.ts
@@ -1,0 +1,9 @@
+/**
+ * A concrete place at the duel table: a position and the team it belongs to.
+ */
+export class Seat {
+	constructor(
+		public readonly position: number,
+		public readonly team: number,
+	) {}
+}

--- a/src/ygopro/room/admission/application/CredentialResolver.test.ts
+++ b/src/ygopro/room/admission/application/CredentialResolver.test.ts
@@ -1,0 +1,89 @@
+import { PlayerInfoMessage } from "@edopro/messages/client-to-server/PlayerInfoMessage";
+import { ISocket } from "@shared/socket/domain/ISocket";
+import { UserAuth } from "@shared/user-auth/application/UserAuth";
+import { UserProfile } from "@shared/user-profile/domain/UserProfile";
+import { UserProfileRepository } from "@shared/user-profile/domain/UserProfileRepository";
+import { ServerErrorClientMessage } from "@edopro/messages/server-to-client/ServerErrorMessageClientMessage";
+
+import { CredentialResolver } from "./CredentialResolver";
+
+const profile = (id: string): UserProfile =>
+	UserProfile.from({ id, username: "Player", password: "hash", email: "e@e", avatar: null });
+
+const socketWith = (resolvedUserId: string | null): ISocket =>
+	({ resolvedUserId }) as unknown as ISocket;
+
+const playerInfo = (name: string, password: string | null): PlayerInfoMessage =>
+	({ name, password }) as unknown as PlayerInfoMessage;
+
+describe("CredentialResolver", () => {
+	let repo: jest.Mocked<UserProfileRepository>;
+	let userAuth: jest.Mocked<UserAuth>;
+	let resolver: CredentialResolver;
+
+	beforeEach(() => {
+		repo = {
+			create: jest.fn(),
+			findByUsername: jest.fn(),
+			findById: jest.fn(),
+			isBanned: jest.fn(),
+		};
+		userAuth = { run: jest.fn() } as unknown as jest.Mocked<UserAuth>;
+		resolver = new CredentialResolver(repo, userAuth);
+	});
+
+	describe("ticket (handshake) → verified", () => {
+		it("resolves a verified credential when the profile exists and is not banned", async () => {
+			repo.findById.mockResolvedValue(profile("u-1"));
+			repo.isBanned.mockResolvedValue(false);
+
+			const credential = await resolver.resolve(socketWith("u-1"), playerInfo("Player", null));
+
+			expect(credential).toEqual({ kind: "verified", userId: "u-1" });
+		});
+
+		it("falls back to guest when the ticket's profile no longer exists", async () => {
+			repo.findById.mockResolvedValue(null);
+
+			const credential = await resolver.resolve(socketWith("u-1"), playerInfo("Player", null));
+
+			expect(credential).toEqual({ kind: "guest", name: "Player" });
+		});
+
+		it("falls back to guest when the ticket's profile is banned", async () => {
+			repo.findById.mockResolvedValue(profile("u-1"));
+			repo.isBanned.mockResolvedValue(true);
+
+			const credential = await resolver.resolve(socketWith("u-1"), playerInfo("Player", null));
+
+			expect(credential).toEqual({ kind: "guest", name: "Player" });
+		});
+	});
+
+	describe("PIN (nickname) → external", () => {
+		it("resolves an external credential when UserAuth accepts the PIN", async () => {
+			userAuth.run.mockResolvedValue(profile("u-2"));
+
+			const credential = await resolver.resolve(socketWith(null), playerInfo("Player", "1234"));
+
+			expect(credential).toEqual({ kind: "external", userId: "u-2" });
+		});
+
+		it("falls back to guest when the PIN is invalid", async () => {
+			userAuth.run.mockResolvedValue({} as ServerErrorClientMessage);
+
+			const credential = await resolver.resolve(socketWith(null), playerInfo("Player", "9999"));
+
+			expect(credential).toEqual({ kind: "guest", name: "Player" });
+		});
+	});
+
+	describe("no credential → guest", () => {
+		it("resolves a guest when there is neither ticket nor PIN", async () => {
+			const credential = await resolver.resolve(socketWith(null), playerInfo("Player", null));
+
+			expect(credential).toEqual({ kind: "guest", name: "Player" });
+			expect(userAuth.run).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/ygopro/room/admission/application/CredentialResolver.ts
+++ b/src/ygopro/room/admission/application/CredentialResolver.ts
@@ -1,0 +1,47 @@
+import { PlayerInfoMessage } from "@edopro/messages/client-to-server/PlayerInfoMessage";
+import { PlayerCredential } from "@shared/room/admission/domain/PlayerCredential";
+import { ISocket } from "@shared/socket/domain/ISocket";
+import { UserAuth } from "@shared/user-auth/application/UserAuth";
+import { UserProfile } from "@shared/user-profile/domain/UserProfile";
+import { UserProfileRepository } from "@shared/user-profile/domain/UserProfileRepository";
+
+/**
+ * Turns "how the client connected" into a single PlayerCredential, in ONE pass.
+ *
+ * This is what kills the historical double-auth: identity is resolved here once
+ * and handed to the admission policy as a value — nobody re-validates downstream.
+ *
+ * Strength order, strongest first:
+ *   1. handshake ticket (socket.resolvedUserId) → verified
+ *   2. legacy PIN in the nickname               → external
+ *   3. neither / invalid                        → guest
+ *
+ * An invalid/banned ticket or a wrong PIN does NOT reject here — it degrades to
+ * `guest`. Whether a guest is allowed in is the admission policy's call, not
+ * the resolver's (single responsibility).
+ */
+export class CredentialResolver {
+	constructor(
+		private readonly userProfileRepository: UserProfileRepository,
+		private readonly userAuth: UserAuth,
+	) {}
+
+	async resolve(socket: ISocket, playerInfo: PlayerInfoMessage): Promise<PlayerCredential> {
+		if (socket.resolvedUserId) {
+			const profile = await this.userProfileRepository.findById(socket.resolvedUserId);
+			if (profile && !(await this.userProfileRepository.isBanned(profile.id))) {
+				return { kind: "verified", userId: profile.id };
+			}
+			return { kind: "guest", name: playerInfo.name };
+		}
+
+		if (playerInfo.password) {
+			const user = await this.userAuth.run(playerInfo);
+			if (user instanceof UserProfile) {
+				return { kind: "external", userId: user.id };
+			}
+		}
+
+		return { kind: "guest", name: playerInfo.name };
+	}
+}


### PR DESCRIPTION
## Description / Descripción

First slice of the redesigned **room connection flow** (Layer 3 — admission). This PR is **purely additive**: it introduces a clean, pure admission domain plus its identity resolver, **without touching any existing code or changing any behavior**. Wiring it into the join flow comes in a later PR.

It encodes the business contract we agreed on:
- **Ranked is segregated by auth method**: a Verified (ticket) room only seats ticket players; an External (PIN) room only seats PIN players. Casual is mixed.
- **Watching a ranked room requires an account** (a guest is turned away).
- **Two keys**: the door (handled upstream) vs the seat (this domain). "Wrong method → watch" and "room full → watch" become the same rule.
- **Single-pass identity**: the resolver removes the historical double-auth on the join path.

## Related Issue(s) / Issue(s) relacionado(s)

N/A — part of an ongoing connection-flow redesign.

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [ ] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

**Layout** — domain is transport-agnostic (shared), application lives per-subtree:

| File | Role |
|------|------|
| `src/shared/room/admission/domain/PlayerCredential.ts` | `verified \| external \| guest` |
| `src/shared/room/admission/domain/RoomLeague.ts` | `Verified/External/Casual` + `admitsAsPlayer` (segregation) |
| `src/shared/room/admission/domain/Admission.ts` | `player \| spectator \| rejected` |
| `src/shared/room/admission/domain/Seat.ts` | position + team VO |
| `src/shared/room/admission/domain/RoomAdmission.ts` | **pure** `decide()` — the whole contract |
| `src/ygopro/room/admission/application/CredentialResolver.ts` | identity in one pass (ticket/PIN/guest) |

`RoomAdmission.decide` is a pure function (no sockets/DB), so its tests are the business-contract table.

**Local verification:** `npm run lint` ✓ · `tsc --noEmit` ✓ · `npm test` → 76 suites, 679 tests ✓ (19 new, all green)