### PR TITLE
feat(lobby): expose room league in the lobby DTO and broadcast

### DIFF
--- a/src/shared/room/admission/domain/RoomLeague.test.ts
+++ b/src/shared/room/admission/domain/RoomLeague.test.ts
@@ -14,6 +14,14 @@ describe("RoomLeague", () => {
 		});
 	});
 
+	describe("type — the wire identifier exposed to the lobby", () => {
+		it("returns the league's identifier", () => {
+			expect(RoomLeague.Verified.type).toBe("verified");
+			expect(RoomLeague.External.type).toBe("external");
+			expect(RoomLeague.Casual.type).toBe("casual");
+		});
+	});
+
 	describe("determine — which league a room is born into", () => {
 		it("the explicit casual flag wins over everything", () => {
 			expect(

--- a/src/shared/room/admission/domain/RoomLeague.ts
+++ b/src/shared/room/admission/domain/RoomLeague.ts
@@ -50,6 +50,11 @@ export class RoomLeague {
 		return this.kind !== "casual";
 	}
 
+	/** Stable identifier exposed to the lobby so the client can group rooms by league. */
+	get type(): "verified" | "external" | "casual" {
+		return this.kind;
+	}
+
 	admitsAsPlayer(credential: PlayerCredential): boolean {
 		switch (this.kind) {
 			case "casual":

--- a/src/ygopro/room/domain/YGOProRoom.ts
+++ b/src/ygopro/room/domain/YGOProRoom.ts
@@ -828,6 +828,16 @@ export class YGOProRoom extends YgoRoom {
       maxPlayers,
       spectators: this._spectators.length,
       ranked: this.ranked,
+      league: this.league.type,
+    };
+  }
+
+  // Adds the room's league to the real-time broadcast so the client can place
+  // it in the right lobby section (verified / external / casual).
+  override toRealTimePresentation(): { [key: string]: unknown } {
+    return {
+      ...super.toRealTimePresentation(),
+      league: this.league.type,
     };
   }
 

--- a/src/ygopro/room/domain/YGOProRoomLeague.test.ts
+++ b/src/ygopro/room/domain/YGOProRoomLeague.test.ts
@@ -49,4 +49,14 @@ describe("YGOProRoom league", () => {
 		expect(create("ROOM", noPin).ranked).toBe(false);
 		expect(create("ROOM", noPin, true).ranked).toBe(true);
 	});
+
+	it("exposes the league type in toRoomListDTO", () => {
+		expect(create("ROOM", withPin).toRoomListDTO().league).toBe("external");
+		expect(create("ROOM", noPin, true).toRoomListDTO().league).toBe("verified");
+		expect(create("ROOM", noPin).toRoomListDTO().league).toBe("casual");
+	});
+
+	it("exposes the league type in toRealTimePresentation", () => {
+		expect(create("ROOM", noPin, true).toRealTimePresentation().league).toBe("verified");
+	});
 });


### PR DESCRIPTION
## Description / Descripción

Last piece of the connection-flow core. The client needs to tell **Verified** rooms (ticket) from **External** rooms (PIN) apart to place them in separate lobby sections. `ranked: boolean` cannot, so this adds **`league: "verified" | "external" | "casual"`** to both:
- the **room-list DTO** (`toRoomListDTO`), and
- the **real-time broadcast** (`toRealTimePresentation`, overridden in `YGOProRoom`).

Purely additive — a new field; no behavior changes.

### Changes
- `RoomLeague.type` exposes the league identifier.
- `toRoomListDTO` includes `league`; `toRealTimePresentation` overridden to add it to ADD/UPDATE-ROOM broadcasts.

## Related Issue(s) / Issue(s) relacionado(s)

N/A — ongoing connection-flow redesign (follows #273).

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [ ] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

The client side (separating the lobby into sections) consumes this field.

**Local verification:** `npm run lint` ✓ · `tsc --noEmit` ✓ · `npm test` → 79 suites, 701 tests ✓