### PR TITLE
feat(admission): close spectator->player escalation

### DIFF
--- a/src/shared/client/domain/YgoClient.ts
+++ b/src/shared/client/domain/YgoClient.ts
@@ -1,4 +1,5 @@
 import { Deck } from "@shared/deck/domain/Deck";
+import { PlayerCredential } from "@shared/room/admission/domain/PlayerCredential";
 import { ISocket } from "../../socket/domain/ISocket";
 
 export abstract class YgoClient {
@@ -13,6 +14,10 @@ export abstract class YgoClient {
 	protected _isReady: boolean;
 	protected _ipAddress: string | null;
 	protected _reconnectionToken: string | null = null;
+	// How this client authenticated when it joined. Remembered so a later
+	// spectator->player promotion can re-check league eligibility, and so the
+	// reconnection layer can tell strong (ticket) from weak (PIN) clients.
+	protected _credential: PlayerCredential | null = null;
 	protected _deck: Deck;
 
 
@@ -120,5 +125,13 @@ export abstract class YgoClient {
 
 	clearReconnectionToken(): void {
 		this._reconnectionToken = null;
+	}
+
+	get credential(): PlayerCredential | null {
+		return this._credential;
+	}
+
+	setCredential(credential: PlayerCredential): void {
+		this._credential = credential;
 	}
 }

--- a/src/ygopro/room/admission/application/AdmitToRoom.test.ts
+++ b/src/ygopro/room/admission/application/AdmitToRoom.test.ts
@@ -51,7 +51,7 @@ describe("AdmitToRoom", () => {
 
 		const result = await admit.run(socket, playerInfo, target);
 
-		expect(target.admitSpectator).toHaveBeenCalledTimes(1);
+		expect(target.admitSpectator).toHaveBeenCalledWith(external);
 		expect(target.seatPlayer).not.toHaveBeenCalled();
 		expect(result.kind).toBe("spectator");
 	});

--- a/src/ygopro/room/admission/application/AdmitToRoom.ts
+++ b/src/ygopro/room/admission/application/AdmitToRoom.ts
@@ -18,7 +18,7 @@ export interface AdmissionTarget {
 	readonly league: RoomLeague;
 	freeSeat(): Seat | null;
 	seatPlayer(credential: PlayerCredential, seat: Seat): Promise<void>;
-	admitSpectator(): Promise<void>;
+	admitSpectator(credential: PlayerCredential): Promise<void>;
 	rejectAdmission(reason: AdmissionRejection): void;
 }
 
@@ -52,7 +52,7 @@ export class AdmitToRoom {
 				await target.seatPlayer(result.credential, result.seat);
 				break;
 			case "spectator":
-				await target.admitSpectator();
+				await target.admitSpectator(credential);
 				break;
 			case "rejected":
 				target.rejectAdmission(result.reason);

--- a/src/ygopro/room/domain/YGOProRoom.ts
+++ b/src/ygopro/room/domain/YGOProRoom.ts
@@ -438,10 +438,12 @@ export class YGOProRoom extends YgoRoom {
           seat.position,
           seat.team,
         );
+        player.setCredential(credential);
         this.addPlayerUnsafe(player);
       },
-      admitSpectator: async () => {
+      admitSpectator: async (credential: PlayerCredential) => {
         const spectator = this.createSpectatorUnsafe(socket, playerInfo.name);
+        spectator.setCredential(credential);
         this.addSpectatorUnsafe(spectator);
       },
       rejectAdmission: () => {

--- a/src/ygopro/room/domain/YGOProRoomAdmissionTarget.test.ts
+++ b/src/ygopro/room/domain/YGOProRoomAdmissionTarget.test.ts
@@ -53,13 +53,23 @@ describe("YGOProRoom.admissionTarget", () => {
 		expect(room.players[0].id).toBeNull();
 	});
 
-	it("admitSpectator adds a spectator", async () => {
+	it("admitSpectator adds a spectator carrying its credential", async () => {
 		const room = YGOProRoomMother.create();
 		const target = room.admissionTarget(makeSocket(), playerInfo("P"));
 
-		await target.admitSpectator();
+		await target.admitSpectator({ kind: "external", userId: "u-9" });
 
 		expect(room.spectators).toHaveLength(1);
+		expect(room.spectators[0].credential).toEqual({ kind: "external", userId: "u-9" });
+	});
+
+	it("seatPlayer stores the credential on the player", async () => {
+		const room = YGOProRoomMother.create();
+		const target = room.admissionTarget(makeSocket(), playerInfo("P"));
+
+		await target.seatPlayer({ kind: "verified", userId: "u-1" }, new Seat(0, 0));
+
+		expect(room.players[0].credential).toEqual({ kind: "verified", userId: "u-1" });
 	});
 
 	it("rejectAdmission sends an error and closes the socket", () => {

--- a/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
@@ -14,6 +14,8 @@ import { BanListDeckError } from "@shared/deck/domain/errors/BanListDeckError";
 import { encodeDeckErrorCode } from "@shared/deck/domain/errors/encodeDeckErrorCode";
 import { AdmitToRoom } from "../../admission/application/AdmitToRoom";
 import { ISocket } from "@shared/socket/domain/ISocket";
+import { RoomLeague } from "@shared/room/admission/domain/RoomLeague";
+import { PlayerCredential } from "@shared/room/admission/domain/PlayerCredential";
 import { ErrorMessageType } from "ygopro-msg-encode";
 
 // ---- helpers ----
@@ -335,5 +337,79 @@ describe("YGOProWaitingState.handleJoin", () => {
 		expect(mockAdmitToRoom.run).not.toHaveBeenCalled();
 		expect(mockSocket.send).toHaveBeenCalled();
 		expect(mockSocket.destroy).toHaveBeenCalled();
+	});
+});
+
+describe("YGOProWaitingState.handleToDuel (spectator -> player)", () => {
+	let eventEmitter: EventEmitter;
+
+	const makeRoom = (league: RoomLeague): jest.Mocked<YGOProRoom> =>
+		({
+			league,
+			mutex: {
+				runExclusive: jest.fn().mockImplementation((fn: () => void) => fn()),
+			},
+			spectatorToPlayerUnsafe: jest.fn(),
+			movePlayerToAnotherCellUnsafe: jest.fn(),
+		} as unknown as jest.Mocked<YGOProRoom>);
+
+	const makeSpectator = (credential: PlayerCredential | null): jest.Mocked<YGOProClient> =>
+		({
+			isSpectator: true,
+			credential,
+			name: "X",
+			logger: makeLogger(),
+		} as unknown as jest.Mocked<YGOProClient>);
+
+	const emitToDuel = (
+		room: jest.Mocked<YGOProRoom>,
+		player: jest.Mocked<YGOProClient>,
+	): Promise<void> =>
+		new Promise((resolve) => {
+			setImmediate(() => resolve());
+			eventEmitter.emit(
+				Commands.TO_DUEL as unknown as string,
+				makeClientMessage(Buffer.alloc(0)),
+				room,
+				player,
+			);
+		});
+
+	beforeEach(() => {
+		eventEmitter = new EventEmitter();
+		new YGOProWaitingState(
+			makeAdmitToRoom() as unknown as AdmitToRoom,
+			eventEmitter,
+			makeLogger(),
+			{ build: jest.fn() } as unknown as YGOProDeckCreator,
+			{ validate: jest.fn() } as unknown as YGOProDeckValidator,
+		);
+	});
+
+	it("does NOT seat a wrong-league spectator (external in a Verified room)", async () => {
+		const room = makeRoom(RoomLeague.Verified);
+		const spectator = makeSpectator({ kind: "external", userId: "u" });
+
+		await emitToDuel(room, spectator);
+
+		expect(room.spectatorToPlayerUnsafe).not.toHaveBeenCalled();
+	});
+
+	it("seats a matching-league spectator (verified in a Verified room)", async () => {
+		const room = makeRoom(RoomLeague.Verified);
+		const spectator = makeSpectator({ kind: "verified", userId: "u" });
+
+		await emitToDuel(room, spectator);
+
+		expect(room.spectatorToPlayerUnsafe).toHaveBeenCalledWith(spectator);
+	});
+
+	it("seats anyone in a casual room", async () => {
+		const room = makeRoom(RoomLeague.Casual);
+		const spectator = makeSpectator({ kind: "guest", name: "X" });
+
+		await emitToDuel(room, spectator);
+
+		expect(room.spectatorToPlayerUnsafe).toHaveBeenCalledWith(spectator);
 	});
 });

--- a/src/ygopro/room/domain/states/YGOProWaitingState.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.ts
@@ -163,6 +163,14 @@ export class YGOProWaitingState extends YGOProRoomState {
 
 		room.mutex.runExclusive(() => {
 			if (player.isSpectator) {
+				// Taking a seat always passes admission: a spectator may only sit if
+				// the room's league accepts how it authenticated. A wrong-league
+				// spectator stays in the stands (closes the escalation through the
+				// stands door, mirroring the JOIN door).
+				const credential = player.credential ?? { kind: "guest" as const, name: player.name };
+				if (!room.league.admitsAsPlayer(credential)) {
+					return;
+				}
 				room.spectatorToPlayerUnsafe(player);
 
 				return;


### PR DESCRIPTION
## Description / Descripción

Closes the **spectator→player escalation** in league-segregated ranked rooms. After #271 segregated the JOIN door, a wrong-league client could still bypass it: join as a **spectator** (allowed) and then promote itself to **player** via `handleToDuel`, which seated it **without re-checking admission**.

Now **the client remembers the `PlayerCredential` it joined with**, and `handleToDuel` asks the room's league whether that credential may take a seat. A wrong-league spectator **stays in the stands** — same guard at both doors (the JOIN and the stands).

Verified **manually with real clients**: an External spectating a Verified room can no longer sit down; a casual spectator still can.

> The remembered credential is also the **foundation for the upcoming reconnection hardening (Layer 4)** — strong (ticket) vs weak (PIN) is read from it.

### Changes
- `YgoClient` gains `credential`, set when seated or admitted as spectator.
- `AdmissionTarget.admitSpectator(credential)` propagates it.
- `handleToDuel` checks `room.league.admitsAsPlayer(credential)` before `spectatorToPlayerUnsafe`.

## Related Issue(s) / Issue(s) relacionado(s)

N/A — ongoing connection-flow redesign (follows #271).

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [ ] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

Note: a wrong-league client still ends up silently in the stands (no chat explaining why) — left as a deliberate product choice for now.

**Local verification:** `npm run lint` ✓ · `tsc --noEmit` ✓ · `npm test` → 78 suites, 692 tests ✓
**Manual verification:** real-client check ✓ (spectator can no longer escalate)