### PR TITLE
chore: fix dead hash in .git-blame-ignore-revs after squash merge

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,7 +1,8 @@
 # Bulk reformat with Biome (2-space indentation -> tabs).
-# Format-only commit; safe to ignore for `git blame`.
+# Squash commit of the ESLint+Prettier -> Biome migration (#283): most of
+# its diff is the mechanical reflow, safe to ignore for `git blame`.
 #
 # Enable locally with:
 #   git config blame.ignoreRevsFile .git-blame-ignore-revs
 # GitHub applies this file automatically.
-c08c24693b4e5a50d0a946c8c588ded75bc5bf39
+b8bbc32ab6fd89f1ab955b6426cd13cd1095a772


### PR DESCRIPTION
## Problem

The Biome migration (#283) was **squash-merged**, so the original reformat commit `c08c2469` — the hash recorded in `.git-blame-ignore-revs` — never reached `main`. The blame-ignore file was pointing at a non-existent commit, so `git blame` was not skipping the mass spaces→tabs reflow.

## Fix

Repoint the file at the squash commit `b8bbc32a` (the `(#283)` commit on `main`). Most of that commit's diff is the mechanical reflow; the few config lines it also carries are harmless to blame-ignore.

Verified: the hash resolves on `main` and `git blame --ignore-revs-file` runs without error.