### PR TITLE
feat(admission): tell PIN users their credentials are invalid on rejection

### DIFF
--- a/src/ygopro/room/admission/application/AdmitToRoom.ts
+++ b/src/ygopro/room/admission/application/AdmitToRoom.ts
@@ -1,4 +1,5 @@
 import { PlayerInfoMessage } from "@edopro/messages/client-to-server/PlayerInfoMessage";
+import { Logger } from "@shared/logger/domain/Logger";
 import { Admission, AdmissionRejection } from "@shared/room/admission/domain/Admission";
 import { PlayerCredential } from "@shared/room/admission/domain/PlayerCredential";
 import { RoomAdmission } from "@shared/room/admission/domain/RoomAdmission";
@@ -34,6 +35,7 @@ export class AdmitToRoom {
 	constructor(
 		private readonly resolver: CredentialResolver,
 		private readonly admission: RoomAdmission,
+		private readonly logger?: Logger,
 	) {}
 
 	async run(
@@ -46,6 +48,12 @@ export class AdmitToRoom {
 			league: target.league,
 			freeSeat: target.freeSeat(),
 		});
+
+		this.logger?.debug(
+			`admission/decision: credential=${credential.kind} league=${target.league.type} decision=${result.kind}${
+				result.kind === "rejected" ? ` reason=${result.reason}` : ""
+			}`,
+		);
 
 		switch (result.kind) {
 			case "player":

--- a/src/ygopro/room/admission/application/CredentialResolver.ts
+++ b/src/ygopro/room/admission/application/CredentialResolver.ts
@@ -1,4 +1,5 @@
 import { PlayerInfoMessage } from "@edopro/messages/client-to-server/PlayerInfoMessage";
+import { Logger } from "@shared/logger/domain/Logger";
 import { PlayerCredential } from "@shared/room/admission/domain/PlayerCredential";
 import { ISocket } from "@shared/socket/domain/ISocket";
 import { UserAuth } from "@shared/user-auth/application/UserAuth";
@@ -24,24 +25,44 @@ export class CredentialResolver {
 	constructor(
 		private readonly userProfileRepository: UserProfileRepository,
 		private readonly userAuth: UserAuth,
+		private readonly logger?: Logger,
 	) {}
 
 	async resolve(socket: ISocket, playerInfo: PlayerInfoMessage): Promise<PlayerCredential> {
 		if (socket.resolvedUserId) {
 			const profile = await this.userProfileRepository.findById(socket.resolvedUserId);
 			if (profile && !(await this.userProfileRepository.isBanned(profile.id))) {
+				this.logger?.debug(
+					`admission/credential: resolved=verified name="${playerInfo.name}" userId=${profile.id}`,
+				);
 				return { kind: "verified", userId: profile.id };
 			}
+			this.logger?.debug(
+				`admission/credential: ticket present but invalid/banned, degrading to guest name="${playerInfo.name}"`,
+			);
 			return { kind: "guest", name: playerInfo.name };
 		}
 
 		if (playerInfo.password) {
 			const user = await this.userAuth.run(playerInfo);
 			if (user instanceof UserProfile) {
+				this.logger?.debug(
+					`admission/credential: resolved=external name="${playerInfo.name}" userId=${user.id}`,
+				);
 				return { kind: "external", userId: user.id };
 			}
+			// PIN was present but UserAuth did NOT return a profile (user-not-found,
+			// banned, or invalid PIN). Identity degrades to guest — which a ranked
+			// room then rejects. This log pinpoints the PIN as the failure point.
+			this.logger?.debug(
+				`admission/credential: PIN present but auth FAILED → degrading to guest name="${playerInfo.name}"`,
+			);
+			return { kind: "guest", name: playerInfo.name };
 		}
 
+		this.logger?.debug(
+			`admission/credential: resolved=guest (no ticket, no PIN) name="${playerInfo.name}"`,
+		);
 		return { kind: "guest", name: playerInfo.name };
 	}
 }

--- a/src/ygopro/room/domain/YGOProRoom.ts
+++ b/src/ygopro/room/domain/YGOProRoom.ts
@@ -37,11 +37,13 @@ import { HostInfo } from "./host-info/HostInfo";
 import { getLobbyDuelInfo } from "./LobbyDuelFlags";
 
 import {
+  ChatColor,
   ErrorMessageType,
   GameMode,
   NetPlayerType,
   PlayerChangeState,
   YGOProMsgBase,
+  YGOProStocChat,
   YGOProStocDeckCount,
   YGOProStocDeckCount_DeckInfo,
 } from "ygopro-msg-encode";
@@ -344,8 +346,13 @@ export class YGOProRoom extends YgoRoom {
     this._roomState?.removeAllListener();
     const userProfileRepo = new UserProfilePostgresRepository();
     const admitToRoom = new AdmitToRoom(
-      new CredentialResolver(userProfileRepo, new UserAuth(userProfileRepo)),
+      new CredentialResolver(
+        userProfileRepo,
+        new UserAuth(userProfileRepo),
+        this._logger,
+      ),
       new RoomAdmission(),
+      this._logger,
     );
     this._roomState = new YGOProWaitingState(
       admitToRoom,
@@ -447,6 +454,18 @@ export class YGOProRoom extends YgoRoom {
         this.addSpectatorUnsafe(spectator);
       },
       rejectAdmission: () => {
+        // A client that supplied a PIN but was still turned away authenticated
+        // as a guest — its PIN did not resolve to a valid account (wrong PIN,
+        // unknown user, or banned). Tell the player WHY before the generic join
+        // error, so a mistyped password isn't an opaque failure. Text is sent as
+        // a STOC_CHAT (the ygopro path's mechanism, matching the duel/side states).
+        if (playerInfo.password) {
+          const chat = new YGOProStocChat().fromPartial({
+            player_type: ChatColor.RED,
+            msg: "Invalid username or password.",
+          });
+          socket.send(Buffer.from(chat.toFullPayload()));
+        }
         socket.send(this.messageSender.errorMessage(ErrorMessageType.JOINERROR));
         socket.close();
       },

--- a/src/ygopro/room/domain/YGOProRoomAdmissionTarget.test.ts
+++ b/src/ygopro/room/domain/YGOProRoomAdmissionTarget.test.ts
@@ -4,6 +4,8 @@ import { ISocket } from "@shared/socket/domain/ISocket";
 
 import { YGOProRoomMother } from "@test-support/mothers/room/YGOProRoomMother";
 
+import { ChatColor, YGOProStocChat } from "ygopro-msg-encode";
+
 jest.mock("@ygopro/SimpleRoomMessageEmitter");
 
 const makeSocket = (): ISocket =>
@@ -18,8 +20,8 @@ const makeSocket = (): ISocket =>
 		closed: false,
 	}) as unknown as ISocket;
 
-const playerInfo = (name: string): PlayerInfoMessage =>
-	({ name, password: null }) as unknown as PlayerInfoMessage;
+const playerInfo = (name: string, password: string | null = null): PlayerInfoMessage =>
+	({ name, password }) as unknown as PlayerInfoMessage;
 
 describe("YGOProRoom.admissionTarget", () => {
 	it("exposes the room's league", () => {
@@ -81,5 +83,34 @@ describe("YGOProRoom.admissionTarget", () => {
 
 		expect(socket.send).toHaveBeenCalled();
 		expect(socket.close).toHaveBeenCalled();
+	});
+
+	it("rejectAdmission explains invalid credentials when the client supplied a PIN", () => {
+		const room = YGOProRoomMother.create();
+		const socket = makeSocket();
+		// password present → the client tried to authenticate with a PIN that did
+		// not resolve to a valid account, so it was turned away as a guest.
+		const target = room.admissionTarget(socket, playerInfo("P", "1313"));
+
+		target.rejectAdmission("ranked-requires-account");
+
+		const expectedChat = Buffer.from(
+			new YGOProStocChat()
+				.fromPartial({ player_type: ChatColor.RED, msg: "Invalid username or password." })
+				.toFullPayload(),
+		);
+		expect(socket.send).toHaveBeenNthCalledWith(1, expectedChat);
+		expect(socket.close).toHaveBeenCalled();
+	});
+
+	it("rejectAdmission does NOT send a credentials message when no PIN was supplied", () => {
+		const room = YGOProRoomMother.create();
+		const socket = makeSocket();
+		const target = room.admissionTarget(socket, playerInfo("P"));
+
+		target.rejectAdmission("ranked-requires-account");
+
+		// Only the generic JOINERROR — a genuine guest never sent credentials.
+		expect(socket.send).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
## Description / Descripción

EN: When a PIN-authenticated (external) player's credentials fail to validate, the identity degrades to `guest` and a ranked room rejects it — previously with an opaque `JOINERROR`, so the player never learned a wrong password was the cause. The rejection now sends a red `STOC_CHAT` "Invalid username or password." before the `JOINERROR`. It also adds debug-level admission diagnostics (resolved credential kind + the admission decision) behind an optional logger, to ease triage of similar reports.

ES: Cuando las credenciales de un jugador autenticado por PIN (externo) no validan, la identidad degrada a `guest` y una sala ranked lo rechaza — antes con un `JOINERROR` opaco, así que el jugador nunca sabía que el motivo era una contraseña incorrecta. Ahora el rechazo envía un `STOC_CHAT` rojo "Invalid username or password." antes del `JOINERROR`. También agrega diagnósticos de admisión a nivel debug (tipo de credencial resuelto + la decisión de admisión) detrás de un logger opcional, para facilitar el diagnóstico de reportes similares.

## Related Issue(s) / Issue(s) relacionado(s)

N/A — follows the admission redesign (#275, #277).

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [ ] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

Strict TDD (RED→GREEN): two new tests in `YGOProRoomAdmissionTarget.test.ts` — a PIN-supplied rejection emits the credentials `STOC_CHAT`, and a no-PIN rejection sends only the generic `JOINERROR`. The text is sent the ygopro way (`YGOProStocChat`, `ChatColor.RED`), matching the duel/side states — NOT the edopro `ServerErrorClientMessage` (type `0xf3`), which does not render on this path.

| File | Change |
|------|--------|
| `YGOProRoom.ts` | `rejectAdmission` sends the credentials chat for PIN clients; wires the logger into admission |
| `CredentialResolver.ts` | Optional logger; debug logs of the resolved credential + degrade-to-guest cause |
| `AdmitToRoom.ts` | Optional logger; debug log of the admission decision |
| `YGOProRoomAdmissionTarget.test.ts` | 2 new tests |

Verified **manually with real clients**: a wrong-PIN external player now sees the red "Invalid username or password." message on the pre-seat rejection.

**Local verification:** `npm run lint` ✓ · `tsc --noEmit` ✓ · `npm test` → 80 suites, 704 tests ✓
