### PR TITLE
feat(reconnect): harden mid-duel reconnect against identity hijack

### DIFF
--- a/src/shared/client/domain/YgoClient.ts
+++ b/src/shared/client/domain/YgoClient.ts
@@ -134,4 +134,11 @@ export abstract class YgoClient {
 	setCredential(credential: PlayerCredential): void {
 		this._credential = credential;
 	}
+
+	// Joined with a strong handshake ticket (evolution client). Such a player
+	// reconnects ONLY through its single-use token, so it must be unreachable
+	// through the weak by-name reconnect path.
+	get isStrongAuth(): boolean {
+		return this._credential?.kind === "verified";
+	}
 }

--- a/src/shared/room/domain/findReconnectingPlayer.test.ts
+++ b/src/shared/room/domain/findReconnectingPlayer.test.ts
@@ -1,0 +1,85 @@
+import { YgoClient } from "@shared/client/domain/YgoClient";
+
+import { findReconnectingPlayer } from "./findReconnectingPlayer";
+
+const player = (overrides: Partial<{
+	name: string;
+	isStrongAuth: boolean;
+	closed: boolean;
+	remoteAddress: string | null;
+}> = {}): YgoClient =>
+	({
+		name: overrides.name ?? "Jaden",
+		isStrongAuth: overrides.isStrongAuth ?? false,
+		socket: {
+			closed: overrides.closed ?? true,
+			remoteAddress: overrides.remoteAddress ?? "1.1.1.1",
+		},
+	}) as unknown as YgoClient;
+
+describe("findReconnectingPlayer", () => {
+	it("matches a disconnected legacy player by name in a ranked room", () => {
+		const p = player();
+		const found = findReconnectingPlayer({
+			players: [p],
+			name: "Jaden",
+			remoteAddress: "9.9.9.9",
+			ranked: true,
+		});
+		expect(found).toBe(p);
+	});
+
+	it("NEVER matches a strong-auth (ticket) player — it is unreachable by name", () => {
+		const p = player({ isStrongAuth: true });
+		const found = findReconnectingPlayer({
+			players: [p],
+			name: "Jaden",
+			remoteAddress: "1.1.1.1",
+			ranked: true,
+		});
+		expect(found).toBeNull();
+	});
+
+	it("NEVER matches a player whose socket is still open (live session)", () => {
+		const p = player({ closed: false });
+		const found = findReconnectingPlayer({
+			players: [p],
+			name: "Jaden",
+			remoteAddress: "1.1.1.1",
+			ranked: true,
+		});
+		expect(found).toBeNull();
+	});
+
+	it("requires a matching name", () => {
+		const p = player({ name: "Other" });
+		const found = findReconnectingPlayer({
+			players: [p],
+			name: "Jaden",
+			remoteAddress: "1.1.1.1",
+			ranked: true,
+		});
+		expect(found).toBeNull();
+	});
+
+	it("in a casual room ALSO requires the same remote address", () => {
+		const p = player({ remoteAddress: "1.1.1.1" });
+		const found = findReconnectingPlayer({
+			players: [p],
+			name: "Jaden",
+			remoteAddress: "2.2.2.2",
+			ranked: false,
+		});
+		expect(found).toBeNull();
+	});
+
+	it("returns null when nobody matches", () => {
+		const found = findReconnectingPlayer({
+			players: [],
+			name: "Jaden",
+			remoteAddress: "1.1.1.1",
+			ranked: true,
+		});
+		expect(found).toBeNull();
+	});
+});

--- a/src/shared/room/domain/findReconnectingPlayer.ts
+++ b/src/shared/room/domain/findReconnectingPlayer.ts
@@ -1,0 +1,42 @@
+import { YgoClient } from "@shared/client/domain/YgoClient";
+
+/**
+ * Finds the player that a by-name JOIN is reconnecting to, while a duel is
+ * already in progress. This is the WEAK reconnect path used by external
+ * clients; the evolution client reconnects through its token instead.
+ *
+ * A reconnection is granted ONLY when every guard holds:
+ *   - the target is NOT strong-auth: ticket players reconnect through their
+ *     single-use token, so they are unreachable here (closes the hijack of a
+ *     verified player by name, with a stolen PIN or another ticket).
+ *   - the target's socket is actually closed: a live session is never taken
+ *     over (closes the in-flight hijack of a connected player).
+ *   - the name matches, and — in casual rooms — the remote address too.
+ *
+ * The remaining residual (knowing a legacy player's PIN while it is down) is
+ * the accepted limit of the 4-char PIN, and never reaches a ticket player.
+ */
+export function findReconnectingPlayer(params: {
+	players: YgoClient[];
+	name: string;
+	remoteAddress: string | undefined;
+	ranked: boolean;
+}): YgoClient | null {
+	const match = params.players.find((client) => {
+		if (client.isStrongAuth) {
+			return false;
+		}
+		if (!client.socket.closed) {
+			return false;
+		}
+		if (client.name !== params.name) {
+			return false;
+		}
+		if (!params.ranked && client.socket.remoteAddress !== params.remoteAddress) {
+			return false;
+		}
+		return true;
+	});
+
+	return match ?? null;
+}

--- a/src/ygopro/room/domain/states/YGOProChoosingOrderState.ts
+++ b/src/ygopro/room/domain/states/YGOProChoosingOrderState.ts
@@ -10,6 +10,7 @@ import { Logger } from "../../../../shared/logger/domain/Logger";
 import { ISocket } from "../../../../shared/socket/domain/ISocket";
 import { YGOProClient } from "../../../client/domain/YGOProClient";
 import { YGOProRoom } from "../YGOProRoom";
+import { findReconnectingPlayer } from "@shared/room/domain/findReconnectingPlayer";
 import { TurnPlayerResult, YGOProCtosTpResult, YGOProStocDuelStart } from "ygopro-msg-encode";
 import { ReconnectionTokenIssuer } from "@shared/room/application/reconnect/ReconnectionTokenIssuer";
 import { ReconnectionAckMessage } from "@shared/messages/server-to-client/ReconnectionAckMessage";
@@ -81,7 +82,12 @@ export class YGOProChoosingOrderState extends RoomState {
 		this.logger.info("handleJoin");
 
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
-		const playerAlreadyInRoom = this.playerAlreadyInRoom(playerInfoMessage, room, socket);
+		const playerAlreadyInRoom = findReconnectingPlayer({
+			players: room.players,
+			name: playerInfoMessage.name,
+			remoteAddress: socket.remoteAddress,
+			ranked: room.ranked,
+		});
 
 		if (!(playerAlreadyInRoom instanceof YGOProClient)) {
 			const spectator = room.createSpectatorUnsafe(socket, playerInfoMessage.name);

--- a/src/ygopro/room/domain/states/YGOProDuelingState.ts
+++ b/src/ygopro/room/domain/states/YGOProDuelingState.ts
@@ -19,6 +19,7 @@ import { YGOProClient } from "../../../client/domain/YGOProClient";
 import { DuelRecord } from "../DuelRecord";
 import { FinalizeYGOProRoom } from "../../application/FinalizeYGOProRoom";
 import { YGOProRoom } from "../YGOProRoom";
+import { findReconnectingPlayer } from "@shared/room/domain/findReconnectingPlayer";
 import { getMessageIdentifier } from "../../../utils/response-time-utils";
 
 import {
@@ -233,11 +234,12 @@ export class YGOProDuelingState extends RoomState {
       message.previousMessage,
       message.data.length,
     );
-    const playerAlreadyInRoom = this.playerAlreadyInRoom(
-      playerInfoMessage,
-      room,
-      socket,
-    );
+    const playerAlreadyInRoom = findReconnectingPlayer({
+      players: room.players,
+      name: playerInfoMessage.name,
+      remoteAddress: socket.remoteAddress,
+      ranked: room.ranked,
+    });
 
     if (!(playerAlreadyInRoom instanceof YGOProClient)) {
       const spectator = room.createSpectatorUnsafe(

--- a/src/ygopro/room/domain/states/YGOProRockPaperScissorState.ts
+++ b/src/ygopro/room/domain/states/YGOProRockPaperScissorState.ts
@@ -7,6 +7,7 @@ import { Logger } from "../../../../shared/logger/domain/Logger";
 import { ISocket } from "../../../../shared/socket/domain/ISocket";
 import { YGOProClient } from "../../../client/domain/YGOProClient";
 import { YGOProRoom } from "../YGOProRoom";
+import { findReconnectingPlayer } from "@shared/room/domain/findReconnectingPlayer";
 import {
   YGOProCtosHandResult,
 } from "ygopro-msg-encode";
@@ -87,11 +88,12 @@ export class YGOProRockPaperScissorState extends YGOProRoomState {
       message.previousMessage,
       message.data.length,
     );
-    const playerAlreadyInRoom = this.playerAlreadyInRoom(
-      playerInfoMessage,
-      room,
-      socket,
-    );
+    const playerAlreadyInRoom = findReconnectingPlayer({
+      players: room.players,
+      name: playerInfoMessage.name,
+      remoteAddress: socket.remoteAddress,
+      ranked: room.ranked,
+    });
 
     if (!(playerAlreadyInRoom instanceof YGOProClient)) {
       const spectator = room.createSpectatorUnsafe(

--- a/src/ygopro/room/domain/states/YGOProSideDeckingState.ts
+++ b/src/ygopro/room/domain/states/YGOProSideDeckingState.ts
@@ -15,6 +15,7 @@ import { ISocket } from "../../../../shared/socket/domain/ISocket";
 
 import { YGOProClient } from "../../../client/domain/YGOProClient";
 import { YGOProRoom } from "../YGOProRoom";
+import { findReconnectingPlayer } from "@shared/room/domain/findReconnectingPlayer";
 import { config } from "../../../../config";
 import { ReconnectionTokenIssuer } from "@shared/room/application/reconnect/ReconnectionTokenIssuer";
 import { ReconnectionAckMessage } from "@shared/messages/server-to-client/ReconnectionAckMessage";
@@ -195,11 +196,12 @@ export class YGOProSideDeckingState extends RoomState {
 			message.previousMessage,
 			message.data.length,
 		);
-		const playerAlreadyInRoom = this.playerAlreadyInRoom(
-			playerInfoMessage,
-			room,
-			socket,
-		);
+		const playerAlreadyInRoom = findReconnectingPlayer({
+			players: room.players,
+			name: playerInfoMessage.name,
+			remoteAddress: socket.remoteAddress,
+			ranked: room.ranked,
+		});
 
 		if (!(playerAlreadyInRoom instanceof YGOProClient)) {
 			const spectator = room.createSpectatorUnsafe(


### PR DESCRIPTION
## Description / Descripción

Closes the **reconnect hijack** vectors from the audit (C3/C4/C5). The mid-duel by-name reconnect used to match purely on the **display name**, which let an attacker take over another player's seat. It now goes through **`findReconnectingPlayer`**, which grants a reclaim only when:

- the target is **NOT strong-auth** — ticket (verified) players reconnect through their single-use token, so they are **unreachable by name** (a verified player can no longer be hijacked with a stolen PIN or another ticket);
- the target's socket is **actually closed** — no live session is taken over;
- the name matches, and **casual** rooms also require the same remote address.

The weak by-name path now only ever reaches **legacy players that are genuinely disconnected**. This fulfils the original goal: **the ticket flow is now intouchable through the weak path.**

Verified **manually with real clients**: legacy reconnect (by name) and evolution reconnect (token) both still recover the seat, across all duel phases.

### Changes
- `YgoClient.isStrongAuth`, derived from the credential remembered on join (#272).
- `findReconnectingPlayer`: a **pure, table-tested** function.
- The 4 mid-duel states (RPS / choosing-order / dueling / side-decking) use it instead of `playerAlreadyInRoom`.

### Left out on purpose
The `socket.closed` guard on the **token** reconnect path (hueco C7) — defence-in-depth with a timing risk that could reject a legit reconnect. To be evaluated separately. (`playerAlreadyInRoom` also still serves the WAITING duplicate-name check; its split is a later cleanup.)

## Related Issue(s) / Issue(s) relacionado(s)

N/A — ongoing connection-flow redesign (follows #272).

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [ ] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

**Local verification:** `npm run lint` ✓ · `tsc --noEmit` ✓ · `npm test` → 79 suites, 698 tests ✓
**Manual verification:** real-client reconnect (legacy by-name + evolution by-token) recovers the seat across phases ✓