### PR TITLE
ci: align CI Node version with engines (22 → 24)

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

`package.json` declares `engines.node >=24.11.0`, but `pipeline.yaml` ran `npm ci`, build, and tests on **Node 22** — CI was validating on a runtime the project doesn't claim to support.

## Change

```diff
       - uses: actions/setup-node@v3
         with:
-          node-version: 22
+          node-version: 24
```

`node-version: 24` resolves to the latest 24.x, which satisfies `>=24.11.0`. Local development runs on 24.13.0; the full build + test suite already passes there.

## Notes

- There's no `.nvmrc`/`.node-version` in the repo, so the engines field is the only source of truth — this keeps CI consistent with it. A `.nvmrc` could pin local + CI to an exact version later if desired.
- Unrelated and left untouched: the workflow still uses `actions/checkout@v3` and `actions/setup-node@v3`, which are getting old and could be bumped to `@v4` in a separate change.