### PR TITLE
refactor: clean up index.ts composition root (hexagonal + DDD)

### DIFF
--- a/src/bootstrap/bootstrapEdoproResources.ts
+++ b/src/bootstrap/bootstrapEdoproResources.ts
@@ -1,0 +1,12 @@
+import { EdoProBanListLoader } from "@edopro/ban-list/infrastructure/BanListLoader";
+import { Logger } from "@shared/logger/domain/Logger";
+
+// Loads edopro ban lists into BanListMemoryRepository. Note: these are also
+// read by the ygopro path (see bootstrapYgoproResources), not only by edopro.
+export async function bootstrapEdoproResources(logger: Logger): Promise<void> {
+	const banLists = new EdoProBanListLoader();
+	await banLists.loadDirectory("resources/edopro/banlists-evolution");
+	await banLists.loadDirectory("resources/edopro/banlists-ignis");
+
+	logger.info("🎴 EdoPro ban lists loaded");
+}

--- a/src/bootstrap/bootstrapPersistence.ts
+++ b/src/bootstrap/bootstrapPersistence.ts
@@ -1,0 +1,24 @@
+import { Redis } from "@shared/db/redis/infrastructure/Redis";
+import { EdoProSQLiteTypeORM } from "@shared/db/sqlite/infrastructure/EdoProSQLiteTypeORM";
+import { Logger } from "@shared/logger/domain/Logger";
+
+import { config } from "src/config";
+import { PostgresTypeORM } from "src/evolution-types/src/PostgresTypeORM";
+
+// Opens every datastore connection the server depends on. Postgres is only
+// touched when ranking is enabled; SQLite and Redis are always required.
+export async function bootstrapPersistence(logger: Logger): Promise<void> {
+	const sqlite = new EdoProSQLiteTypeORM();
+	await sqlite.connect();
+	await sqlite.initialize();
+	logger.info("🗄️  SQLite connected");
+
+	if (config.ranking.enabled) {
+		const postgres = new PostgresTypeORM();
+		await postgres.connect();
+		logger.info("🗄️  Postgres connected · ranking ON");
+	}
+
+	const redis = new Redis();
+	await redis.connect();
+}

--- a/src/bootstrap/bootstrapResources.ts
+++ b/src/bootstrap/bootstrapResources.ts
@@ -1,0 +1,20 @@
+import { EdoProBanListLoader } from "@edopro/ban-list/infrastructure/BanListLoader";
+import { Logger } from "@shared/logger/domain/Logger";
+import { YGOProBanListLoader } from "@ygopro/ban-list/infrastructure/YGOProBanListLoader";
+import { YGOProResourceLoader } from "@ygopro/ygopro/YGOProResourceLoader";
+
+// Loads card resources and ban lists into memory. Must run before any server
+// accepts connections, since duels resolve cards and ban lists from memory.
+export async function bootstrapResources(logger: Logger): Promise<void> {
+	const edoBanLists = new EdoProBanListLoader();
+	await edoBanLists.loadDirectory("resources/edopro/banlists-evolution");
+	await edoBanLists.loadDirectory("resources/edopro/banlists-ignis");
+
+	await YGOProResourceLoader.start();
+	await YGOProResourceLoader.get().logLFLists();
+
+	const ygoBanLists = new YGOProBanListLoader();
+	await ygoBanLists.load();
+
+	logger.info("🎴 YGOPro resources & ban lists loaded");
+}

--- a/src/bootstrap/bootstrapResources.ts
+++ b/src/bootstrap/bootstrapResources.ts
@@ -1,20 +1,12 @@
-import { EdoProBanListLoader } from "@edopro/ban-list/infrastructure/BanListLoader";
 import { Logger } from "@shared/logger/domain/Logger";
-import { YGOProBanListLoader } from "@ygopro/ban-list/infrastructure/YGOProBanListLoader";
-import { YGOProResourceLoader } from "@ygopro/ygopro/YGOProResourceLoader";
 
-// Loads card resources and ban lists into memory. Must run before any server
-// accepts connections, since duels resolve cards and ban lists from memory.
+import { bootstrapEdoproResources } from "./bootstrapEdoproResources";
+import { bootstrapYgoproResources } from "./bootstrapYgoproResources";
+
+// Order is mandatory: ygopro resources cross-reference edopro ban lists by name
+// (YGOProRoom resolves _edoBanListHash from BanListMemoryRepository), so edopro
+// ban lists must load first. Do not reorder these two calls.
 export async function bootstrapResources(logger: Logger): Promise<void> {
-	const edoBanLists = new EdoProBanListLoader();
-	await edoBanLists.loadDirectory("resources/edopro/banlists-evolution");
-	await edoBanLists.loadDirectory("resources/edopro/banlists-ignis");
-
-	await YGOProResourceLoader.start();
-	await YGOProResourceLoader.get().logLFLists();
-
-	const ygoBanLists = new YGOProBanListLoader();
-	await ygoBanLists.load();
-
-	logger.info("🎴 YGOPro resources & ban lists loaded");
+	await bootstrapEdoproResources(logger);
+	await bootstrapYgoproResources(logger);
 }

--- a/src/bootstrap/bootstrapYgoproResources.ts
+++ b/src/bootstrap/bootstrapYgoproResources.ts
@@ -1,0 +1,19 @@
+import { Logger } from "@shared/logger/domain/Logger";
+import { YGOProBanListLoader } from "@ygopro/ban-list/infrastructure/YGOProBanListLoader";
+import { YGOProResourceLoader } from "@ygopro/ygopro/YGOProResourceLoader";
+
+// Loads ygopro card resources and ban lists.
+//
+// Precondition: edopro ban lists must already be loaded. YGOProRoom cross-
+// references them by name (BanListMemoryRepository) to resolve _edoBanListHash,
+// so calling this before bootstrapEdoproResources yields empty hashes. The
+// order is enforced by bootstrapResources.
+export async function bootstrapYgoproResources(logger: Logger): Promise<void> {
+	await YGOProResourceLoader.start();
+	await YGOProResourceLoader.get().logLFLists();
+
+	const banLists = new YGOProBanListLoader();
+	await banLists.load();
+
+	logger.info("🎴 YGOPro resources & ban lists loaded");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,9 +28,7 @@ import { AIJoinTokenStrategy } from "./ygopro/room/application/join-strategies/A
 import { WindBotJoinStrategy } from "./ygopro/room/application/join-strategies/WindBotJoinStrategy";
 import { DefaultJoinStrategy } from "./ygopro/room/application/join-strategies/DefaultJoinStrategy";
 import { TicketJoinStrategy } from "./ygopro/room/application/join-strategies/TicketJoinStrategy";
-
-// YGOPro protocol version (same as DuelRecord.ts — must stay in sync)
-const YGOPRO_VERSION = 0x1362;
+import { YGOPRO_PROTOCOL_VERSION } from "./ygopro/ygopro/protocol-version";
 
 void start();
 
@@ -101,7 +99,7 @@ async function start(): Promise<void> {
 			endpoint: config.windbot.endpoint,
 			myIp: config.windbot.myIp,
 			serverPort: config.servers.mercury.port,
-			version: YGOPRO_VERSION,
+			version: YGOPRO_PROTOCOL_VERSION,
 		});
 		WindbotModule.init({ enabled: true, repo, tokenStore, provider });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,17 @@
 import "reflect-metadata";
 import "src/shared/error-handler/error-handler";
 
-import { EdoProBanListLoader } from "src/edopro/ban-list/infrastructure/BanListLoader";
-import BanListMemoryRepository from "src/edopro/ban-list/infrastructure/BanListMemoryRepository";
-import { EdoProSQLiteTypeORM } from "src/shared/db/sqlite/infrastructure/EdoProSQLiteTypeORM";
 import LoggerFactory from "src/shared/logger/infrastructure/LoggerFactory";
 
 import { config } from "./config";
-import { PostgresTypeORM } from "./evolution-types/src/PostgresTypeORM";
+import { bootstrapResources } from "./bootstrap/bootstrapResources";
+import { bootstrapPersistence } from "./bootstrap/bootstrapPersistence";
 import { Server } from "./http-server/Server";
-import { YGOProBanListLoader } from "./ygopro/ban-list/infrastructure/YGOProBanListLoader";
-import { YGOProResourceLoader } from "./ygopro/ygopro/YGOProResourceLoader";
 import { HostServer } from "./socket-server/HostServer";
 import { WSHostServer } from "./socket-server/WSHostServer";
 import { YGOProServer } from "./socket-server/YGOProServer";
 import { WSYGOProServer } from "./socket-server/WSYGOProServer";
 import { HandshakeTicketAuthenticator } from "./socket-server/HandshakeTicketAuthenticator";
-import { Redis } from "@shared/db/redis/infrastructure/Redis";
 import { RedisTicketRepository } from "./shared/ticket/infrastructure/redis/RedisTicketRepository";
 import WebSocketSingleton from "./web-socket-server/WebSocketSingleton";
 import { bootstrapWindbot } from "./ygopro/windbot/infrastructure/bootstrapWindbot";
@@ -40,31 +35,8 @@ async function start(): Promise<void> {
 	const hostServer = new HostServer(logger);
 	const wsHostServer = new WSHostServer(logger);
 
-	const database = new EdoProSQLiteTypeORM();
-	const banListLoader = new EdoProBanListLoader();
-	await banListLoader.loadDirectory("resources/edopro/banlists-evolution");
-	await banListLoader.loadDirectory("resources/edopro/banlists-ignis");
-
-	await YGOProResourceLoader.start();
-	await YGOProResourceLoader.get().logLFLists();
-
-	const ygoProBanListLoader = new YGOProBanListLoader();
-	await ygoProBanListLoader.load();
-
-	logger.info("🎴 YGOPro resources & ban lists loaded");
-
-	await database.connect();
-	await database.initialize();
-	logger.info("🗄️  SQLite connected");
-
-	if (config.ranking.enabled) {
-		const postgresDatabase = new PostgresTypeORM();
-		await postgresDatabase.connect();
-		logger.info("🗄️  Postgres connected · ranking ON");
-	}
-
-	const redisDatabase = new Redis();
-	await redisDatabase.connect();
+	await bootstrapResources(logger);
+	await bootstrapPersistence(logger);
 
 	await server.initialize();
 	WebSocketSingleton.getInstance();

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,16 +19,9 @@ import { HandshakeTicketAuthenticator } from "./socket-server/HandshakeTicketAut
 import { Redis } from "@shared/db/redis/infrastructure/Redis";
 import { RedisTicketRepository } from "./shared/ticket/infrastructure/redis/RedisTicketRepository";
 import WebSocketSingleton from "./web-socket-server/WebSocketSingleton";
-import { WindbotModule } from "./ygopro/windbot/application/WindbotModule";
-import { FileBotlistRepository } from "./ygopro/windbot/infrastructure/FileBotlistRepository";
-import { HttpWindBotProvider } from "./ygopro/windbot/infrastructure/HttpWindBotProvider";
-import { WindbotTokenStore } from "./ygopro/windbot/domain/WindbotTokenStore";
+import { bootstrapWindbot } from "./ygopro/windbot/infrastructure/bootstrapWindbot";
 import { JoinStrategyRegistry } from "./ygopro/room/application/join-strategies/JoinStrategyRegistry";
-import { AIJoinTokenStrategy } from "./ygopro/room/application/join-strategies/AIJoinTokenStrategy";
-import { WindBotJoinStrategy } from "./ygopro/room/application/join-strategies/WindBotJoinStrategy";
-import { DefaultJoinStrategy } from "./ygopro/room/application/join-strategies/DefaultJoinStrategy";
-import { TicketJoinStrategy } from "./ygopro/room/application/join-strategies/TicketJoinStrategy";
-import { YGOPRO_PROTOCOL_VERSION } from "./ygopro/ygopro/protocol-version";
+import { composeJoinStrategies } from "./ygopro/room/application/join-strategies/composeJoinStrategies";
 
 void start();
 
@@ -78,37 +71,12 @@ async function start(): Promise<void> {
 	hostServer.initialize();
 	wsHostServer.initialize();
 
-	// Base strategy chain — always registered, with or without windbot.
-	// Priority order (no windbot):
-	//   1. TicketJoinStrategy — sockets with a resolved ticket userId (ranked-by-ticket)
-	//   2. DefaultJoinStrategy — game password / unranked fallback
-	const baseChain = [new TicketJoinStrategy(), new DefaultJoinStrategy()];
-	JoinStrategyRegistry.setStrategies(baseChain);
-
-	// Windbot bootstrap — ONLY when ENABLE_WINDBOT=true.
-	// When enabled, AI/wind strategies are prepended to the base chain:
-	//   1. AIJoinTokenStrategy — AIJOIN# prefix (reverse-connecting bot)
-	//   2. WindBotJoinStrategy — explicit "ai" token, AI / AI#name (human requesting bot)
-	//   3. TicketJoinStrategy  — ticket-authenticated ranked join
-	//   4. DefaultJoinStrategy — game password / unranked fallback
-	// config.windbot is parsed (and validated for fail-fast) at module load time in src/config/index.ts.
-	if (config.windbot.enabled) {
-		const repo = new FileBotlistRepository(config.windbot.botlistPath);
-		const tokenStore = new WindbotTokenStore();
-		const provider = new HttpWindBotProvider({
-			endpoint: config.windbot.endpoint,
-			myIp: config.windbot.myIp,
-			serverPort: config.servers.mercury.port,
-			version: YGOPRO_PROTOCOL_VERSION,
-		});
-		WindbotModule.init({ enabled: true, repo, tokenStore, provider });
-
-		const module = WindbotModule.getInstance();
-		JoinStrategyRegistry.setStrategies([
-			new AIJoinTokenStrategy(module),
-			new WindBotJoinStrategy(module),
-			...baseChain,
-		]);
+	// config.windbot is validated for fail-fast at module load (src/config/index.ts).
+	const windbotModule = config.windbot.enabled
+		? bootstrapWindbot(config.windbot, config.servers.mercury.port)
+		: undefined;
+	JoinStrategyRegistry.setStrategies(composeJoinStrategies(windbotModule));
+	if (windbotModule) {
 		logger.info("🤖 Windbot enabled");
 	}
 

--- a/src/ygopro/room/application/join-strategies/composeJoinStrategies.test.ts
+++ b/src/ygopro/room/application/join-strategies/composeJoinStrategies.test.ts
@@ -1,0 +1,39 @@
+import { composeJoinStrategies } from "./composeJoinStrategies";
+import { AIJoinTokenStrategy } from "./AIJoinTokenStrategy";
+import { WindBotJoinStrategy } from "./WindBotJoinStrategy";
+import { TicketJoinStrategy } from "./TicketJoinStrategy";
+import { DefaultJoinStrategy } from "./DefaultJoinStrategy";
+import { WindbotModule } from "../../../windbot/application/WindbotModule";
+import { WindbotTokenStore } from "../../../windbot/domain/WindbotTokenStore";
+
+const makeModule = (): WindbotModule =>
+	WindbotModule.createForTests({
+		enabled: true,
+		repo: {
+			findAll: jest.fn(),
+			findByName: jest.fn(),
+			pickRandom: jest.fn(),
+		} as never,
+		tokenStore: WindbotTokenStore.createForTests(),
+		provider: { requestJoin: jest.fn() } as never,
+	});
+
+describe("composeJoinStrategies", () => {
+	it("returns the base chain [Ticket, Default] when windbot is absent", () => {
+		const strategies = composeJoinStrategies();
+
+		expect(strategies).toHaveLength(2);
+		expect(strategies[0]).toBeInstanceOf(TicketJoinStrategy);
+		expect(strategies[1]).toBeInstanceOf(DefaultJoinStrategy);
+	});
+
+	it("prepends [AIJoinToken, WindBot] before the base chain when windbot is present", () => {
+		const strategies = composeJoinStrategies(makeModule());
+
+		expect(strategies).toHaveLength(4);
+		expect(strategies[0]).toBeInstanceOf(AIJoinTokenStrategy);
+		expect(strategies[1]).toBeInstanceOf(WindBotJoinStrategy);
+		expect(strategies[2]).toBeInstanceOf(TicketJoinStrategy);
+		expect(strategies[3]).toBeInstanceOf(DefaultJoinStrategy);
+	});
+});

--- a/src/ygopro/room/application/join-strategies/composeJoinStrategies.ts
+++ b/src/ygopro/room/application/join-strategies/composeJoinStrategies.ts
@@ -1,0 +1,18 @@
+import { WindbotModule } from "../../../windbot/application/WindbotModule";
+import { JoinStrategy } from "./JoinStrategy";
+import { AIJoinTokenStrategy } from "./AIJoinTokenStrategy";
+import { WindBotJoinStrategy } from "./WindBotJoinStrategy";
+import { TicketJoinStrategy } from "./TicketJoinStrategy";
+import { DefaultJoinStrategy } from "./DefaultJoinStrategy";
+
+// Join-routing policy: this context owns the strategy priority order; the
+// composition root only decides whether windbot is available.
+export function composeJoinStrategies(windbot?: WindbotModule): JoinStrategy[] {
+	const baseChain = [new TicketJoinStrategy(), new DefaultJoinStrategy()];
+
+	if (!windbot) {
+		return baseChain;
+	}
+
+	return [new AIJoinTokenStrategy(windbot), new WindBotJoinStrategy(windbot), ...baseChain];
+}

--- a/src/ygopro/room/domain/DuelRecord.ts
+++ b/src/ygopro/room/domain/DuelRecord.ts
@@ -10,13 +10,13 @@ import {
 } from "ygopro-msg-encode";
 import { YGOProRoom } from "./YGOProRoom";
 import { calculateDuelOptions } from "@ygopro/utils/calculate-duel-options";
+import { YGOPRO_PROTOCOL_VERSION } from "@ygopro/ygopro/protocol-version";
 
 // Constants from ygopro
 const REPLAY_COMPRESSED = 0x1;
 const REPLAY_TAG = 0x2;
 const REPLAY_UNIFORM = 0x10;
 const REPLAY_ID_YRP2 = 0x32707279;
-const PRO_VERSION = 0x1362;
 
 export class DuelRecord {
 	constructor(
@@ -69,7 +69,7 @@ export class DuelRecord {
 		// Create replay header
 		const header = new ReplayHeader();
 		header.id = REPLAY_ID_YRP2;
-		header.version = PRO_VERSION;
+		header.version = YGOPRO_PROTOCOL_VERSION;
 		header.flag = REPLAY_COMPRESSED | REPLAY_UNIFORM;
 		if (isTag) {
 			header.flag |= REPLAY_TAG;

--- a/src/ygopro/windbot/infrastructure/bootstrapWindbot.ts
+++ b/src/ygopro/windbot/infrastructure/bootstrapWindbot.ts
@@ -1,0 +1,23 @@
+import { YGOPRO_PROTOCOL_VERSION } from "../../ygopro/protocol-version";
+import { WindbotModule } from "../application/WindbotModule";
+import { WindbotTokenStore } from "../domain/WindbotTokenStore";
+import { WindbotConfigEnabled } from "./WindbotConfig";
+import { FileBotlistRepository } from "./FileBotlistRepository";
+import { HttpWindBotProvider } from "./HttpWindBotProvider";
+
+// Wires windbot's concrete adapters and inits the module, so the composition
+// root never has to know about them.
+export function bootstrapWindbot(config: WindbotConfigEnabled, serverPort: number): WindbotModule {
+	const repo = new FileBotlistRepository(config.botlistPath);
+	const tokenStore = new WindbotTokenStore();
+	const provider = new HttpWindBotProvider({
+		endpoint: config.endpoint,
+		myIp: config.myIp,
+		serverPort,
+		version: YGOPRO_PROTOCOL_VERSION,
+	});
+
+	WindbotModule.init({ enabled: true, repo, tokenStore, provider });
+
+	return WindbotModule.getInstance();
+}

--- a/src/ygopro/ygopro/protocol-version.ts
+++ b/src/ygopro/ygopro/protocol-version.ts
@@ -1,0 +1,10 @@
+/**
+ * YGOPRO_PROTOCOL_VERSION — the YGOPro network protocol version (PVERSION).
+ *
+ * Canonical single source of truth. Consumed by:
+ *   - DuelRecord replay header (ygopro/room/domain/DuelRecord.ts)
+ *   - WindBot join wiring (composition root, src/index.ts)
+ *
+ * Must match the protocol version the clients and WindBot binary speak.
+ */
+export const YGOPRO_PROTOCOL_VERSION = 0x1362;

--- a/src/ygopro/ygopro/protocol-version.ts
+++ b/src/ygopro/ygopro/protocol-version.ts
@@ -1,10 +1,3 @@
-/**
- * YGOPRO_PROTOCOL_VERSION — the YGOPro network protocol version (PVERSION).
- *
- * Canonical single source of truth. Consumed by:
- *   - DuelRecord replay header (ygopro/room/domain/DuelRecord.ts)
- *   - WindBot join wiring (composition root, src/index.ts)
- *
- * Must match the protocol version the clients and WindBot binary speak.
- */
+// YGOPro network protocol version (PVERSION). Must match what the clients and
+// the WindBot binary speak. Single source of truth — do not inline 0x1362.
 export const YGOPRO_PROTOCOL_VERSION = 0x1362;


### PR DESCRIPTION
## Why

`src/index.ts` had grown into a ~128-line entry point mixing business decisions and duplication with its legitimate wiring job. This cleans it into a composition root that reads as an index, moving each concern to the context it belongs to. No behavior change — pure refactor.

The guiding principle: the composition root is *allowed* to know every concrete adapter (that's its job). The goal here is removing **decisions** and **duplication** from it, not the wiring.

## Changes (one commit per step)

1. **`refactor(ygopro): extract YGOPro protocol version to single source`**
   Replace the duplicated `0x1362` literal (`index.ts` + `DuelRecord.ts`, with a "must stay in sync" comment) with a single `YGOPRO_PROTOCOL_VERSION` constant.

2. **`refactor(ygopro): extract join-strategy composition out of the root`**
   Move the join-routing policy into `composeJoinStrategies` (`room/application`) and the windbot adapter wiring into `bootstrapWindbot` (`windbot/infrastructure`). The root now only decides whether windbot is available and delegates.

3. **`refactor(bootstrap): extract resource and persistence startup from the root`**
   Group ban-list/resource loading and the SQLite/Postgres/Redis connections into `bootstrapResources` and `bootstrapPersistence` under `src/bootstrap`. Also drops a dead `BanListMemoryRepository` import.

4. **`refactor(bootstrap): split resource bootstrap by bounded context`**
   Split `bootstrapResources` into `bootstrapEdoproResources` / `bootstrapYgoproResources`, orchestrated in order. The mandatory edopro-before-ygopro load order (ygopro cross-references edopro ban lists to resolve `_edoBanListHash`) is documented at the call site and as a precondition on the ygopro loader.

## Result

`start()` goes from mixed business logic + duplication to a clean sequence: create servers → `bootstrapResources` → `bootstrapPersistence` → initialize → wire join strategies → log endpoints.

## Verification

- `tsc --noEmit` clean
- Full suite green (714 tests, 81 suites)
- Biome clean
- New unit test for `composeJoinStrategies` (TDD: order with/without windbot)

## Follow-up (out of scope)

`EdoProSQLiteTypeORM` is edopro-only but lives under `src/shared/db/`. Relocating it under `edopro/` would complete the per-context classification — left as a separate change.