### PR TITLE
refactor: remove empty blocks flagged by Biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -83,7 +83,7 @@
 				"noDuplicateEnumValues": "error",
 				"noDuplicateObjectKeys": "error",
 				"noDuplicateParameters": "error",
-				"noEmptyBlockStatements": "off",
+				"noEmptyBlockStatements": "error",
 				"noExplicitAny": "error",
 				"noExtraNonNullAssertion": "error",
 				"noFallthroughSwitchClause": "error",

--- a/src/edopro/room/domain/Room.ts
+++ b/src/edopro/room/domain/Room.ts
@@ -709,8 +709,6 @@ export class Room extends YgoRoom {
 
 		team0Players.find((p) => p.duelPosition === 0)?.turn();
 		team1Players.find((p) => p.duelPosition === 0)?.turn();
-
-		this.players.forEach((element: Client) => {});
 	}
 
 	nextTurn(team: number): void {

--- a/src/ygopro/windbot/domain/WindbotTokenStore.ts
+++ b/src/ygopro/windbot/domain/WindbotTokenStore.ts
@@ -9,8 +9,6 @@ export type WindbotTokenPayload = {
 export class WindbotTokenStore {
 	private readonly entries: Map<string, WindbotTokenPayload> = new Map();
 
-	constructor() {}
-
 	register(roomId: number, botName: string, deck: string): string {
 		const token = this._generateUniqueToken();
 		this.entries.set(token, { roomId, botName, deck });


### PR DESCRIPTION
## Summary

Follow-up to the Biome migration. Re-enables `noEmptyBlockStatements` — the last rule that was turned off during the migration to keep it a pure drop-in — and removes the 2 empty blocks it surfaced.

## Changes

| File | Removed |
|---|---|
| `Room.ts` | `this.players.forEach((element) => {})` — a no-op iteration with an empty body that did nothing |
| `WindbotTokenStore.ts` | empty `constructor() {}` — `entries` is initialized inline and there's no DI, so the default constructor suffices |

`biome.json`: `noEmptyBlockStatements` flipped from `off` to `error`.

## Validation

- `biome lint` — clean (0 errors).
- `npm run build` — exit 0.
- `npm test` — **704 tests / 80 suites pass**, unchanged.

With this, all rules disabled during the migration are back on; the config no longer carries any drop-in concessions.