### PR TITLE
fix(reconnect): allow ranked by-name reconnect over half-open sockets

### DIFF
--- a/src/shared/room/domain/findReconnectingPlayer.test.ts
+++ b/src/shared/room/domain/findReconnectingPlayer.test.ts
@@ -42,13 +42,24 @@ describe("findReconnectingPlayer", () => {
 		expect(found).toBeNull();
 	});
 
-	it("NEVER matches a player whose socket is still open (live session)", () => {
+	it("matches even a still-open socket in a ranked room — a backgrounded mobile client leaves a half-open socket that never reports closed, so the by-name reconnect must take it over (last-join-wins)", () => {
 		const p = player({ closed: false });
 		const found = findReconnectingPlayer({
 			players: [p],
 			name: "Jaden",
-			remoteAddress: "1.1.1.1",
+			remoteAddress: "9.9.9.9",
 			ranked: true,
+		});
+		expect(found).toBe(p);
+	});
+
+	it("in a casual room NEVER takes over a still-open socket", () => {
+		const p = player({ closed: false, remoteAddress: "1.1.1.1" });
+		const found = findReconnectingPlayer({
+			players: [p],
+			name: "Jaden",
+			remoteAddress: "1.1.1.1",
+			ranked: false,
 		});
 		expect(found).toBeNull();
 	});

--- a/src/shared/room/domain/findReconnectingPlayer.ts
+++ b/src/shared/room/domain/findReconnectingPlayer.ts
@@ -9,12 +9,21 @@ import { YgoClient } from "@shared/client/domain/YgoClient";
  *   - the target is NOT strong-auth: ticket players reconnect through their
  *     single-use token, so they are unreachable here (closes the hijack of a
  *     verified player by name, with a stolen PIN or another ticket).
- *   - the target's socket is actually closed: a live session is never taken
- *     over (closes the in-flight hijack of a connected player).
- *   - the name matches, and — in casual rooms — the remote address too.
+ *   - the name matches.
  *
- * The remaining residual (knowing a legacy player's PIN while it is down) is
- * the accepted limit of the 4-char PIN, and never reaches a ticket player.
+ * In casual rooms it is additionally bound to the original location and only
+ * takes over a socket already known closed: casual rooms have no PIN, so the
+ * remote address is the only credential.
+ *
+ * Ranked (incl. external/PIN) rooms intentionally do NOT require the socket to
+ * be closed. Mobile clients on the raw-TCP path leave a half-open socket when
+ * backgrounded — no FIN/RST reaches the server, so `socket.closed` stays false
+ * indefinitely (the TCP path has no liveness heartbeat). Requiring it there
+ * locked legitimate players out of their own duel. The takeover is safe: the
+ * stale socket is destroyed when the new one is attached (Client.setSocket).
+ * The residual (someone knowing a legacy player's name takes their seat while
+ * it looks live) is the accepted limit of the legacy by-name path, and never
+ * reaches a ticket player.
  */
 export function findReconnectingPlayer(params: {
 	players: YgoClient[];
@@ -26,14 +35,16 @@ export function findReconnectingPlayer(params: {
 		if (client.isStrongAuth) {
 			return false;
 		}
-		if (!client.socket.closed) {
-			return false;
-		}
 		if (client.name !== params.name) {
 			return false;
 		}
-		if (!params.ranked && client.socket.remoteAddress !== params.remoteAddress) {
-			return false;
+		if (!params.ranked) {
+			if (client.socket.remoteAddress !== params.remoteAddress) {
+				return false;
+			}
+			if (!client.socket.closed) {
+				return false;
+			}
 		}
 		return true;
 	});


### PR DESCRIPTION
## Description / Descripción

EN: Mobile clients on the raw-TCP edopro path could not reconnect to ranked / external (PIN) rooms. Since the reconnect hardening, `findReconnectingPlayer` required the seated player's socket to be **closed** before granting a by-name reconnect. When a phone is backgrounded the socket goes **half-open** — no FIN/RST reaches the server, the TCP path has no liveness heartbeat, so `socket.closed` stays `false` indefinitely. The legitimate player was pushed into **spectator mode of their own duel**.

ES: Los clientes móviles en el path TCP de edopro no podían reconectar a salas ranked / external (PIN). El guard `!socket.closed` exigía que el socket del jugador estuviera cerrado, pero un celular en segundo plano deja el socket **half-open** (sin FIN/RST), y al no haber heartbeat en TCP, `socket.closed` nunca pasa a `true`. El jugador legítimo terminaba como **espectador de su propio duelo**.

**Fix:** drop the closed-socket requirement for ranked (incl. external/PIN) rooms — match by name + non-strong-auth only. Casual rooms are unchanged (still require same remote address + closed socket).

**Why it's safe:**
- The stale socket is destroyed when the new one is attached (`Client.setSocket`), so no double sockets.
- `isStrongAuth` (ticket/verified) players remain unreachable by name — they reconnect via their single-use token.
- Ranked reconnects still validate account credentials downstream in `Reconnect.run` → `CheckIfUseCanJoin`, so a wrong PIN is rejected.

## Related Issue(s) / Issue(s) relacionado(s)

N/A

## Checklist

- [x] My code follows the project style and guidelines
- [x] I have added tests or examples if needed
- [ ] I have updated documentation if needed
- [x] The PR title is descriptive

## Additional Notes / Notas adicionales

Root cause (TCP half-open detection) remains: the edopro `YGOProServer` TCP path has no heartbeat, unlike the Mercury WS path (#290). This PR restores reconnection; a follow-up could add TCP liveness detection so `socket.closed` becomes reliable.

| File | Change |
|------|--------|
| `src/shared/room/domain/findReconnectingPlayer.ts` | Drop `!socket.closed` guard for ranked rooms; keep it (plus remote address) for casual |
| `src/shared/room/domain/findReconnectingPlayer.test.ts` | Cover ranked half-open takeover + casual still-open rejection |

Tests: 712/712 green. tsc + Biome clean.