### PR TITLE
refactor(reconnect): split player-in-room check into name-taken and reconnecting-player

### DIFF
--- a/src/edopro/room/domain/RoomState.ts
+++ b/src/edopro/room/domain/RoomState.ts
@@ -43,38 +43,6 @@ export abstract class RoomState {
 		this.eventEmitter.removeAllListeners();
 	}
 
-	protected playerAlreadyInRoom(
-		playerInfoMessage: PlayerInfoMessage,
-		room: YgoRoom,
-		socket: ISocket
-	): YgoClient | null {
-		if (!room.ranked) {
-			const player = room.players.find((client) => {
-				return (
-					client.socket.remoteAddress === socket.remoteAddress &&
-					client.socket.closed &&
-					playerInfoMessage.name === client.name
-				);
-			});
-
-			if (!player) {
-				return null;
-			}
-
-			return player;
-		}
-
-		const player = room.players.find((client) => {
-			return playerInfoMessage.name === client.name;
-		});
-
-		if (!player) {
-			return null;
-		}
-
-		return player;
-	}
-
 	protected validateVersion(message: Buffer, socket: ISocket): void {
 		const joinMessage = new YGOProJoinGameMessage(message);
 

--- a/src/edopro/room/domain/states/chossing-order/ChossingOrderState.ts
+++ b/src/edopro/room/domain/states/chossing-order/ChossingOrderState.ts
@@ -16,6 +16,7 @@ import { Reconnect } from "../../../application/Reconnect";
 import { Room } from "../../Room";
 import { RoomState } from "../../RoomState";
 import { ReconnectionTokenIssuer } from "../../../../../shared/room/application/reconnect/ReconnectionTokenIssuer";
+import { findReconnectingPlayer } from "../../../../../shared/room/domain/findReconnectingPlayer";
 import { ReconnectionAckMessage } from "../../../../../shared/messages/server-to-client/ReconnectionAckMessage";
 
 export class ChossingOrderState extends RoomState {
@@ -123,7 +124,12 @@ export class ChossingOrderState extends RoomState {
 		this.logger.info("CHOSSING_ORDER: JOIN");
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
 		const joinMessage = new JoinGameMessage(message.data);
-		const reconnectingPlayer = this.playerAlreadyInRoom(playerInfoMessage, room, socket);
+		const reconnectingPlayer = findReconnectingPlayer({
+			players: room.players,
+			name: playerInfoMessage.name,
+			remoteAddress: socket.remoteAddress,
+			ranked: room.ranked,
+		});
 
 		if (!(reconnectingPlayer instanceof Client)) {
 			await this.joinToDuelAsSpectator.run(joinMessage, playerInfoMessage, socket, room);

--- a/src/edopro/room/domain/states/dueling/DuelingState.ts
+++ b/src/edopro/room/domain/states/dueling/DuelingState.ts
@@ -26,6 +26,7 @@ import { TimeLimitClientMessage } from "../../../../messages/server-to-client/ga
 import { CatchUpClientMessage } from "../../../../messages/server-to-client/CatchUpClientMessage";
 import { PlayerChangeClientMessage } from "../../../../messages/server-to-client/PlayerChangeClientMessage";
 import { ReconnectionTokenIssuer } from "../../../../../shared/room/application/reconnect/ReconnectionTokenIssuer";
+import { findReconnectingPlayer } from "../../../../../shared/room/domain/findReconnectingPlayer";
 import { ReconnectionAckMessage } from "../../../../../shared/messages/server-to-client/ReconnectionAckMessage";
 import { ServerErrorClientMessage } from "../../../../messages/server-to-client/ServerErrorMessageClientMessage";
 import { ServerMessageClientMessage } from "../../../../messages/server-to-client/ServerMessageClientMessage";
@@ -743,7 +744,12 @@ export class DuelingState extends RoomState {
 
 			return;
 		}
-		const reconnectingPlayer = this.playerAlreadyInRoom(playerInfoMessage, room, socket);
+		const reconnectingPlayer = findReconnectingPlayer({
+			players: room.players,
+			name: playerInfoMessage.name,
+			remoteAddress: socket.remoteAddress,
+			ranked: room.ranked,
+		});
 
 		if (!(reconnectingPlayer instanceof Client)) {
 			await this.joinToDuelAsSpectator.run(joinMessage, playerInfoMessage, socket, room);

--- a/src/edopro/room/domain/states/rps/RockPaperScissorsState.ts
+++ b/src/edopro/room/domain/states/rps/RockPaperScissorsState.ts
@@ -17,6 +17,7 @@ import { Room } from "../../Room";
 import { RoomState } from "../../RoomState";
 import { RpsChoiceCommandStrategy } from "./RpsChoiceCommandStrategy";
 import { ReconnectionTokenIssuer } from "../../../../../shared/room/application/reconnect/ReconnectionTokenIssuer";
+import { findReconnectingPlayer } from "../../../../../shared/room/domain/findReconnectingPlayer";
 import { ReconnectionAckMessage } from "../../../../../shared/messages/server-to-client/ReconnectionAckMessage";
 
 export class RockPaperScissorState extends RoomState {
@@ -114,7 +115,12 @@ export class RockPaperScissorState extends RoomState {
 		this.logger.info("JOIN");
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
 		const joinMessage = new JoinGameMessage(message.data);
-		const reconnectingPlayer = this.playerAlreadyInRoom(playerInfoMessage, room, socket);
+		const reconnectingPlayer = findReconnectingPlayer({
+			players: room.players,
+			name: playerInfoMessage.name,
+			remoteAddress: socket.remoteAddress,
+			ranked: room.ranked,
+		});
 
 		if (!(reconnectingPlayer instanceof Client)) {
 			await this.joinToDuelAsSpectator.run(joinMessage, playerInfoMessage, socket, room);

--- a/src/edopro/room/domain/states/side-decking/SideDeckingState.test.ts
+++ b/src/edopro/room/domain/states/side-decking/SideDeckingState.test.ts
@@ -11,6 +11,7 @@ import { UpdateDeckMessageParser } from "@edopro/deck/application/UpdateDeckMess
 import { ISocket } from "@shared/socket/domain/ISocket";
 import { Commands } from "@shared/messages/Commands";
 import { TokenIndex } from "@shared/room/domain/TokenIndex";
+import { findReconnectingPlayer } from "@shared/room/domain/findReconnectingPlayer";
 
 // Mocks
 jest.mock("@shared/logger/domain/Logger");
@@ -24,6 +25,7 @@ jest.mock("@edopro/client/domain/Client");
 jest.mock(
   "@edopro/deck/application/UpdateDeckMessageSizeCalculator",
 );
+jest.mock("@shared/room/domain/findReconnectingPlayer");
 
 describe("SideDeckingState", () => {
   let state: SideDeckingState;
@@ -194,33 +196,8 @@ describe("SideDeckingState", () => {
       previousMessage: Buffer.alloc(40), // PlayerInfoMessage size
     } as ClientMessage;
 
-    // Mock RoomState.playerAlreadyInRoom
-    // Since RoomState is extended, we can mock the method on the instance if possible,
-    // or better: checking logic depends on `room.clients`.
-    // `playerAlreadyInRoom` checks `clients` for matching name/ip.
-
-    // Let's assume we mock `room.clients` to include a client with same name.
-    // Wait, `playerAlreadyInRoom` implementation is in `RoomState.ts`.
-    // We are not testing `RoomState.ts` logic here (it's abstract/base), but we rely on it.
-    // We can't easily mock the method on `state` because it's the SUT.
-    // But we can ensure `room.clients` has a match.
-
-    // RoomState.playerAlreadyInRoom logic:
-    // const player = room.clients.find((client) => client.name === playerInfoMessage.name);
-    // if (!player) return null;
-    // ... check ip ...
-
-    // We need to provide a JoinGameMessage buffer that parses to something usable?
-    // Or just mock `Room` behavior if `playerAlreadyInRoom` delegates?
-    // No, `playerAlreadyInRoom` is on `this`.
-
-    // Let's create a real-ish scenario.
-    // `playerInfoMessage` name comes from `message.previousMessage`.
-
-    // If we can't easily trigger `reconnectingPlayer` to be found without valid buffers/logic,
-    // we might mock `playerAlreadyInRoom` on the prototype or instance.
-
-    jest.spyOn(state as any, "playerAlreadyInRoom").mockReturnValue(mockClient);
+    // A reconnecting player is one that findReconnectingPlayer resolves to a Client.
+    (findReconnectingPlayer as jest.Mock).mockReturnValue(mockClient);
 
     mockEmitter.emit("JOIN", message, mockRoom, mockSocket);
     await new Promise(process.nextTick);
@@ -234,7 +211,7 @@ describe("SideDeckingState", () => {
       previousMessage: Buffer.alloc(40),
     } as ClientMessage;
 
-    jest.spyOn(state as any, "playerAlreadyInRoom").mockReturnValue(null);
+    (findReconnectingPlayer as jest.Mock).mockReturnValue(null);
 
     mockEmitter.emit("JOIN", message, mockRoom, mockSocket);
     await new Promise(process.nextTick);

--- a/src/edopro/room/domain/states/side-decking/SideDeckingState.ts
+++ b/src/edopro/room/domain/states/side-decking/SideDeckingState.ts
@@ -21,6 +21,7 @@ import { Reconnect } from "../../../application/Reconnect";
 import { Room } from "../../Room";
 import { RoomState } from "../../RoomState";
 import { ReconnectionTokenIssuer } from "../../../../../shared/room/application/reconnect/ReconnectionTokenIssuer";
+import { findReconnectingPlayer } from "../../../../../shared/room/domain/findReconnectingPlayer";
 import { ReconnectionAckMessage } from "../../../../../shared/messages/server-to-client/ReconnectionAckMessage";
 
 export class SideDeckingState extends RoomState {
@@ -96,7 +97,12 @@ export class SideDeckingState extends RoomState {
 		this.logger.info("JOIN");
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
 		const joinMessage = new JoinGameMessage(message.data);
-		const reconnectingPlayer = this.playerAlreadyInRoom(playerInfoMessage, room, socket);
+		const reconnectingPlayer = findReconnectingPlayer({
+			players: room.players,
+			name: playerInfoMessage.name,
+			remoteAddress: socket.remoteAddress,
+			ranked: room.ranked,
+		});
 
 		if (!(reconnectingPlayer instanceof Client)) {
 			await this.joinToDuelAsSpectator.run(joinMessage, playerInfoMessage, socket, room);

--- a/src/edopro/room/domain/states/waiting/WaitingState.ts
+++ b/src/edopro/room/domain/states/waiting/WaitingState.ts
@@ -20,6 +20,7 @@ import { JoinGameClientMessage } from "../../../../messages/server-to-client/Joi
 import { RPSChooseClientMessage } from "../../../../messages/server-to-client/RPSChooseClientMessage";
 import { ServerErrorClientMessage } from "../../../../messages/server-to-client/ServerErrorMessageClientMessage";
 import { ReconnectionTokenIssuer } from "../../../../../shared/room/application/reconnect/ReconnectionTokenIssuer";
+import { isNameTaken } from "../../../../../shared/room/domain/isNameTaken";
 import { Room } from "../../Room";
 import { RoomState } from "../../RoomState";
 
@@ -255,7 +256,7 @@ export class WaitingState extends RoomState {
 		this.logger.info("JOIN");
 
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
-		if (this.playerAlreadyInRoom(playerInfoMessage, room, socket)) {
+		if (isNameTaken(room.players, playerInfoMessage.name)) {
 			this.sendExistingPlayerErrorMessage(playerInfoMessage, socket);
 
 			return;

--- a/src/shared/room/domain/isNameTaken.test.ts
+++ b/src/shared/room/domain/isNameTaken.test.ts
@@ -1,0 +1,19 @@
+import { YgoClient } from "@shared/client/domain/YgoClient";
+
+import { isNameTaken } from "./isNameTaken";
+
+const player = (name: string): YgoClient => ({ name }) as unknown as YgoClient;
+
+describe("isNameTaken", () => {
+	it("is true when a player with that name is already in the room", () => {
+		expect(isNameTaken([player("Jaden"), player("Yugi")], "Jaden")).toBe(true);
+	});
+
+	it("is false when no player has that name", () => {
+		expect(isNameTaken([player("Yugi")], "Jaden")).toBe(false);
+	});
+
+	it("is false for an empty room", () => {
+		expect(isNameTaken([], "Jaden")).toBe(false);
+	});
+});

--- a/src/shared/room/domain/isNameTaken.ts
+++ b/src/shared/room/domain/isNameTaken.ts
@@ -1,0 +1,11 @@
+import { YgoClient } from "@shared/client/domain/YgoClient";
+
+/**
+ * Whether a player with this name is already seated in the room. Used in the
+ * WAITING lobby to reject duplicate names, so a later by-name reconnect can
+ * never be ambiguous. This is purely a name check — it has nothing to do with
+ * reconnection (that is findReconnectingPlayer).
+ */
+export function isNameTaken(players: YgoClient[], name: string): boolean {
+	return players.some((client) => client.name === name);
+}

--- a/src/ygopro/room/domain/states/YGOProWaitingState.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.ts
@@ -8,6 +8,7 @@ import { YgoClient } from "@shared/client/domain/YgoClient";
 import { Logger } from "@shared/logger/domain/Logger";
 import { ISocket } from "@shared/socket/domain/ISocket";
 import { ReconnectionTokenIssuer } from "@shared/room/application/reconnect/ReconnectionTokenIssuer";
+import { isNameTaken } from "@shared/room/domain/isNameTaken";
 
 import { YGOProClient } from "../../../client/domain/YGOProClient";
 import { YGOProRoom } from "../YGOProRoom";
@@ -87,7 +88,7 @@ export class YGOProWaitingState extends YGOProRoomState {
 			message.previousMessage,
 			message.data.length,
 		);
-		if (this.playerAlreadyInRoom(playerInfoMessage, room, socket)) {
+		if (isNameTaken(room.players, playerInfoMessage.name)) {
 			this.sendExistingPlayerErrorMessage(playerInfoMessage, socket);
 			return;
 		}


### PR DESCRIPTION
## Description / Descripción

Splits the overloaded edopro `RoomState.playerAlreadyInRoom` into two single-responsibility helpers in `src/shared/room/domain`, separating *"this nick is already taken"* (pre-duel) from *"this player is reconnecting to a live duel"* — the conflation that was the root of the reconnection gaps.

Divide el sobrecargado `RoomState.playerAlreadyInRoom` de edopro en dos helpers de responsabilidad única en `src/shared/room/domain`, separando *"este nick ya está tomado"* (pre-duelo) de *"este jugador se está reconectando a un duelo en curso"* — la mezcla que originaba los huecos de reconexión.

- **`isNameTaken`** — pure duplicate-nick guard used by the **WAITING** phase (edopro `WaitingState` + ygopro `YGOProWaitingState`). / Guard puro de nick duplicado para la fase WAITING.
- **`findReconnectingPlayer`** — the mid-duel reconnection matcher already used by ygopro, now also used by the four edopro mid-duel states (Dueling, RPS, SideDecking, ChoosingOrder). / El matcher de reconexión mid-duelo que ya usaba ygopro, ahora también en los cuatro estados mid-duelo de edopro.

`RoomState.playerAlreadyInRoom` is deleted entirely. / `playerAlreadyInRoom` se elimina por completo.

### Behavior changes / Cambios de comportamiento (edopro)

1. **WAITING rejects a duplicate nick unconditionally** — previously, in unranked rooms, only when the existing socket was closed and shared the same IP. / WAITING rechaza nick duplicado siempre — antes, en salas unranked, solo si el socket existente estaba cerrado y desde la misma IP.
2. **Ranked mid-duel reconnection now requires `socket.closed`** — previously it matched by nick alone, allowing an in-flight session hijack (**C3**). This brings edopro to parity with the ygopro reconnection hardening. / La reconexión ranked mid-duelo ahora exige `socket.closed` — antes matcheaba solo por nick, permitiendo robo de sesión en vivo (C3). Lleva edopro a la par del blindaje de reconexión de ygopro.

edopro clients carry no credential (`isStrongAuth` is always false), so the strong-auth branch does not apply; the rest is equivalent. / Los clientes edopro no llevan credential (`isStrongAuth` siempre false), así que la rama de strong-auth no aplica; el resto es equivalente.

Verified **manually with real clients** (per earlier agreement): edopro mid-duel reconnection recovers the seat, and a duplicate nick in the waiting room is rejected. / Verificado manualmente con clientes reales: la reconexión mid-duelo de edopro recupera el lugar, y un nick duplicado en la sala de espera es rechazado.

## Related Issue(s) / Issue(s) relacionado(s)

N/A — connection-flow redesign cleanup (follows #275).

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [ ] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

New unit `isNameTaken.test.ts` (3 tests). `SideDeckingState.test.ts` updated to mock the `findReconnectingPlayer` module instead of spying the removed `playerAlreadyInRoom`. / Nuevo unit `isNameTaken.test.ts` (3 tests). `SideDeckingState.test.ts` ahora mockea el módulo `findReconnectingPlayer` en vez de espiar el eliminado `playerAlreadyInRoom`.

**Local verification:** `npm run lint` ✓ · `tsc --noEmit` ✓ · `npm test` → 80 suites, 704 tests ✓