### PR TITLE
feat(admission): let verified players sit in External rooms (one-way cross-league)

### DIFF
--- a/src/shared/room/admission/domain/RoomAdmission.test.ts
+++ b/src/shared/room/admission/domain/RoomAdmission.test.ts
@@ -40,9 +40,9 @@ describe("RoomAdmission.decide", () => {
 			expect(result).toEqual({ kind: "spectator" });
 		});
 
-		it("a verified (authenticated) in an External room only watches", () => {
+		it("seats a verified player in an External room (one-way cross-league)", () => {
 			const result = admission.decide(verified, { league: RoomLeague.External, freeSeat });
-			expect(result).toEqual({ kind: "spectator" });
+			expect(result).toEqual({ kind: "player", credential: verified, seat: freeSeat });
 		});
 	});
 

--- a/src/shared/room/admission/domain/RoomAdmission.ts
+++ b/src/shared/room/admission/domain/RoomAdmission.ts
@@ -20,9 +20,9 @@ export interface AdmissionContext {
  * three steps, in order:
  *
  *   1. Ranked rooms require an account even to WATCH → a guest is rejected.
- *   2. A client only SITS in a league that matches its credential
- *      (segregation); otherwise it watches.
- *   3. With a matching credential, sit if there is a free seat, else watch.
+ *   2. A client only SITS if the league admits its credential (segregation,
+ *      with the verified→External one-way cross); otherwise it watches.
+ *   3. When admitted, sit if there is a free seat, else watch.
  *
  * Mental model — two keys: the door (handled upstream + step 1) and the seat
  * (steps 2-3). "Wrong method → watch" and "room full → watch" are the same

--- a/src/shared/room/admission/domain/RoomLeague.test.ts
+++ b/src/shared/room/admission/domain/RoomLeague.test.ts
@@ -67,10 +67,15 @@ describe("RoomLeague", () => {
 			expect(RoomLeague.Verified.admitsAsPlayer(guest)).toBe(false);
 		});
 
-		it("External admits ONLY external credentials", () => {
+		it("External admits external AND verified (one-way cross), but not guests", () => {
 			expect(RoomLeague.External.admitsAsPlayer(external)).toBe(true);
-			expect(RoomLeague.External.admitsAsPlayer(verified)).toBe(false);
+			expect(RoomLeague.External.admitsAsPlayer(verified)).toBe(true);
 			expect(RoomLeague.External.admitsAsPlayer(guest)).toBe(false);
+		});
+
+		it("the cross is one-way: a verified sits in External, but an external never sits in Verified", () => {
+			expect(RoomLeague.External.admitsAsPlayer(verified)).toBe(true);
+			expect(RoomLeague.Verified.admitsAsPlayer(external)).toBe(false);
 		});
 	});
 });

--- a/src/shared/room/admission/domain/RoomLeague.ts
+++ b/src/shared/room/admission/domain/RoomLeague.ts
@@ -3,12 +3,13 @@ import { PlayerCredential } from "./PlayerCredential";
 /**
  * The "league" a room belongs to — it decides who may SIT DOWN to play.
  *
- * - `Verified`: ranked, only ticket-authenticated players.
- * - `External`: ranked, only PIN-authenticated players.
+ * - `Verified`: ranked, only ticket-authenticated players (tournament-grade).
+ * - `External`: ranked, PIN-authenticated players AND verified players who step down.
  * - `Casual`:   anyone may play.
  *
- * The two ranked leagues are SEGREGATED: a player only sits at the league that
- * matches how they authenticated. A mismatched-but-authenticated client is not
+ * The two ranked leagues are segregated, but the cross is ONE-WAY: a verified
+ * player may step down into an External room, while an external player never
+ * steps up into a Verified one. A mismatched client that cannot sit is not
  * rejected here — it falls back to spectating, a decision that belongs to
  * RoomAdmission, not to the league itself.
  */
@@ -62,7 +63,11 @@ export class RoomLeague {
 			case "verified":
 				return credential.kind === "verified";
 			case "external":
-				return credential.kind === "external";
+				// One-way cross-league: a verified (strong) player may step DOWN into an
+				// External room, but an external (PIN) player never steps UP into a
+				// Verified one. Verified rooms — used for tournaments — stay pure; the
+				// asymmetry is the trust signal that nudges externals to verify.
+				return credential.kind === "external" || credential.kind === "verified";
 		}
 	}
 }


### PR DESCRIPTION
## Description / Descripción

Relaxes the ranked league segregation into a **one-way cross**: a **verified** (ticket) player may now step DOWN into an **External** (PIN) room and play, while an **external** player still **never** steps UP into a **Verified** room.

Relaja la segregación de ligas ranked a un **cruce de una sola vía**: un jugador **verificado** (ticket) ahora puede **bajar** a una sala **Externa** (PIN) y jugar, mientras que un jugador **externo** sigue **sin poder subir** a una sala **Verificada**.

### Why / Por qué

- **Tournaments stay pure / Los torneos quedan puros**: Verified rooms remain ticket-only, so tournament-grade rooms are still verified-vs-verified. The asymmetry guarantees it for free. / Las salas Verificadas siguen siendo solo-ticket, así que las salas de torneo siguen siendo verificado-vs-verificado. La asimetría lo garantiza gratis.
- **Trust signal / Señal de confianza**: the lobby already shows External and Verified rooms apart (#274). Externals see a club they cannot sit at, which nudges them to verify over time. / El lobby ya muestra las salas Externas separadas de las Verificadas (#274). Los externos ven un club al que no pueden sentarse, lo que los empuja a verificarse con el tiempo.
- **Shared ranking / Ranking compartido**: ranked stays a single table; a verified player who steps down earns ranked points against PIN identities by choice. / El ranking sigue siendo una tabla única; un verificado que baja juega puntos ranked contra identidades PIN por elección propia.

### Scope / Alcance

One line in `RoomLeague.admitsAsPlayer` (the single source of truth for "who may sit"). Both the **JOIN path** and the **spectator→player escalation** already route through it, so both honor the new rule automatically. / Una línea en `RoomLeague.admitsAsPlayer` (la única fuente de verdad de "quién se sienta"). Tanto el **JOIN** como la **escalada espectador→jugador** ya pasan por ahí, así que ambos respetan la regla nueva automáticamente.

```ts
case "external":
    return credential.kind === "external" || credential.kind === "verified";
```

## Related Issue(s) / Issue(s) relacionado(s)

N/A — follows the lobby split (#274) and the admission redesign.

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [ ] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

Strict TDD (RED→GREEN). `RoomLeague.test.ts` / `RoomAdmission.test.ts` updated to the new contract, plus a new test pinning the one-way asymmetry (`verified` sits in External, `external` never sits in Verified). / Strict TDD (RED→GREEN). `RoomLeague.test.ts` / `RoomAdmission.test.ts` actualizados al contrato nuevo, más un test nuevo que clava la asimetría de una vía.

Verified **manually with real clients**: verified joins/escalates into an External room and plays; an external in a Verified room still only watches. / Verificado **manualmente con clientes reales**: un verificado entra/escala en una sala Externa y juega; un externo en una sala Verificada sigue solo mirando.

**Local verification:** `npm run lint` ✓ · `tsc --noEmit` ✓ · `npm test` → 80 suites, 702 tests ✓