### PR TITLE
fix(join): route blank join password to a default room instead of AI

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ async function start(): Promise<void> {
   // Windbot bootstrap — ONLY when ENABLE_WINDBOT=true.
   // When enabled, AI/wind strategies are prepended to the base chain:
   //   1. AIJoinTokenStrategy — AIJOIN# prefix (reverse-connecting bot)
-  //   2. WindBotJoinStrategy — blank / AI / AI#name (human requesting bot)
+  //   2. WindBotJoinStrategy — explicit "ai" token, AI / AI#name (human requesting bot)
   //   3. TicketJoinStrategy  — ticket-authenticated ranked join
   //   4. DefaultJoinStrategy — game password / unranked fallback
   // config.windbot is parsed (and validated for fail-fast) at module load time in src/config/index.ts.

--- a/src/ygopro/room/application/join-strategies/JoinStrategyRegistry.ts
+++ b/src/ygopro/room/application/join-strategies/JoinStrategyRegistry.ts
@@ -6,8 +6,8 @@ import { DefaultJoinStrategy } from "./DefaultJoinStrategy";
  *
  * Priority order (highest to lowest):
  *   1. AIJoinTokenStrategy  — catches reverse-connecting bot first (AIJOIN# prefix)
- *   2. WindBotJoinStrategy  — matches blank / AI / AI#name when windbot enabled
- *   3. DefaultJoinStrategy  — terminal fallback, always matches
+ *   2. WindBotJoinStrategy  — matches the explicit "ai" token (AI / AI#name) when windbot enabled
+ *   3. DefaultJoinStrategy  — terminal fallback, always matches (blank password lands here)
  *
  * Mirrors the YGOProRoomList module-level singleton pattern.
  *

--- a/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.test.ts
@@ -132,9 +132,9 @@ describe("WindBotJoinStrategy", () => {
 			expect(strategy.matches(makeCtx("AI#Anna"))).toBe(false);
 		});
 
-		it("returns true for blank password when enabled", () => {
+		it("returns false for blank password — blank routes to the default chain, not AI", () => {
 			const strategy = new WindBotJoinStrategy(makeModule());
-			expect(strategy.matches(makeCtx(""))).toBe(true);
+			expect(strategy.matches(makeCtx(""))).toBe(false);
 		});
 
 		it("returns true for 'AI' password when enabled", () => {

--- a/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.ts
@@ -8,10 +8,14 @@ import { YGOProRoom } from "../../domain/YGOProRoom";
 import YGOProRoomList from "../../infrastructure/YGOProRoomList";
 
 /**
- * WindBotJoinStrategy — handles blank / AI / AI#name join passwords.
+ * WindBotJoinStrategy — handles AI / AI#name join passwords (explicit "ai" token).
+ *
+ * A blank password is NOT an AI request — it falls through to the default chain
+ * and creates a normal room. Only an explicit "ai" token (any position,
+ * case-insensitive) routes here.
  *
  * Matches only when WindbotModule is enabled (falls through to DefaultJoinStrategy
- * when ENABLE_WINDBOT=false, so AI/blank become normal room names).
+ * when ENABLE_WINDBOT=false, so AI becomes a normal room name).
  *
  * Rejects tag-mode rooms BEFORE any room or token is created.
  * Sets windbot, noHost, noReconnect flags on the created room.
@@ -23,11 +27,6 @@ export class WindBotJoinStrategy implements JoinStrategy {
 	matches(ctx: JoinContext): boolean {
 		if (!this.module.isEnabled()) {
 			return false;
-		}
-
-		// Blank password routes to windbot when enabled
-		if (ctx.rawPass === "") {
-			return true;
 		}
 
 		// Extract config segment (everything before the first "#"), split by comma,
@@ -45,7 +44,6 @@ export class WindBotJoinStrategy implements JoinStrategy {
 		// "ai,jtp#Joey" → botName = "Joey"
 		// "nc,ns,ai#joey" → botName = "joey"
 		// "ai" / "nc,ai" (no "#") → botName = null (random)
-		// blank → null (random)
 		const botNameOrNull = ctx.password !== "" ? ctx.password : null;
 
 		// Create the room through the SAME path as the default flow


### PR DESCRIPTION
## Description / Descripción

EN: A blank join password was matched by `WindBotJoinStrategy` and spawned an AI (WindBot) room, so a player who left the room field empty was sent to play against the AI. Blank now falls through to the default chain and creates a normal room; only an explicit `ai` token (any position, case-insensitive) routes to WindBot.

ES: Una contraseña de unión vacía era capturada por `WindBotJoinStrategy` y creaba una sala de IA (WindBot), así que un jugador que dejaba el campo de sala vacío terminaba jugando contra la IA. Ahora el campo vacío cae a la cadena por defecto y crea una sala normal; solo un token `ai` explícito (en cualquier posición, sin distinguir mayúsculas) enruta a WindBot.

## Related Issue(s) / Issue(s) relacionado(s)

N/A — reported bug: leaving the room field empty sends players to play vs the AI.

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [ ] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

Strict TDD (RED→GREEN): `WindBotJoinStrategy.test.ts` flips the blank-password case to assert it no longer routes to AI, then the `if (rawPass === "") return true` branch is removed from `matches()`. Doc comments updated in `WindBotJoinStrategy`, `JoinStrategyRegistry`, and `index.ts`.

| File | Change |
|------|--------|
| `WindBotJoinStrategy.ts` | Remove the blank→AI branch; only the explicit `ai` token matches |
| `WindBotJoinStrategy.test.ts` | Blank password now asserts `false` (routes to the default chain) |
| `JoinStrategyRegistry.ts` | Doc: blank password lands on `DefaultJoinStrategy` |
| `index.ts` | Doc: WindBot matches the explicit `ai` token |

**Local verification:** `npm run lint` ✓ · `tsc --noEmit` ✓ · `npm test` → 80 suites, 704 tests ✓
