### PR TITLE
refactor(admission): remove redundant join-time auth (double-auth + dead injection)

### DIFF
--- a/src/socket-server/WSYGOProServer.ts
+++ b/src/socket-server/WSYGOProServer.ts
@@ -2,9 +2,6 @@ import { randomUUID as uuidv4 } from "crypto";
 import { createServer, IncomingMessage } from "http";
 import { WebSocketServer, WebSocket } from "ws";
 import { config } from "src/config";
-import { CheckIfUseCanJoin } from "src/shared/user-auth/application/CheckIfUserCanJoin";
-import { UserAuth } from "src/shared/user-auth/application/UserAuth";
-import { UserProfilePostgresRepository } from "src/shared/user-profile/infrastructure/postgres/UserProfilePostgresRepository";
 import { EventEmitter } from "stream";
 
 import { MessageEmitter } from "../edopro/MessageEmitter";
@@ -24,8 +21,6 @@ export class WSYGOProServer {
 	private readonly wss: WebSocketServer;
 	private readonly logger: Logger;
 	private readonly roomFinder: RoomFinder;
-	private readonly userAuth: UserAuth;
-	private readonly checkIfUserCanJoin: CheckIfUseCanJoin;
 	private readonly handshakeAuth: HandshakeTicketAuthenticator;
 
 	constructor(logger: Logger, handshakeAuth: HandshakeTicketAuthenticator) {
@@ -34,8 +29,6 @@ export class WSYGOProServer {
 		this.roomFinder = new RoomFinder();
 		const server = createServer();
 		this.wss = new WebSocketServer({ server });
-		this.userAuth = new UserAuth(new UserProfilePostgresRepository());
-		this.checkIfUserCanJoin = new CheckIfUseCanJoin(this.userAuth);
 	}
 
 	initialize(): void {
@@ -67,7 +60,6 @@ export class WSYGOProServer {
 					eventEmitter,
 					connectionLogger,
 					ygoClientSocket,
-					this.checkIfUserCanJoin,
 					messageRepository,
 				);
 			};

--- a/src/socket-server/YGOProServer.ts
+++ b/src/socket-server/YGOProServer.ts
@@ -1,9 +1,6 @@
 import { randomUUID as uuidv4 } from "crypto";
 import net, { Socket } from "net";
 import { config } from "src/config";
-import { CheckIfUseCanJoin } from "src/shared/user-auth/application/CheckIfUserCanJoin";
-import { UserAuth } from "src/shared/user-auth/application/UserAuth";
-import { UserProfilePostgresRepository } from "src/shared/user-profile/infrastructure/postgres/UserProfilePostgresRepository";
 import { EventEmitter } from "stream";
 
 import { MessageEmitter } from "../edopro/MessageEmitter";
@@ -20,15 +17,11 @@ export class YGOProServer {
 	private readonly logger: Logger;
 	private readonly roomFinder: RoomFinder;
 	private address?: string;
-	private readonly userAuth: UserAuth;
-	private readonly checkIfUserCanJoin: CheckIfUseCanJoin;
 
 	constructor(logger: Logger) {
 		this.logger = logger;
 		this.roomFinder = new RoomFinder();
 		this.server = net.createServer({ keepAlive: true });
-		this.userAuth = new UserAuth(new UserProfilePostgresRepository());
-		this.checkIfUserCanJoin = new CheckIfUseCanJoin(this.userAuth);
 	}
 
 	initialize(): void {
@@ -58,7 +51,6 @@ export class YGOProServer {
 					eventEmitter,
 					connectionLogger,
 					ygoClientSocket,
-					this.checkIfUserCanJoin,
 					messageRepository,
 				);
 			};

--- a/src/ygopro/room/application/YGOProJoinHandler.ts
+++ b/src/ygopro/room/application/YGOProJoinHandler.ts
@@ -1,6 +1,5 @@
 import { EventEmitter } from "stream";
 
-import { CheckIfUseCanJoin } from "@shared/user-auth/application/CheckIfUserCanJoin";
 import { Commands } from "@shared/messages/Commands";
 import { ClientMessage } from "@shared/messages/MessageProcessor";
 import { Logger } from "@shared/logger/domain/Logger";
@@ -18,7 +17,6 @@ export class YGOProJoinHandler implements JoinMessageHandler {
 	private readonly logger: Logger;
 	private readonly socket: ISocket;
 	private readonly eventEmitter: EventEmitter;
-	private readonly checkIfUserCanJoin: CheckIfUseCanJoin;
 	private readonly messageRepository: MessageRepository;
 	private readonly registry: JoinStrategyRegistry;
 
@@ -26,14 +24,12 @@ export class YGOProJoinHandler implements JoinMessageHandler {
 		eventEmitter: EventEmitter,
 		logger: Logger,
 		socket: ISocket,
-		checkIfUserCanJoin: CheckIfUseCanJoin,
 		messageRepository: MessageRepository,
 		registry?: JoinStrategyRegistry,
 	) {
 		this.logger = logger.child({ file: "YGOProJoinHandler" });
 		this.socket = socket;
 		this.eventEmitter = eventEmitter;
-		this.checkIfUserCanJoin = checkIfUserCanJoin;
 		this.messageRepository = messageRepository;
 		this.registry = registry ?? JoinStrategyRegistry.getInstance();
 		this.eventEmitter.on(
@@ -64,7 +60,6 @@ export class YGOProJoinHandler implements JoinMessageHandler {
 			eventEmitter: this.eventEmitter,
 			messageRepository: this.messageRepository,
 			logger: this.logger,
-			checkIfUserCanJoin: this.checkIfUserCanJoin,
 			message,
 		};
 

--- a/src/ygopro/room/application/join-strategies/DefaultJoinStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/DefaultJoinStrategy.test.ts
@@ -1,12 +1,9 @@
 import { EventEmitter } from "stream";
 
-import { ErrorMessageType } from "ygopro-msg-encode";
-
 import { JoinContext } from "./JoinStrategy";
 import { DefaultJoinStrategy } from "./DefaultJoinStrategy";
 import { YGOProRoom } from "../../domain/YGOProRoom";
 import YGOProRoomList from "../../infrastructure/YGOProRoomList";
-
 
 // ---- helpers ----
 
@@ -65,7 +62,6 @@ describe("DefaultJoinStrategy", () => {
 
 	beforeEach(() => {
 		strategy = new DefaultJoinStrategy();
-		// Clear the room list between tests
 		const rooms = YGOProRoomList.getRooms();
 		while (rooms.length) {
 			YGOProRoomList.deleteRoom(rooms[0]);
@@ -83,18 +79,15 @@ describe("DefaultJoinStrategy", () => {
 
 	describe("handle()", () => {
 		it("destroys the socket when the room exists but password is wrong", async () => {
-			// Create a room directly
 			const emitter = new EventEmitter();
-			const logger = makeLogger();
-			const messageRepo = makeMessageRepository();
 			const room = YGOProRoom.create(
 				9999,
 				"SECRETROOM#correctpass",
-				logger as never,
+				makeLogger() as never,
 				emitter,
 				{ name: "TestPlayer", password: "", previousMessage: Buffer.alloc(0) } as never,
 				"sock-original",
-				messageRepo as never,
+				makeMessageRepository() as never,
 			);
 			YGOProRoomList.addRoom(room);
 
@@ -113,20 +106,17 @@ describe("DefaultJoinStrategy", () => {
 
 		it("calls room.emit(JOIN) when the existing room has the correct password", async () => {
 			const emitter = new EventEmitter();
-			const logger = makeLogger();
-			const messageRepo = makeMessageRepository();
 			const room = YGOProRoom.create(
 				8888,
 				"MYROOM#mypass",
-				logger as never,
+				makeLogger() as never,
 				emitter,
 				{ name: "TestPlayer", password: "", previousMessage: Buffer.alloc(0) } as never,
 				"sock-original",
-				messageRepo as never,
+				makeMessageRepository() as never,
 			);
 			YGOProRoomList.addRoom(room);
 
-			// Spy on room.emit to verify JOIN is called without triggering WaitingState
 			const emitSpy = jest.spyOn(room, "emit").mockImplementation(() => undefined);
 
 			const socket = makeSocket();
@@ -143,23 +133,19 @@ describe("DefaultJoinStrategy", () => {
 			expect(emitSpy).toHaveBeenCalledWith("JOIN", expect.anything(), ctx.socket);
 		});
 
-		it("closes the socket and does NOT emit JOIN when the ranked room rejects the user", async () => {
-			// Ranked room created via rankedOverride=true (8th arg)
+		it("emits JOIN for a ranked room — admission is now decided downstream by AdmitToRoom", async () => {
 			const emitter = new EventEmitter();
-			const logger = makeLogger();
-			const messageRepo = makeMessageRepository();
 			const room = YGOProRoom.create(
 				7777,
 				"RANKEDROOM",
-				logger as never,
+				makeLogger() as never,
 				emitter,
 				{ name: "TestPlayer", password: "", previousMessage: Buffer.alloc(0) } as never,
 				"sock-original",
-				messageRepo as never,
+				makeMessageRepository() as never,
 				true,
 			);
 			YGOProRoomList.addRoom(room);
-
 			const emitSpy = jest.spyOn(room, "emit").mockImplementation(() => undefined);
 
 			const socket = makeSocket();
@@ -169,94 +155,20 @@ describe("DefaultJoinStrategy", () => {
 				password: "",
 				socket: socket as never,
 				eventEmitter: emitter,
-				// check() returns false → user cannot join the ranked room
-				checkIfUserCanJoin: { check: jest.fn().mockResolvedValue(false) } as never,
 			});
 
 			await strategy.handle(ctx);
 
-			expect(socket.close).toHaveBeenCalled();
-			expect(emitSpy).not.toHaveBeenCalledWith("JOIN", expect.anything(), expect.anything());
-		});
-
-		it("sends the JOINERROR via messageRepository (ygopro 8-byte format) on ranked reject", async () => {
-			const emitter = new EventEmitter();
-			const room = YGOProRoom.create(
-				7778,
-				"RANKEDROOM2",
-				makeLogger() as never,
-				emitter,
-				{ name: "TestPlayer", password: "", previousMessage: Buffer.alloc(0) } as never,
-				"sock-original",
-				makeMessageRepository() as never,
-				true,
-			);
-			YGOProRoomList.addRoom(room);
-			jest.spyOn(room, "emit").mockImplementation(() => undefined);
-
-			const socket = makeSocket();
-			const ctxMessageRepo = makeMessageRepository();
-			const ctx = makeCtx({
-				rawPass: "RANKEDROOM2",
-				command: "RANKEDROOM2",
-				password: "",
-				socket: socket as never,
-				eventEmitter: emitter,
-				messageRepository: ctxMessageRepo as never,
-				checkIfUserCanJoin: { check: jest.fn().mockResolvedValue(false) } as never,
-			});
-
-			await strategy.handle(ctx);
-
-			// The reject must serialize the JOINERROR through the ygopro repository (same
-			// path as DECKERROR → YGOProStocErrorMsg, 8-byte body with code at offset 4),
-			// NOT the @edopro ErrorClientMessage (5-byte body) the web client cannot decode.
-			expect(ctxMessageRepo.errorMessage).toHaveBeenCalledWith(ErrorMessageType.JOINERROR, 0);
-			expect(socket.send).toHaveBeenCalled();
-		});
-
-		it("does NOT close the socket on the happy ranked path (check passes)", async () => {
-			const emitter = new EventEmitter();
-			const logger = makeLogger();
-			const messageRepo = makeMessageRepository();
-			const room = YGOProRoom.create(
-				6666,
-				"RANKEDOK",
-				logger as never,
-				emitter,
-				{ name: "TestPlayer", password: "", previousMessage: Buffer.alloc(0) } as never,
-				"sock-original",
-				messageRepo as never,
-				true,
-			);
-			YGOProRoomList.addRoom(room);
-
-			jest.spyOn(room, "emit").mockImplementation(() => undefined);
-
-			const socket = makeSocket();
-			const ctx = makeCtx({
-				rawPass: "RANKEDOK",
-				command: "RANKEDOK",
-				password: "",
-				socket: socket as never,
-				eventEmitter: emitter,
-				checkIfUserCanJoin: { check: jest.fn().mockResolvedValue(true) } as never,
-			});
-
-			await strategy.handle(ctx);
-
+			// The strategy no longer authenticates — it just routes the join.
+			expect(emitSpy).toHaveBeenCalledWith("JOIN", expect.anything(), ctx.socket);
 			expect(socket.close).not.toHaveBeenCalled();
 		});
 
 		it("creates a new room when none exists and adds it to the list", async () => {
 			const emitter = new EventEmitter();
-			const messageRepo = makeMessageRepository();
 			const socket = makeSocket();
 
-			// Mock YGOProRoom.prototype.waiting to prevent WaitingState setup
-			// (we don't want WaitingState listening for JOIN events in this unit test)
 			const waitingSpy = jest.spyOn(YGOProRoom.prototype, "waiting").mockImplementation(() => undefined);
-			// Also mock emit so JOIN doesn't try to invoke WaitingState
 			const emitSpy = jest.spyOn(YGOProRoom.prototype, "emit").mockImplementation(() => undefined);
 
 			const ctx = makeCtx({
@@ -265,7 +177,7 @@ describe("DefaultJoinStrategy", () => {
 				password: "",
 				socket: socket as never,
 				eventEmitter: emitter,
-				messageRepository: messageRepo as never,
+				messageRepository: makeMessageRepository() as never,
 			});
 
 			await strategy.handle(ctx);
@@ -273,8 +185,7 @@ describe("DefaultJoinStrategy", () => {
 			waitingSpy.mockRestore();
 			emitSpy.mockRestore();
 
-			const found = YGOProRoomList.findByName("NEWROOM");
-			expect(found).not.toBeNull();
+			expect(YGOProRoomList.findByName("NEWROOM")).not.toBeNull();
 		});
 	});
 });

--- a/src/ygopro/room/application/join-strategies/DefaultJoinStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/DefaultJoinStrategy.ts
@@ -1,7 +1,5 @@
 import { generateUniqueId } from "src/utils/generateUniqueId";
 
-import { ErrorMessageType } from "ygopro-msg-encode";
-
 import { JoinContext, JoinStrategy } from "./JoinStrategy";
 import { YGOProRoom } from "../../domain/YGOProRoom";
 import YGOProRoomList from "../../infrastructure/YGOProRoomList";
@@ -28,20 +26,8 @@ export class DefaultJoinStrategy implements JoinStrategy {
 			return;
 		}
 
-		if (room.ranked && !(await ctx.checkIfUserCanJoin.check(ctx.playerInfo, ctx.socket))) {
-			// Send the JOINERROR with the ygopro serializer (YGOProStocErrorMsg → 8-byte
-			// body, code at offset 4), the same path DECKERROR uses. checkIfUserCanJoin no
-			// longer sends it because the @edopro ErrorClientMessage it used has a 5-byte
-			// body the web client cannot decode ("Data too short: need 8 bytes, got 5").
-			ctx.socket.send(ctx.messageRepository.errorMessage(ErrorMessageType.JOINERROR, 0));
-			// Close the socket so the client gets a real disconnect instead of a
-			// live-but-useless connection it would keep reusing (the handshake — where the
-			// ticket travels — never re-runs otherwise). close() is graceful: the queued
-			// error frame is flushed first.
-			ctx.socket.close();
-			return;
-		}
-
+		// Admission — ranked auth and league segregation — is decided inside the
+		// room's WaitingState via AdmitToRoom. The strategy only routes the join.
 		room.emit("JOIN", ctx.message, ctx.socket);
 	}
 

--- a/src/ygopro/room/application/join-strategies/JoinStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/JoinStrategy.ts
@@ -5,7 +5,6 @@ import { ClientMessage } from "@shared/messages/MessageProcessor";
 import { ISocket } from "@shared/socket/domain/ISocket";
 import { Logger } from "@shared/logger/domain/Logger";
 import { MessageRepository } from "@shared/messages/MessageRepository";
-import { CheckIfUseCanJoin } from "@shared/user-auth/application/CheckIfUserCanJoin";
 
 /**
  * Everything handleJoinGame has available at the point it dispatches.
@@ -30,8 +29,6 @@ export interface JoinContext {
 	messageRepository: MessageRepository;
 	/** Logger (child already attached in the handler) */
 	logger: Logger;
-	/** Rank check dependency (passed through for ranked rooms) */
-	checkIfUserCanJoin: CheckIfUseCanJoin;
 	/** The original ClientMessage — needed to emit the JOIN event to the room state machine */
 	message: ClientMessage;
 }

--- a/src/ygopro/room/application/join-strategies/TicketJoinStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/TicketJoinStrategy.test.ts
@@ -26,10 +26,6 @@ const makeMessageRepository = () => ({
 	errorMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
 });
 
-const makeCheckIfUserCanJoin = () => ({
-	check: jest.fn().mockResolvedValue(true),
-});
-
 const makeClientMessage = (): { data: Buffer; previousMessage: Buffer } => ({
 	data: Buffer.alloc(0),
 	previousMessage: Buffer.alloc(0),
@@ -50,7 +46,6 @@ const makeCtx = (overrides: Partial<JoinContext> = {}): JoinContext =>
 		eventEmitter: new EventEmitter(),
 		messageRepository: makeMessageRepository(),
 		logger: makeLogger(),
-		checkIfUserCanJoin: makeCheckIfUserCanJoin(),
 		message: makeClientMessage(),
 		...overrides,
 	} as unknown as JoinContext);
@@ -144,36 +139,6 @@ describe("TicketJoinStrategy", () => {
 			await strategy.handle(ctx);
 
 			expect(emitSpy).toHaveBeenCalledWith("JOIN", expect.anything(), ctx.socket);
-
-			waitingSpy.mockRestore();
-			emitSpy.mockRestore();
-		});
-
-		it("does NOT call checkIfUserCanJoin", async () => {
-			const emitter = new EventEmitter();
-			const waitingSpy = jest
-				.spyOn(
-					(await import("../../domain/YGOProRoom")).YGOProRoom.prototype,
-					"waiting",
-				)
-				.mockImplementation(() => undefined);
-			const emitSpy = jest
-				.spyOn(
-					(await import("../../domain/YGOProRoom")).YGOProRoom.prototype,
-					"emit",
-				)
-				.mockImplementation(() => undefined);
-
-			const checkIfUserCanJoin = makeCheckIfUserCanJoin();
-			const ctx = makeCtx({
-				socket: makeSocket("ticket-user") as never,
-				eventEmitter: emitter,
-				checkIfUserCanJoin: checkIfUserCanJoin as never,
-			});
-
-			await strategy.handle(ctx);
-
-			expect(checkIfUserCanJoin.check).not.toHaveBeenCalled();
 
 			waitingSpy.mockRestore();
 			emitSpy.mockRestore();

--- a/src/ygopro/room/application/join-strategies/YGOProJoinHandlerStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/YGOProJoinHandlerStrategy.test.ts
@@ -46,10 +46,6 @@ const makeMessageRepository = () => ({
 	spectatorCountMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
 });
 
-const makeCheckIfUserCanJoin = () => ({
-	check: jest.fn().mockResolvedValue(true),
-});
-
 /**
  * Build a minimal JOIN_GAME ClientMessage payload.
  *
@@ -112,14 +108,12 @@ describe("YGOProJoinHandler — strategy chain integration", () => {
 
 		const socket = makeSocket();
 		const messageRepo = makeMessageRepository();
-		const checkJoin = makeCheckIfUserCanJoin();
 		const logger = makeLogger();
 
 		new YGOProJoinHandler(
 			emitter,
 			logger as never,
 			socket as never,
-			checkJoin as never,
 			messageRepo as never,
 		);
 
@@ -159,14 +153,12 @@ describe("YGOProJoinHandler — strategy chain integration", () => {
 
 		const socket = makeSocket();
 		const messageRepo = makeMessageRepository();
-		const checkJoin = makeCheckIfUserCanJoin();
 		const logger = makeLogger();
 
 		const handler = new YGOProJoinHandler(
 			emitter,
 			logger as never,
 			socket as never,
-			checkJoin as never,
 			messageRepo as never,
 			registry,
 		);
@@ -186,7 +178,6 @@ describe("YGOProJoinHandler — strategy chain integration", () => {
 	it("YGOProJoinHandler uses the default registry when none is injected", () => {
 		const socket = makeSocket();
 		const messageRepo = makeMessageRepository();
-		const checkJoin = makeCheckIfUserCanJoin();
 		const logger = makeLogger();
 
 		expect(() => {
@@ -194,7 +185,6 @@ describe("YGOProJoinHandler — strategy chain integration", () => {
 				emitter,
 				logger as never,
 				socket as never,
-				checkJoin as never,
 				messageRepo as never,
 			);
 		}).not.toThrow();


### PR DESCRIPTION
## Description / Descripción

Final cleanup of the connection-flow redesign: removes the **double authentication** on the join path. `DefaultJoinStrategy` no longer authenticates before emitting JOIN — admission (ranked auth + league segregation) is decided **once, downstream**, by `AdmitToRoom` in the `WaitingState`.

It also removes the now-**dead `CheckIfUseCanJoin` injection** from the entire ygopro chain (`JoinContext`, `YGOProJoinHandler`, `WSYGOProServer`, `YGOProServer`). **edopro's `Reconnect` still uses `CheckIfUseCanJoin`, so that path is untouched.**

Verified **manually with real clients** (per earlier agreement): a guest still cannot join a ranked room.

### Behavior note
The strategy no longer sends the legacy `ServerErrorMessage` detail before the `JOINERROR` (the web client already ignored it). Rejection now flows through `AdmitToRoom`'s `rejectAdmission`.

## Related Issue(s) / Issue(s) relacionado(s)

N/A — final cleanup of the connection-flow redesign (follows #274).

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [ ] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

Net **−172 lines**: the strategy shrinks to pure routing and the auth dependency disappears from the ygopro server wiring.

**Local verification:** `npm run lint` ✓ · `tsc --noEmit` ✓ · `npm test` → 79 suites, 698 tests ✓