### PR TITLE
refactor: remove dead private class members

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -56,7 +56,7 @@
 				"noUnsafeFinally": "error",
 				"noUnsafeOptionalChaining": "error",
 				"noUnusedLabels": "error",
-				"noUnusedPrivateClassMembers": "off",
+				"noUnusedPrivateClassMembers": "error",
 				"noUnusedVariables": "error",
 				"useIsNan": "error",
 				"useValidForDirection": "error",

--- a/src/edopro/messages/JSONMessageProcessor.ts
+++ b/src/edopro/messages/JSONMessageProcessor.ts
@@ -7,9 +7,7 @@ export interface JSONClientMessage {
 export class JSONMessageProcessor {
 	private buffer: Buffer;
 	private _size: number;
-	private readonly _command: number;
 	private _data: string;
-	private readonly _previousMessage: Buffer;
 
 	constructor() {
 		this.buffer = Buffer.alloc(0);
@@ -23,9 +21,6 @@ export class JSONMessageProcessor {
 	process(): void {
 		if (!this.isMessageReady()) {
 			return;
-		}
-		if (this._data.length) {
-			// this._previousMessage = this._data;
 		}
 		this._size = this.buffer.readUint32LE(0);
 		this._data = this.buffer.subarray(4, this._size + 4).toString("utf-8");

--- a/src/edopro/room/application/RoomCreator.ts
+++ b/src/edopro/room/application/RoomCreator.ts
@@ -3,14 +3,12 @@ import { EventEmitter } from "stream";
 
 import { CreateRoomRequest } from "../../../http-server/controllers/CreateRoomController";
 import { Logger } from "../../../shared/logger/domain/Logger";
-import { ISocket } from "../../../shared/socket/domain/ISocket";
 import { UTF8ToUTF16 } from "../../../utils/UTF8ToUTF16";
 import BanListMemoryRepository from "../../ban-list/infrastructure/BanListMemoryRepository";
 import { Room } from "../domain/Room";
 import RoomList from "../infrastructure/RoomList";
 
 export class RoomCreator {
-	private readonly socket: ISocket;
 	constructor(private readonly logger: Logger) {}
 
 	create(payload: CreateRoomRequest): { password: string } {

--- a/src/edopro/room/domain/Room.ts
+++ b/src/edopro/room/domain/Room.ts
@@ -116,7 +116,6 @@ export class Room extends YgoRoom {
 	private _playerExtraDeckSize: number;
 	private _opponentMainDeckSize: number;
 	private _opponentExtraDeckSize: number;
-	private readonly _turn = 0;
 	private readonly timers: Timer[];
 	private readonly roomTimer: Timer;
 	private roomState: RoomState | null = null;

--- a/src/http-server/controllers/ServerMessagesController.ts
+++ b/src/http-server/controllers/ServerMessagesController.ts
@@ -4,7 +4,6 @@ import { z } from "zod";
 import { ServerMessageClientMessage } from "../../edopro/messages/server-to-client/ServerMessageClientMessage";
 import RoomList from "../../edopro/room/infrastructure/RoomList";
 import MercuryRoomList from "@ygopro/room/infrastructure/YGOProRoomList";
-import { Logger } from "../../shared/logger/domain/Logger";
 
 export const ServerMessageSchema = z.object({
 	message: z.string().min(1).max(500),
@@ -14,8 +13,6 @@ export const ServerMessageSchema = z.object({
 export type CreateMessageRequest = z.infer<typeof ServerMessageSchema>;
 
 export class ServerMessagesController {
-	constructor(private readonly logger: Logger) {}
-
 	async run(req: Request, response: Response): Promise<void> {
 		const validation = ServerMessageSchema.safeParse(req.body);
 

--- a/src/http-server/routes/index.ts
+++ b/src/http-server/routes/index.ts
@@ -17,6 +17,6 @@ export function loadRoutes(app: Express, logger: Logger): void {
 	app.use("/api/admin", AuthAdminMiddleware);
 
 	app.post("/api/admin/message", async (req, res) => {
-		await new ServerMessagesController(logger).run(req, res);
+		await new ServerMessagesController().run(req, res);
 	});
 }

--- a/src/shared/deck/domain/errors/BanListDeckError.ts
+++ b/src/shared/deck/domain/errors/BanListDeckError.ts
@@ -2,10 +2,7 @@ import { DeckError } from "./DeckError";
 import { DeckErrorType } from "./DeckErrorType";
 
 export class BanListDeckError extends DeckError {
-	private readonly cardId: number;
-
 	constructor(cardId: number) {
 		super({ type: DeckErrorType.CARD_BANLISTED, code: cardId, got: 0, min: 0, max: 0 });
-		this.cardId = cardId;
 	}
 }

--- a/src/shared/deck/domain/errors/CardMoreThan3Error.ts
+++ b/src/shared/deck/domain/errors/CardMoreThan3Error.ts
@@ -2,10 +2,7 @@ import { DeckError } from "./DeckError";
 import { DeckErrorType } from "./DeckErrorType";
 
 export class CardMoreThan3Error extends DeckError {
-	private readonly cardId: number;
-
 	constructor(cardId: number) {
 		super({ type: DeckErrorType.CARD_MORE_THAN_3, code: cardId, got: 0, min: 0, max: 0 });
-		this.cardId = cardId;
 	}
 }

--- a/src/shared/deck/domain/errors/NotOfficialCardError.ts
+++ b/src/shared/deck/domain/errors/NotOfficialCardError.ts
@@ -2,10 +2,7 @@ import { DeckError } from "./DeckError";
 import { DeckErrorType } from "./DeckErrorType";
 
 export class NotOfficialCardError extends DeckError {
-	private readonly cardId: number;
-
 	constructor(cardId: number) {
 		super({ type: DeckErrorType.CARD_UNOFFICIAL, code: cardId, got: 0, min: 0, max: 0 });
-		this.cardId = cardId;
 	}
 }

--- a/src/shared/deck/domain/errors/OCGCardError.ts
+++ b/src/shared/deck/domain/errors/OCGCardError.ts
@@ -2,10 +2,7 @@ import { DeckError } from "./DeckError";
 import { DeckErrorType } from "./DeckErrorType";
 
 export class OCGCardError extends DeckError {
-	private readonly cardId: number;
-
 	constructor(cardId: number) {
 		super({ type: DeckErrorType.CARD_OCG_ONLY, code: cardId, got: 0, min: 0, max: 0 });
-		this.cardId = cardId;
 	}
 }

--- a/src/shared/deck/domain/errors/TCGCardError.ts
+++ b/src/shared/deck/domain/errors/TCGCardError.ts
@@ -2,10 +2,7 @@ import { DeckError } from "./DeckError";
 import { DeckErrorType } from "./DeckErrorType";
 
 export class TCGCardError extends DeckError {
-	private readonly cardId: number;
-
 	constructor(cardId: number) {
 		super({ type: DeckErrorType.CARD_TCG_ONLY, code: cardId, got: 0, min: 0, max: 0 });
-		this.cardId = cardId;
 	}
 }

--- a/src/shared/deck/domain/errors/UnknownCardError.ts
+++ b/src/shared/deck/domain/errors/UnknownCardError.ts
@@ -2,10 +2,7 @@ import { DeckError } from "./DeckError";
 import { DeckErrorType } from "./DeckErrorType";
 
 export class UnknownCardError extends DeckError {
-	private readonly cardId: number;
-
 	constructor(cardId: number) {
 		super({ type: DeckErrorType.CARD_UNKNOWN, code: cardId, got: 0, min: 0, max: 0 });
-		this.cardId = cardId;
 	}
 }

--- a/src/shared/deck/domain/validators/GenesysRulesValidationHandler.ts
+++ b/src/shared/deck/domain/validators/GenesysRulesValidationHandler.ts
@@ -1,4 +1,3 @@
-import { EdoproBanList } from "@edopro/ban-list/domain/BanList";
 import { CardTypes } from "@shared/card/domain/CardTypes";
 import genesys from "genesys.json";
 
@@ -9,7 +8,6 @@ import { MainDeckLimitError } from "../errors/MainDeckLimitError";
 import { DeckValidationHandler } from "./DeckValidationHandler";
 
 export class GenesysRulesValidationHandler implements DeckValidationHandler {
-	private readonly banList: EdoproBanList;
 	private readonly nextHandler: DeckValidationHandler | null = null;
 	private readonly genesysMap = new Map(genesys.map((item) => [item.code.toString(), item.points]));
 


### PR DESCRIPTION
## Summary

Follow-up to the Biome migration (#283). Re-enables Biome's `noUnusedPrivateClassMembers` rule (disabled during the migration to keep it a pure drop-in) and removes the 12 unused private members it surfaced — real dead code the old ESLint never reported.

## Changes

| File | Removed |
|---|---|
| `JSONMessageProcessor.ts` | `_command`, `_previousMessage` fields + a dead `if` block whose only body was a commented-out assignment |
| `RoomCreator.ts` | unused `socket` field (+ its `ISocket` import) |
| `Room.ts` | `_turn` field |
| `ServerMessagesController.ts` | unused injected `logger` (constructor + `Logger` import); updated the call site in `routes/index.ts` |
| `GenesysRulesValidationHandler.ts` | unused `banList` field (+ its `EdoproBanList` import) |
| 6× deck `*Error.ts` | write-only `cardId` field + its assignment (the parameter stays — it's still passed to `super`) |

`biome.json`: `noUnusedPrivateClassMembers` flipped from `off` to `error`.

## Validation

- `biome lint` — clean (0 errors).
- `npm run build` — exit 0.
- `npm test` — **704 tests / 80 suites pass**, unchanged.

No behavior changes — every removed member was either never read or write-only.