### PR TITLE
feat(admission): determine room league + AdmitToRoom use case

### DIFF
--- a/src/shared/room/admission/domain/RoomLeague.test.ts
+++ b/src/shared/room/admission/domain/RoomLeague.test.ts
@@ -14,6 +14,38 @@ describe("RoomLeague", () => {
 		});
 	});
 
+	describe("determine — which league a room is born into", () => {
+		it("the explicit casual flag wins over everything", () => {
+			expect(
+				RoomLeague.determine({ casual: true, rankedOverride: true, hasPin: true }),
+			).toBe(RoomLeague.Casual);
+		});
+
+		it("a ticket-created room is Verified", () => {
+			expect(
+				RoomLeague.determine({ casual: false, rankedOverride: true, hasPin: false }),
+			).toBe(RoomLeague.Verified);
+		});
+
+		it("an explicit non-ranked override is Casual (e.g. rooms vs bot)", () => {
+			expect(
+				RoomLeague.determine({ casual: false, rankedOverride: false, hasPin: true }),
+			).toBe(RoomLeague.Casual);
+		});
+
+		it("a PIN-created room (no override) is External", () => {
+			expect(
+				RoomLeague.determine({ casual: false, rankedOverride: undefined, hasPin: true }),
+			).toBe(RoomLeague.External);
+		});
+
+		it("no credential and no override is Casual", () => {
+			expect(
+				RoomLeague.determine({ casual: false, rankedOverride: undefined, hasPin: false }),
+			).toBe(RoomLeague.Casual);
+		});
+	});
+
 	describe("admitsAsPlayer", () => {
 		it("Casual admits anyone", () => {
 			expect(RoomLeague.Casual.admitsAsPlayer(verified)).toBe(true);

--- a/src/shared/room/admission/domain/RoomLeague.ts
+++ b/src/shared/room/admission/domain/RoomLeague.ts
@@ -19,6 +19,33 @@ export class RoomLeague {
 	static readonly External = new RoomLeague("external");
 	static readonly Casual = new RoomLeague("casual");
 
+	/**
+	 * Which league a room is born into, from how its host created it. Centralizes
+	 * the rule that used to live as `casual ? false : (rankedOverride ?? hasPin)`
+	 * and additionally distinguishes the ranked TYPE by its source:
+	 *   - explicit `casual` flag wins → Casual
+	 *   - ticket host (rankedOverride === true) → Verified
+	 *   - explicit non-ranked override (=== false) → Casual (e.g. rooms vs bot)
+	 *   - PIN host (no override) → External
+	 *   - otherwise → Casual
+	 */
+	static determine(input: {
+		casual: boolean;
+		rankedOverride: boolean | undefined;
+		hasPin: boolean;
+	}): RoomLeague {
+		if (input.casual) {
+			return RoomLeague.Casual;
+		}
+		if (input.rankedOverride === true) {
+			return RoomLeague.Verified;
+		}
+		if (input.rankedOverride === false) {
+			return RoomLeague.Casual;
+		}
+		return input.hasPin ? RoomLeague.External : RoomLeague.Casual;
+	}
+
 	get isRanked(): boolean {
 		return this.kind !== "casual";
 	}

--- a/src/ygopro/room/admission/application/AdmitToRoom.test.ts
+++ b/src/ygopro/room/admission/application/AdmitToRoom.test.ts
@@ -1,0 +1,81 @@
+import { PlayerInfoMessage } from "@edopro/messages/client-to-server/PlayerInfoMessage";
+import { PlayerCredential } from "@shared/room/admission/domain/PlayerCredential";
+import { RoomAdmission } from "@shared/room/admission/domain/RoomAdmission";
+import { RoomLeague } from "@shared/room/admission/domain/RoomLeague";
+import { Seat } from "@shared/room/admission/domain/Seat";
+import { ISocket } from "@shared/socket/domain/ISocket";
+
+import { AdmissionTarget, AdmitToRoom } from "./AdmitToRoom";
+import { CredentialResolver } from "./CredentialResolver";
+
+const socket = {} as ISocket;
+const playerInfo = { name: "P", password: null } as unknown as PlayerInfoMessage;
+
+const verified: PlayerCredential = { kind: "verified", userId: "u-1" };
+const external: PlayerCredential = { kind: "external", userId: "u-2" };
+const guest: PlayerCredential = { kind: "guest", name: "P" };
+
+const makeTarget = (league: RoomLeague, freeSeat: Seat | null): jest.Mocked<AdmissionTarget> =>
+	({
+		league,
+		freeSeat: jest.fn().mockReturnValue(freeSeat),
+		seatPlayer: jest.fn(),
+		admitSpectator: jest.fn(),
+		rejectAdmission: jest.fn(),
+	}) as unknown as jest.Mocked<AdmissionTarget>;
+
+describe("AdmitToRoom", () => {
+	let resolver: jest.Mocked<CredentialResolver>;
+	let admit: AdmitToRoom;
+
+	beforeEach(() => {
+		resolver = { resolve: jest.fn() } as unknown as jest.Mocked<CredentialResolver>;
+		admit = new AdmitToRoom(resolver, new RoomAdmission());
+	});
+
+	it("seats a matching player when there is a free seat", async () => {
+		resolver.resolve.mockResolvedValue(verified);
+		const seat = new Seat(0, 0);
+		const target = makeTarget(RoomLeague.Verified, seat);
+
+		const result = await admit.run(socket, playerInfo, target);
+
+		expect(target.seatPlayer).toHaveBeenCalledWith(verified, seat);
+		expect(target.admitSpectator).not.toHaveBeenCalled();
+		expect(result.kind).toBe("player");
+	});
+
+	it("admits as spectator when the method is wrong for the league", async () => {
+		resolver.resolve.mockResolvedValue(external); // external in a Verified room
+		const target = makeTarget(RoomLeague.Verified, new Seat(0, 0));
+
+		const result = await admit.run(socket, playerInfo, target);
+
+		expect(target.admitSpectator).toHaveBeenCalledTimes(1);
+		expect(target.seatPlayer).not.toHaveBeenCalled();
+		expect(result.kind).toBe("spectator");
+	});
+
+	it("rejects a guest from a ranked room", async () => {
+		resolver.resolve.mockResolvedValue(guest);
+		const target = makeTarget(RoomLeague.Verified, new Seat(0, 0));
+
+		const result = await admit.run(socket, playerInfo, target);
+
+		expect(target.rejectAdmission).toHaveBeenCalledWith("ranked-requires-account");
+		expect(target.seatPlayer).not.toHaveBeenCalled();
+		expect(target.admitSpectator).not.toHaveBeenCalled();
+		expect(result.kind).toBe("rejected");
+	});
+
+	it("seats a guest in a casual room (no free-seat check skipped)", async () => {
+		resolver.resolve.mockResolvedValue(guest);
+		const seat = new Seat(1, 1);
+		const target = makeTarget(RoomLeague.Casual, seat);
+
+		const result = await admit.run(socket, playerInfo, target);
+
+		expect(target.seatPlayer).toHaveBeenCalledWith(guest, seat);
+		expect(result.kind).toBe("player");
+	});
+});

--- a/src/ygopro/room/admission/application/AdmitToRoom.ts
+++ b/src/ygopro/room/admission/application/AdmitToRoom.ts
@@ -1,0 +1,64 @@
+import { PlayerInfoMessage } from "@edopro/messages/client-to-server/PlayerInfoMessage";
+import { Admission, AdmissionRejection } from "@shared/room/admission/domain/Admission";
+import { PlayerCredential } from "@shared/room/admission/domain/PlayerCredential";
+import { RoomAdmission } from "@shared/room/admission/domain/RoomAdmission";
+import { RoomLeague } from "@shared/room/admission/domain/RoomLeague";
+import { Seat } from "@shared/room/admission/domain/Seat";
+import { ISocket } from "@shared/socket/domain/ISocket";
+
+import { CredentialResolver } from "./CredentialResolver";
+
+/**
+ * What AdmitToRoom needs from the room to EXECUTE a decision. The room (or an
+ * adapter around it) implements this; the use case never touches sockets,
+ * wire messages or persistence — that keeps it transport-agnostic and testable
+ * (Dependency Inversion).
+ */
+export interface AdmissionTarget {
+	readonly league: RoomLeague;
+	freeSeat(): Seat | null;
+	seatPlayer(credential: PlayerCredential, seat: Seat): Promise<void>;
+	admitSpectator(): Promise<void>;
+	rejectAdmission(reason: AdmissionRejection): void;
+}
+
+/**
+ * The single guard that decides AND applies how a connecting client is admitted
+ * to a room. Reused at both doors — the JOIN and the spectator→player switch —
+ * so the rule "sitting down always passes admission" cannot be bypassed.
+ *
+ * Flow: resolve identity once → ask the pure policy → apply the outcome on the
+ * target. The contract itself lives in RoomAdmission; this only wires it up.
+ */
+export class AdmitToRoom {
+	constructor(
+		private readonly resolver: CredentialResolver,
+		private readonly admission: RoomAdmission,
+	) {}
+
+	async run(
+		socket: ISocket,
+		playerInfo: PlayerInfoMessage,
+		target: AdmissionTarget,
+	): Promise<Admission> {
+		const credential = await this.resolver.resolve(socket, playerInfo);
+		const result = this.admission.decide(credential, {
+			league: target.league,
+			freeSeat: target.freeSeat(),
+		});
+
+		switch (result.kind) {
+			case "player":
+				await target.seatPlayer(result.credential, result.seat);
+				break;
+			case "spectator":
+				await target.admitSpectator();
+				break;
+			case "rejected":
+				target.rejectAdmission(result.reason);
+				break;
+		}
+
+		return result;
+	}
+}

--- a/src/ygopro/room/domain/YGOProRoom.ts
+++ b/src/ygopro/room/domain/YGOProRoom.ts
@@ -5,6 +5,7 @@ import { PlayerInfoMessage } from "@edopro/messages/client-to-server/PlayerInfoM
 import { RoomState } from "@edopro/room/domain/RoomState";
 
 import { Team } from "@shared/room/Team";
+import { RoomLeague } from "@shared/room/admission/domain/RoomLeague";
 import { UserAuth } from "@shared/user-auth/application/UserAuth";
 import { UserProfilePostgresRepository } from "@shared/user-profile/infrastructure/postgres/UserProfilePostgresRepository";
 import { RankedUserResolver } from "../application/RankedUserResolver";
@@ -55,6 +56,7 @@ const BEST_OF = {
 export class YGOProRoom extends YgoRoom {
   readonly name: string;
   readonly password: string;
+  readonly league: RoomLeague;
   readonly createdBySocketId: string;
   readonly banListHash: number;
   readonly useExtendedCardPool: boolean;
@@ -86,7 +88,7 @@ export class YGOProRoom extends YgoRoom {
     hostInfo,
     team0,
     team1,
-    ranked,
+    league,
     createdBySocketId,
     bestOf,
     startLp,
@@ -100,7 +102,7 @@ export class YGOProRoom extends YgoRoom {
     hostInfo: HostInfo;
     team0: number;
     team1: number;
-    ranked: boolean;
+    league: RoomLeague;
     createdBySocketId: string;
     bestOf: number;
     startLp: number;
@@ -111,7 +113,7 @@ export class YGOProRoom extends YgoRoom {
     super({
       team0,
       team1,
-      ranked,
+      ranked: league.isRanked,
       bestOf,
       startLp,
       id,
@@ -120,6 +122,7 @@ export class YGOProRoom extends YgoRoom {
     });
     this.name = name;
     this.password = password;
+    this.league = league;
     this._players = [];
     this._hostInfo = hostInfo;
     this._state = DuelState.WAITING;
@@ -225,7 +228,11 @@ export class YGOProRoom extends YgoRoom {
     // The host's explicit "casual" token wins over any ranked default — a
     // ticket-authenticated user must be able to host unranked rooms.
     const casual = options.includes("casual");
-    const ranked = casual ? false : (rankedOverride ?? Boolean(playerInfo.password));
+    const league = RoomLeague.determine({
+      casual,
+      rankedOverride,
+      hasPin: Boolean(playerInfo.password),
+    });
     const useExtendedCardPool = options.some((opt) => extendedCardPoolFormats.has(opt));
     const banList = MercuryBanListMemoryRepository.findLFListByIndex(
       hostInfo.lflist,
@@ -239,7 +246,7 @@ export class YGOProRoom extends YgoRoom {
       password,
       team0: teamCount,
       team1: teamCount,
-      ranked,
+      league,
       createdBySocketId,
       bestOf: hostInfo.best_of,
       startLp: hostInfo.start_lp,

--- a/src/ygopro/room/domain/YGOProRoomLeague.test.ts
+++ b/src/ygopro/room/domain/YGOProRoomLeague.test.ts
@@ -1,0 +1,52 @@
+import EventEmitter from "events";
+
+import { PlayerInfoMessage } from "@edopro/messages/client-to-server/PlayerInfoMessage";
+import { RoomLeague } from "@shared/room/admission/domain/RoomLeague";
+import { YGOProRoom } from "@ygopro/room/domain/YGOProRoom";
+
+import { PlayerInfoMessageMother } from "@test-support/mothers/PlayerInfoMessageMother";
+import { LoggerMock } from "@test-support/mocks/logger/LoggerMock";
+import { MessageRepositoryMock } from "@test-support/mocks/MessageRepositoryMock";
+
+const noPin = PlayerInfoMessageMother.create(); // host name carries no ":pin"
+const withPin = { name: "P", password: "1234" } as unknown as PlayerInfoMessage;
+
+const create = (
+	command: string,
+	playerInfo: PlayerInfoMessage,
+	rankedOverride?: boolean,
+): YGOProRoom =>
+	YGOProRoom.create(
+		1,
+		command,
+		new LoggerMock(),
+		new EventEmitter(),
+		playerInfo,
+		"socket-id",
+		new MessageRepositoryMock(),
+		rankedOverride,
+	);
+
+describe("YGOProRoom league", () => {
+	it("a plain room (no PIN, no ticket) is Casual", () => {
+		expect(create("ROOM", noPin).league).toBe(RoomLeague.Casual);
+	});
+
+	it("a PIN-hosted room is External", () => {
+		expect(create("ROOM", withPin).league).toBe(RoomLeague.External);
+	});
+
+	it("a ticket-hosted room (rankedOverride) is Verified", () => {
+		expect(create("ROOM", noPin, true).league).toBe(RoomLeague.Verified);
+	});
+
+	it("the explicit casual flag forces Casual even for a ticket host", () => {
+		expect(create("ROOM,casual", noPin, true).league).toBe(RoomLeague.Casual);
+	});
+
+	it("derives `ranked` from the league (unchanged behavior)", () => {
+		expect(create("ROOM", withPin).ranked).toBe(true);
+		expect(create("ROOM", noPin).ranked).toBe(false);
+		expect(create("ROOM", noPin, true).ranked).toBe(true);
+	});
+});


### PR DESCRIPTION
## Description / Descripción

Second **additive** slice of the connection-flow redesign (Layer 3). Like the foundation PR, this one **does not change behavior**: the room learns its *league*, and the admission use case is built but **not yet wired** into the join path. Wiring it in (which activates segregation) is the next PR, with manual testing.

- **`RoomLeague.determine`** centralizes *"which league a room is born into"* — the casual flag wins, a ticket host → `Verified`, a PIN host → `External`. It replaces the inline `casual ? false : (rankedOverride ?? hasPin)`.
- **`YGOProRoom.league`** — the room now carries its league, and `ranked` is **derived** from `league.isRanked`. Integration tests assert this is identical to the old computation.
- **`AdmitToRoom`** — the admission use case (`resolve → decide → apply`). It talks to the room through the **`AdmissionTarget` port**, so it stays free of sockets and wire messages (DIP). Reusable at both doors (JOIN and spectator→player).

## Related Issue(s) / Issue(s) relacionado(s)

N/A — part of the ongoing connection-flow redesign (follows #269).

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [ ] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

| File | Change |
|------|--------|
| `src/shared/room/admission/domain/RoomLeague.ts` | `+ determine()` factory |
| `src/ygopro/room/domain/YGOProRoom.ts` | `+ league`; `ranked` derived from `league.isRanked` |
| `src/ygopro/room/admission/application/AdmitToRoom.ts` | use case + `AdmissionTarget` port |
| `*.test.ts` | +14 tests (determine, league wiring, use case orchestration) |

`YGOProRoom`'s constructor changed from taking `ranked` to taking `league` (private factory, single caller). Behavior is unchanged — `ranked` is now `league.isRanked`.

**Local verification:** `npm run lint` ✓ · `tsc --noEmit` ✓ · `npm test` → 77 suites, 693 tests ✓ (14 new, all green)