### PR TITLE
feat(ygopro): add ws heartbeat and app-level ping echo

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -31,6 +31,7 @@ export const config = {
 		mercury: {
 			port: Number(process.env.YGOPRO_PORT),
 			wsPort: Number(process.env.YGOPRO_WEBSOCKET_PORT) || 4002,
+			wsHeartbeatIntervalMs: Number(process.env.YGOPRO_WEBSOCKET_HEARTBEAT_MS) || 30000,
 		},
 		http: {
 			port: Number(process.env.HTTP_PORT),

--- a/src/socket-server/WSYGOProServer.test.ts
+++ b/src/socket-server/WSYGOProServer.test.ts
@@ -4,6 +4,7 @@ import { WebSocket, WebSocketServer } from "ws";
 
 import { Logger } from "@shared/logger/domain/Logger";
 import { WebSocketClientSocket } from "../shared/socket/domain/WebSocketClientSocket";
+import { Commands } from "../shared/messages/Commands";
 import { MessageEmitter } from "../edopro/MessageEmitter";
 import { HandshakeTicketAuthenticator } from "./HandshakeTicketAuthenticator";
 import { WSYGOProServer } from "./WSYGOProServer";
@@ -13,7 +14,7 @@ jest.mock("ws");
 jest.mock("http", () => ({ createServer: jest.fn().mockReturnValue({}) }));
 jest.mock("crypto", () => ({ randomUUID: jest.fn().mockReturnValue("test-socket-uuid") }));
 jest.mock("src/config", () => ({
-	config: { servers: { mercury: { wsPort: 7800 } } },
+	config: { servers: { mercury: { wsPort: 7800, wsHeartbeatIntervalMs: 30000 } } },
 }));
 jest.mock("src/shared/user-auth/application/CheckIfUserCanJoin");
 jest.mock("src/shared/user-auth/application/UserAuth");
@@ -35,6 +36,7 @@ const makeRawSocket = (): WebSocket =>
 		send: jest.fn(),
 		close: jest.fn(),
 		terminate: jest.fn(),
+		ping: jest.fn(),
 		readyState: 1, // WebSocket.OPEN
 	}) as unknown as WebSocket;
 
@@ -51,13 +53,20 @@ describe("WSYGOProServer", () => {
 	let mockClientSocket: {
 		resolvedUserId?: string;
 		close: jest.Mock;
+		send: jest.Mock;
 		onMessage: jest.Mock;
 		onClose: jest.Mock;
 		id?: string;
 		remoteAddress: string;
 	};
-	let mockWssInstance: { on: jest.Mock; options: { server: { listen: jest.Mock } } };
+	let mockWssInstance: {
+		on: jest.Mock;
+		options: { server: { listen: jest.Mock } };
+		clients: Set<WebSocket>;
+	};
 	let connectionCallback: (rawSocket: WebSocket, req: IncomingMessage) => Promise<void>;
+	let heartbeatTick: () => void;
+	let setIntervalSpy: jest.SpyInstance;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -66,6 +75,7 @@ describe("WSYGOProServer", () => {
 		mockClientSocket = {
 			resolvedUserId: undefined,
 			close: jest.fn(),
+			send: jest.fn(),
 			onMessage: jest.fn(),
 			onClose: jest.fn(),
 			id: undefined,
@@ -79,8 +89,16 @@ describe("WSYGOProServer", () => {
 				if (event === "connection") connectionCallback = cb as typeof connectionCallback;
 			}),
 			options: { server: { listen: jest.fn() } },
+			clients: new Set<WebSocket>(),
 		};
 		(WebSocketServer as unknown as jest.Mock).mockImplementation(() => mockWssInstance);
+
+		// Capture the heartbeat sweep callback instead of running a real timer,
+		// so tests can drive it deterministically and no handle leaks between tests.
+		setIntervalSpy = jest.spyOn(global, "setInterval").mockImplementation(((cb: () => void) => {
+			heartbeatTick = cb;
+			return { unref: jest.fn() } as unknown as NodeJS.Timeout;
+		}) as unknown as typeof setInterval);
 
 		logger = mock<Logger>();
 		logger.child.mockReturnValue(logger);
@@ -88,6 +106,10 @@ describe("WSYGOProServer", () => {
 
 		const server = new WSYGOProServer(logger, handshakeAuth);
 		server.initialize();
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
 	});
 
 	describe("connection handler — ticket authentication", () => {
@@ -171,6 +193,112 @@ describe("WSYGOProServer", () => {
 
 			expect(mockClientSocket.close).toHaveBeenCalled();
 			expect(handleMessage).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("heartbeat — liveness detection", () => {
+		type AliveSocket = WebSocket & { isAlive?: boolean };
+
+		const getPongHandler = (rawSocket: WebSocket): (() => void) => {
+			const call = (rawSocket.on as jest.Mock).mock.calls.find(([event]) => event === "pong");
+			return call[1] as () => void;
+		};
+
+		it("starts the sweep with the configured heartbeat interval", () => {
+			expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 30000);
+		});
+
+		it("marks the connection alive and registers a pong listener on connect", async () => {
+			const rawSocket = makeRawSocket();
+			handshakeAuth.authenticate.mockResolvedValue({ status: "anonymous" });
+
+			await connectionCallback(rawSocket, makeRequest());
+
+			expect((rawSocket as AliveSocket).isAlive).toBe(true);
+			expect(rawSocket.on).toHaveBeenCalledWith("pong", expect.any(Function));
+		});
+
+		it("re-marks the connection alive when a pong arrives", async () => {
+			const rawSocket = makeRawSocket();
+			handshakeAuth.authenticate.mockResolvedValue({ status: "anonymous" });
+
+			await connectionCallback(rawSocket, makeRequest());
+
+			(rawSocket as AliveSocket).isAlive = false;
+			getPongHandler(rawSocket)();
+
+			expect((rawSocket as AliveSocket).isAlive).toBe(true);
+		});
+
+		it("re-marks the connection alive on any inbound message (keeps active duels alive)", async () => {
+			const rawSocket = makeRawSocket();
+			handshakeAuth.authenticate.mockResolvedValue({ status: "authenticated", userId: "u1" });
+
+			let pumpCallback!: (data: Buffer) => Promise<void>;
+			mockClientSocket.onMessage.mockImplementation((cb: (d: Buffer) => Promise<void>) => {
+				pumpCallback = cb;
+			});
+
+			await connectionCallback(rawSocket, makeRequest());
+
+			(rawSocket as AliveSocket).isAlive = false;
+			await pumpCallback(Buffer.from("000022", "hex")); // CHAT, not a ping
+
+			expect((rawSocket as AliveSocket).isAlive).toBe(true);
+		});
+
+		it("terminates unresponsive clients and pings the responsive ones on each sweep", () => {
+			const dead = makeRawSocket() as AliveSocket;
+			const alive = makeRawSocket() as AliveSocket;
+			dead.isAlive = false;
+			alive.isAlive = true;
+			mockWssInstance.clients.add(dead);
+			mockWssInstance.clients.add(alive);
+
+			heartbeatTick();
+
+			expect(dead.terminate).toHaveBeenCalled();
+			expect(dead.ping).not.toHaveBeenCalled();
+			expect(alive.terminate).not.toHaveBeenCalled();
+			expect(alive.ping).toHaveBeenCalled();
+			expect(alive.isAlive).toBe(false);
+		});
+	});
+
+	describe("application-level ping (0xff) echo", () => {
+		const runPump = async (data: Buffer): Promise<void> => {
+			handshakeAuth.authenticate.mockResolvedValue({ status: "authenticated", userId: "u1" });
+			let pumpCallback!: (data: Buffer) => Promise<void>;
+			mockClientSocket.onMessage.mockImplementation((cb: (d: Buffer) => Promise<void>) => {
+				pumpCallback = cb;
+			});
+			await connectionCallback(makeRawSocket(), makeRequest());
+			await pumpCallback(data);
+		};
+
+		it("echoes a PING (0xff) back as PONG (0xfe) preserving the payload, without forwarding it", async () => {
+			const handleMessage = jest.fn();
+			(MessageEmitter as unknown as jest.Mock).mockImplementation(() => ({ handleMessage }));
+			const ping = Buffer.from([0x04, 0x00, Commands.PING, 0xde, 0xad, 0xbe]);
+
+			await runPump(ping);
+
+			expect(mockClientSocket.send).toHaveBeenCalledTimes(1);
+			const sent = mockClientSocket.send.mock.calls[0][0] as Buffer;
+			expect(sent.readUInt8(2)).toBe(0xfe);
+			expect(sent.subarray(3)).toEqual(ping.subarray(3));
+			expect(handleMessage).not.toHaveBeenCalled();
+		});
+
+		it("forwards non-ping frames to the message emitter", async () => {
+			const handleMessage = jest.fn();
+			(MessageEmitter as unknown as jest.Mock).mockImplementation(() => ({ handleMessage }));
+			const chat = Buffer.from([0x01, 0x00, Commands.CHAT]);
+
+			await runPump(chat);
+
+			expect(handleMessage).toHaveBeenCalledWith(chat);
+			expect(mockClientSocket.send).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/socket-server/WSYGOProServer.ts
+++ b/src/socket-server/WSYGOProServer.ts
@@ -6,6 +6,7 @@ import { EventEmitter } from "stream";
 
 import { MessageEmitter } from "../edopro/MessageEmitter";
 import { Logger } from "../shared/logger/domain/Logger";
+import { Commands } from "../shared/messages/Commands";
 import { DisconnectHandler } from "../shared/room/application/DisconnectHandler";
 import { RoomFinder } from "../shared/room/application/RoomFinder";
 import { ExpressReconnectHandler } from "../shared/room/application/reconnect/ExpressReconnectHandler";
@@ -16,6 +17,12 @@ import { YGOProJoinHandler } from "@ygopro/room/application/YGOProJoinHandler";
 import { YGOProMessageRepository } from "@ygopro/room/infrastructure/YGOProMessageRepository";
 import YGOProRoomList from "@ygopro/room/infrastructure/YGOProRoomList";
 import { YGOProClient } from "@ygopro/client/domain/YGOProClient";
+
+// Application-level PONG command echoed back to the client for a PING (0xff).
+const PONG_COMMAND = 0xfe;
+
+// The raw ws socket, tagged with the liveness flag used by the heartbeat sweep.
+type HeartbeatSocket = WebSocket & { isAlive?: boolean };
 
 export class WSYGOProServer {
 	private readonly wss: WebSocketServer;
@@ -36,7 +43,34 @@ export class WSYGOProServer {
 
 		this.wss.options.server?.listen(port);
 
+		// Heartbeat: drop half-open connections (e.g. a mobile client whose runtime
+		// is frozen in background). The browser/native WS layer auto-replies to ping
+		// frames, so a missing pong across one interval means the peer is gone. The
+		// terminate() fires the existing onClose -> DisconnectHandler -> room cleanup.
+		const heartbeatInterval = setInterval(() => {
+			this.wss.clients.forEach((client) => {
+				const heartbeatSocket = client as HeartbeatSocket;
+				if (heartbeatSocket.isAlive === false) {
+					heartbeatSocket.terminate();
+					return;
+				}
+				heartbeatSocket.isAlive = false;
+				heartbeatSocket.ping();
+			});
+		}, config.servers.mercury.wsHeartbeatIntervalMs);
+		heartbeatInterval.unref();
+
+		this.wss.on("close", () => {
+			clearInterval(heartbeatInterval);
+		});
+
 		this.wss.on("connection", async (socket: WebSocket, request: IncomingMessage) => {
+			const heartbeatSocket = socket as HeartbeatSocket;
+			heartbeatSocket.isAlive = true;
+			socket.on("pong", () => {
+				heartbeatSocket.isAlive = true;
+			});
+
 			const ygoClientSocket = new WebSocketClientSocket(socket);
 			const eventEmitter = new EventEmitter();
 			const messageRepository = new YGOProMessageRepository();
@@ -86,10 +120,25 @@ export class WSYGOProServer {
 			});
 
 			ygoClientSocket.onMessage(async (data: Buffer) => {
+				// Any inbound frame proves the peer is alive — keeps active duels
+				// from being reaped by the heartbeat even if a pong is delayed.
+				heartbeatSocket.isAlive = true;
 				connectionLogger.debug(
 					`Incoming message handle by Mercury WS Server: ${data.toString("hex")}`,
 				);
 				await ready;
+
+				// Application-level ping (0xff): echo it straight back as a pong (0xfe)
+				// preserving the payload, so the client can measure RTT in-duel. Mirrors
+				// the TCP server (SocketConnectionHandler); MessageEmitter ignores 0xff.
+				if (data.length >= 3 && data.readUInt8(2) === Commands.PING) {
+					const pongResponse = Buffer.alloc(data.length);
+					data.copy(pongResponse);
+					pongResponse.writeUInt8(PONG_COMMAND, 2);
+					ygoClientSocket.send(pongResponse);
+					return;
+				}
+
 				messageEmitter.handleMessage(data);
 			});
 


### PR DESCRIPTION
## Description / Descripción

Adds a WebSocket heartbeat to the Mercury WS server (`WSYGOProServer`) so the server detects half-open connections — e.g. a mobile client whose runtime is frozen after the game goes to background and never sends a TCP `close`.

- **Heartbeat (`isAlive`)**: each connection starts `isAlive = true` and refreshes it on `pong`. A periodic sweep (`setInterval`) pings every client and `terminate()`s any that missed their pong. `terminate()` triggers the existing `onClose` → `DisconnectHandler` flow, so the player is removed from its room. No client changes required (the browser/native WS layer auto-replies to ping frames; a frozen background runtime stops replying).
- **No false positives in active duels**: any inbound frame also refreshes `isAlive`, so a player mid-duel is never reaped over a delayed pong.
- **App-level ping echo (`0xff` → `0xfe`)**: mirrors the TCP server (`SocketConnectionHandler`) — echoes the PING payload back as PONG so clients can measure in-duel RTT over the WS path too. Previously this was only handled on the TCP path, so WS clients had no ping reply.
- **Configurable**: interval via `YGOPRO_WEBSOCKET_HEARTBEAT_MS` (default `30000`).

## Related Issue(s) / Issue(s) relacionado(s)

N/A

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [ ] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

The in-duel ping **display** still requires client-side work (the web client must send `0xff` with a timestamp and render the RTT from the `0xfe` reply); this PR only makes the server echo it. Detection latency is up to ~2× the interval (one sweep marks + pings, the next terminates), i.e. ~60s with the 30s default.

Tests: full suite green (711 passing), incl. 6 new cases covering the heartbeat sweep, `isAlive` refresh on pong/message, and the `0xff`/`0xfe` echo.