### PR TITLE
ci: enforce Biome format check in the pipeline

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -26,8 +26,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Lint
-        run: npm run lint
+      - name: Lint & format check
+        run: npx biome ci
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
## Summary

Closes the last follow-up from the Biome migration. The pipeline already had a lint step (`npm run lint` → `biome lint`), but **`biome lint` only checks lint rules, not formatting**. Mis-formatted code (e.g. spaces instead of tabs, wrong line width) could be merged without CI noticing.

## Change

Replace the `Lint` step with a `Lint & format check` step that runs `biome ci` — Biome's read-only CI command that validates **lint + formatting + assist** in a single pass, optimized for CI (GitHub Actions reporter, never writes).

```diff
-      - name: Lint
-        run: npm run lint
+      - name: Lint & format check
+        run: npx biome ci
```

## Verification

- Demonstrated the gap locally: a deliberately mis-formatted file passed `biome lint` but failed `biome ci` ("File content differs from formatting output").
- `biome ci` runs clean against the current repo (377 files, 0 errors).

The Husky pre-commit hook (lint-staged → `biome check --write`) is unchanged; this just makes CI a true backstop if the hook is bypassed.