### PR TITLE
ci: bump checkout and setup-node actions to latest majors

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: true
@@ -19,7 +19,7 @@ jobs:
       - name: Update submodules
         run: git submodule update --init --recursive
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -19,7 +19,7 @@ jobs:
           release-type: node
       - name: Checkout 🛬
         if: ${{ steps.release.outputs.release_created }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Tag major and minor versions 🏷
         if: ${{ steps.release.outputs.release_created }}
         run: |


### PR DESCRIPTION
## Summary

The workflows pinned old action majors whose action runtimes GitHub is deprecating. Bump them to the current stable majors.

| Action | Before | After | Where |
|---|---|---|---|
| `actions/checkout` | `@v3` | `@v7` | `pipeline.yaml` |
| `actions/checkout` | `@v4` | `@v7` | `release-please.yaml` |
| `actions/setup-node` | `@v3` | `@v6` | `pipeline.yaml` |

Latest majors verified via the GitHub releases API: checkout `v7.0.0`, setup-node `v6.4.0`.

## Risk

Low. Usage is basic — `checkout` with `fetch-depth: 0` + `submodules: true`, `setup-node` with `node-version: 24`. These inputs are stable across the bumped majors; the major bumps are mostly the action's own Node runtime.

`pipeline.yaml` runs on `pull_request`, so this PR's own checks exercise `checkout@v7` + `setup-node@v6` end to end. (`release-please.yaml` only runs on push to `main`, so its bump validates on merge.)

## Note

`googleapis/release-please-action@v4` was left as-is — out of scope for this action-runtime bump.