### PR TITLE
feat: public card & banlist inspection page

### DIFF
--- a/src/edopro/card/infrastructure/EdoProCardSearchRepository.ts
+++ b/src/edopro/card/infrastructure/EdoProCardSearchRepository.ts
@@ -1,0 +1,33 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import {
+	CdbCardSearchRepository,
+	CdbFile,
+} from "@shared/card/infrastructure/cdb/CdbCardSearchRepository";
+
+export class EdoProCardSearchRepository extends CdbCardSearchRepository {
+	constructor(private readonly directoryPaths: string[] = ["./resources/edopro/databases"]) {
+		super({ lastSourceWins: true });
+	}
+
+	protected async *cdbFiles(): AsyncIterable<CdbFile> {
+		for (const directoryPath of this.directoryPaths) {
+			let files: string[];
+			try {
+				files = await readdir(directoryPath);
+			} catch {
+				continue;
+			}
+
+			for (const file of files) {
+				if (!file.endsWith(".cdb")) {
+					continue;
+				}
+
+				const path = join(directoryPath, file);
+				yield { path, read: () => readFile(path) };
+			}
+		}
+	}
+}

--- a/src/http-server/composition/CardRepositories.ts
+++ b/src/http-server/composition/CardRepositories.ts
@@ -1,0 +1,12 @@
+import { CardEngine } from "@shared/card/application/SearchCards";
+import { CdbCardSearchRepository } from "@shared/card/infrastructure/cdb/CdbCardSearchRepository";
+import { EdoProCardSearchRepository } from "@edopro/card/infrastructure/EdoProCardSearchRepository";
+import { YGOProCardSearchRepository } from "@ygopro/card/infrastructure/YGOProCardSearchRepository";
+
+export const cardRepositories: Record<CardEngine, CdbCardSearchRepository> = {
+	edopro: new EdoProCardSearchRepository(),
+	ygopro: new YGOProCardSearchRepository(),
+};
+
+export const isCardEngine = (value: unknown): value is CardEngine =>
+	value === "edopro" || value === "ygopro";

--- a/src/http-server/controllers/GetBanListDetailController.ts
+++ b/src/http-server/controllers/GetBanListDetailController.ts
@@ -1,0 +1,41 @@
+import { Request, Response } from "express";
+
+import { toBanListDetail } from "@shared/ban-list/application/BanListDetail";
+import { BanList } from "@shared/ban-list/BanList";
+import EdoProBanListMemoryRepository from "@edopro/ban-list/infrastructure/BanListMemoryRepository";
+import YGOProBanListMemoryRepository from "@ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository";
+
+import { cardRepositories, isCardEngine } from "../composition/CardRepositories";
+
+const findBanList = (engine: "edopro" | "ygopro", name: string): BanList | null =>
+	engine === "edopro"
+		? EdoProBanListMemoryRepository.findByName(name)
+		: YGOProBanListMemoryRepository.findByName(name);
+
+export class GetBanListDetailController {
+	async run(request: Request, response: Response): Promise<void> {
+		const engine = request.params.engine;
+		const name = request.params.name;
+
+		if (!isCardEngine(engine) || typeof name !== "string") {
+			response.status(400).json({ error: "unknown engine or ban list" });
+
+			return;
+		}
+
+		const banList = findBanList(engine, name);
+		if (!banList) {
+			response.status(404).json({ error: "ban list not found" });
+
+			return;
+		}
+
+		const ids = [...banList.forbidden, ...banList.limited, ...banList.semiLimited, ...banList.all];
+		const names = await cardRepositories[engine].resolveNames(ids);
+
+		response.status(200).json({
+			engine,
+			...toBanListDetail(banList, (id) => names.get(id) ?? null),
+		});
+	}
+}

--- a/src/http-server/controllers/GetBanListsController.ts
+++ b/src/http-server/controllers/GetBanListsController.ts
@@ -1,0 +1,14 @@
+import { Request, Response } from "express";
+
+import { toBanListViews } from "@shared/ban-list/application/BanListView";
+import EdoProBanListMemoryRepository from "@edopro/ban-list/infrastructure/BanListMemoryRepository";
+import YGOProBanListMemoryRepository from "@ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository";
+
+export class GetBanListsController {
+	run(_req: Request, response: Response): void {
+		response.status(200).json({
+			edopro: toBanListViews(EdoProBanListMemoryRepository.get()),
+			ygopro: toBanListViews(YGOProBanListMemoryRepository.get()),
+		});
+	}
+}

--- a/src/http-server/controllers/GetDatabaseCardsController.ts
+++ b/src/http-server/controllers/GetDatabaseCardsController.ts
@@ -1,0 +1,38 @@
+import { Request, Response } from "express";
+
+import { cardRepositories, isCardEngine } from "../composition/CardRepositories";
+
+const DEFAULT_LIMIT = 60;
+const MAX_LIMIT = 200;
+
+const parsePositive = (value: unknown, fallback: number, max: number): number => {
+	if (typeof value !== "string") {
+		return fallback;
+	}
+
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed) || parsed < 0) {
+		return fallback;
+	}
+
+	return Math.min(Math.floor(parsed), max);
+};
+
+export class GetDatabaseCardsController {
+	async run(request: Request, response: Response): Promise<void> {
+		const engine = request.query.engine;
+		const source = request.query.source;
+
+		if (!isCardEngine(engine) || typeof source !== "string" || source === "") {
+			response.status(400).json({ error: "engine and source are required" });
+
+			return;
+		}
+
+		const limit = parsePositive(request.query.limit, DEFAULT_LIMIT, MAX_LIMIT);
+		const offset = parsePositive(request.query.offset, 0, Number.MAX_SAFE_INTEGER);
+
+		const page = await cardRepositories[engine].findBySource(source, limit, offset);
+		response.status(200).json({ engine, source, ...page });
+	}
+}

--- a/src/http-server/controllers/GetDatabasesController.ts
+++ b/src/http-server/controllers/GetDatabasesController.ts
@@ -1,0 +1,14 @@
+import { Request, Response } from "express";
+
+import { cardRepositories } from "../composition/CardRepositories";
+
+export class GetDatabasesController {
+	async run(_request: Request, response: Response): Promise<void> {
+		const [edopro, ygopro] = await Promise.all([
+			cardRepositories.edopro.listSources(),
+			cardRepositories.ygopro.listSources(),
+		]);
+
+		response.status(200).json({ edopro, ygopro });
+	}
+}

--- a/src/http-server/controllers/InspectPageController.ts
+++ b/src/http-server/controllers/InspectPageController.ts
@@ -1,0 +1,303 @@
+import { Request, Response } from "express";
+
+const PAGE = `<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<title>Arcane Library · Server cards & banlists</title>
+	<link rel="preconnect" href="https://fonts.googleapis.com" />
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+	<link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600&display=swap" rel="stylesheet" />
+	<style>
+		:root {
+			--bg: #0a0712; --panel: rgba(28,18,46,.66); --panel-2: rgba(20,13,34,.82);
+			--border: rgba(176,138,74,.28); --gold: #e6c074; --gold-soft: #f3d79b;
+			--violet: #a78bfa; --text: #ece6f5; --muted: #9b91b3;
+			--forbidden: #ff6b6b; --limited: #ffa94d; --semi: #ffd43b; --white: #69db7c;
+		}
+		* { box-sizing: border-box; }
+		html, body { height: 100%; }
+		body {
+			margin: 0; color: var(--text);
+			font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+			background:
+				radial-gradient(1200px 600px at 20% -10%, rgba(123,58,237,.16), transparent 60%),
+				radial-gradient(900px 500px at 100% 0%, rgba(230,192,116,.08), transparent 55%),
+				var(--bg);
+		}
+		input, select, button { font: inherit; color: var(--text); }
+		.muted { color: var(--muted); font-size: .9rem; }
+
+		.layout { display: grid; grid-template-columns: 320px 1fr; height: 100vh; }
+
+		.sidebar {
+			overflow-y: auto; padding: 1.3rem 1rem; border-right: 1px solid var(--border);
+			background: linear-gradient(180deg, rgba(28,18,46,.55), rgba(10,7,18,.15));
+		}
+		.brand {
+			font-family: "Cinzel", Georgia, serif; color: var(--gold); text-align: center;
+			letter-spacing: .08em; font-size: 1.15rem; margin-bottom: 1.2rem;
+			text-shadow: 0 0 14px rgba(230,192,116,.3);
+		}
+		.filters { display: flex; flex-direction: column; gap: .55rem; margin-bottom: 1.4rem; }
+		.filters input, .filters select, .filters button {
+			width: 100%; background: var(--panel-2); border: 1px solid var(--border);
+			border-radius: 10px; padding: .6rem .75rem;
+		}
+		.filters input:focus, .filters select:focus { outline: none; border-color: var(--gold); box-shadow: 0 0 0 3px rgba(230,192,116,.15); }
+		.btn-primary {
+			cursor: pointer; background: linear-gradient(180deg, rgba(230,192,116,.22), rgba(230,192,116,.08));
+			color: var(--gold-soft); border-color: var(--gold); transition: box-shadow .12s, transform .12s;
+		}
+		.btn-primary:hover { box-shadow: 0 0 14px rgba(230,192,116,.22); }
+		.btn-primary:active { transform: translateY(1px); }
+
+		.nav-section { margin-bottom: 1.3rem; }
+		.nav-section h3 { font-size: .72rem; text-transform: uppercase; letter-spacing: .12em; color: var(--muted); margin: .2rem .3rem .5rem; }
+		.nav-item {
+			display: flex; align-items: center; gap: .55rem; width: 100%; text-align: left;
+			background: transparent; border: 1px solid transparent; border-radius: 9px;
+			padding: .45rem .55rem; margin-bottom: .15rem; cursor: pointer; transition: background .1s, border-color .1s;
+		}
+		.nav-item:hover { background: rgba(255,255,255,.04); border-color: var(--border); }
+		.nav-item.active { background: rgba(230,192,116,.12); border-color: var(--gold); }
+		.nav-label { flex: 1; font-size: .86rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+		.nav-sub { font-size: .72rem; color: var(--muted); }
+		.dot { width: 8px; height: 8px; border-radius: 50%; flex: none; }
+		.dot-edopro { background: var(--gold); box-shadow: 0 0 6px var(--gold); }
+		.dot-ygopro { background: var(--violet); box-shadow: 0 0 6px var(--violet); }
+		.empty { padding: .3rem .55rem; }
+
+		.main { overflow-y: auto; padding: 2rem 2.4rem 3rem; }
+		.main-head { margin-bottom: 1.3rem; border-bottom: 1px solid var(--border); padding-bottom: 1rem; }
+		.main-head h1 {
+			font-family: "Cinzel", Georgia, serif; color: var(--gold-soft); font-size: 1.6rem;
+			margin: 0 0 .25rem; letter-spacing: .04em;
+		}
+		.list { display: flex; flex-direction: column; }
+		.card-row {
+			display: flex; align-items: center; gap: .8rem; padding: .6rem .7rem; border-radius: 10px;
+			border-bottom: 1px solid rgba(255,255,255,.04);
+		}
+		.card-row:hover { background: rgba(255,255,255,.035); }
+		.mono { font-family: ui-monospace, "SF Mono", Menlo, monospace; color: var(--gold-soft); font-size: .82rem; min-width: 100px; }
+		.cname { flex: 1; }
+		.src { font-size: .72rem; color: var(--muted); background: rgba(255,255,255,.05); padding: .12rem .5rem; border-radius: 6px; }
+		.tag { font-size: .66rem; text-transform: uppercase; letter-spacing: .05em; padding: .14rem .5rem; border-radius: 6px; font-weight: 600; }
+		.tag-edopro { color: #1a1206; background: var(--gold); }
+		.tag-ygopro { color: #0b1220; background: var(--violet); }
+		.ban-sec { margin: 1.3rem 0; border-left: 3px solid var(--border); padding-left: .9rem; }
+		.ban-sec h4 { margin: .2rem 0 .5rem; font-size: .9rem; letter-spacing: .05em; }
+		.sec-forbidden h4 { color: var(--forbidden); } .sec-limited h4 { color: var(--limited); }
+		.sec-semi h4 { color: var(--semi); } .sec-white h4 { color: var(--white); }
+		.pager { display: flex; gap: .6rem; margin-top: 1.4rem; align-items: center; }
+		.pager button {
+			cursor: pointer; background: var(--panel-2); border: 1px solid var(--border);
+			border-radius: 10px; padding: .5rem .9rem; transition: border-color .12s;
+		}
+		.pager button:hover:not(:disabled) { border-color: var(--gold); }
+		.pager button:disabled { opacity: .4; cursor: default; }
+
+		@media (max-width: 820px) {
+			.layout { grid-template-columns: 1fr; height: auto; min-height: 100vh; }
+			.sidebar { border-right: none; border-bottom: 1px solid var(--border); max-height: 52vh; }
+			.main { padding: 1.4rem 1.2rem 2.5rem; }
+		}
+		@media (max-width: 480px) {
+			.main-head h1 { font-size: 1.3rem; }
+			.card-row { flex-wrap: wrap; gap: .35rem .7rem; }
+			.mono { min-width: 0; }
+			.cname { flex: 1 1 60%; }
+		}
+	</style>
+</head>
+<body>
+	<div class="layout">
+		<aside class="sidebar">
+			<div class="brand">&#10022; Arcane Library &#10022;</div>
+			<div class="filters">
+				<input id="q" placeholder="Search card name or passcode" />
+				<select id="engine">
+					<option value="">Both engines</option>
+					<option value="edopro">EDOPro</option>
+					<option value="ygopro">YGOPro</option>
+				</select>
+				<button id="search" class="btn-primary">Search</button>
+			</div>
+			<div class="nav-section">
+				<h3>Ban lists</h3>
+				<div id="nav-banlists" class="muted empty">Loading&hellip;</div>
+			</div>
+			<div class="nav-section">
+				<h3>Databases (.cdb)</h3>
+				<div id="nav-databases" class="muted empty">Loading&hellip;</div>
+			</div>
+		</aside>
+
+		<main class="main">
+			<div class="main-head">
+				<h1 id="main-title">Arcane Library</h1>
+				<p id="main-sub" class="muted">Pick a ban list or database on the left, or search for a card.</p>
+			</div>
+			<div id="main-list" class="list"></div>
+			<div id="main-pager"></div>
+		</main>
+	</div>
+
+	<script>
+		var $ = function (id) { return document.getElementById(id); };
+		var PAGE_SIZE = 60;
+		var state = { engineFilter: "", banlists: {}, databases: {} };
+
+		function el(tag, className, text) {
+			var node = document.createElement(tag);
+			if (className) node.className = className;
+			if (text !== undefined) node.textContent = text;
+			return node;
+		}
+
+		function engineTag(engine) { return el("span", "tag tag-" + engine, engine); }
+
+		function cardRow(card) {
+			var row = el("div", "card-row");
+			row.appendChild(el("span", "mono", card.id));
+			row.appendChild(el("span", "cname", card.name));
+			if (card.source) row.appendChild(el("span", "src", card.source));
+			if (card.engine) row.appendChild(engineTag(card.engine));
+			return row;
+		}
+
+		function setMain(title, sub) {
+			$("main-title").textContent = title;
+			$("main-sub").textContent = sub || "";
+			$("main-list").innerHTML = "";
+			$("main-pager").innerHTML = "";
+		}
+
+		function setActive(item) {
+			var items = document.querySelectorAll(".nav-item");
+			for (var i = 0; i < items.length; i++) items[i].classList.remove("active");
+			if (item) item.classList.add("active");
+		}
+
+		function navItem(engine, label, sub, onClick) {
+			var button = el("button", "nav-item");
+			button.appendChild(el("span", "dot dot-" + engine));
+			button.appendChild(el("span", "nav-label", label));
+			button.appendChild(el("span", "nav-sub", sub));
+			button.addEventListener("click", function () { setActive(button); onClick(); });
+			return button;
+		}
+
+		function renderNav() {
+			var banlists = $("nav-banlists");
+			var databases = $("nav-databases");
+			banlists.innerHTML = "";
+			databases.innerHTML = "";
+			["edopro", "ygopro"].forEach(function (engine) {
+				if (state.engineFilter && state.engineFilter !== engine) return;
+				(state.banlists[engine] || []).forEach(function (b) {
+					var count = b.forbidden + b.limited + b.semiLimited;
+					banlists.appendChild(navItem(engine, b.name, String(count), function () { selectBanlist(engine, b.name); }));
+				});
+				(state.databases[engine] || []).forEach(function (s) {
+					databases.appendChild(navItem(engine, s.source, String(s.count), function () { selectDatabase(engine, s.source, 0); }));
+				});
+			});
+			if (!banlists.children.length) banlists.appendChild(el("p", "muted empty", "No ban lists."));
+			if (!databases.children.length) databases.appendChild(el("p", "muted empty", "No databases."));
+		}
+
+		function loadBanlists() {
+			fetch("/api/banlists").then(function (r) { return r.json(); }).then(function (data) {
+				state.banlists = data;
+				renderNav();
+			});
+		}
+
+		function loadDatabases() {
+			fetch("/api/databases").then(function (r) { return r.json(); }).then(function (data) {
+				state.databases = data;
+				renderNav();
+			});
+		}
+
+		function doSearch() {
+			var q = $("q").value.trim();
+			var engine = state.engineFilter;
+			setActive(null);
+			if (!q) { setMain("Search", "Type a card name or passcode."); return; }
+			setMain("Search \\u00b7 " + q, "Searching\\u2026");
+			var url = "/api/cards?q=" + encodeURIComponent(q) + (engine ? "&engine=" + engine : "");
+			fetch(url).then(function (r) { return r.json(); }).then(function (data) {
+				var results = data.results || [];
+				$("main-sub").textContent = results.length ? results.length + " result(s)" : "Not found on the server.";
+				var list = $("main-list");
+				results.forEach(function (c) { list.appendChild(cardRow(c)); });
+			});
+		}
+
+		function banSection(title, cssClass, entries) {
+			if (!entries || !entries.length) return null;
+			var sec = el("div", "ban-sec " + cssClass);
+			sec.appendChild(el("h4", null, title + " \\u00b7 " + entries.length));
+			entries.forEach(function (e) { sec.appendChild(cardRow({ id: e.id, name: e.name || "(unknown card)" })); });
+			return sec;
+		}
+
+		function selectBanlist(engine, name) {
+			setMain("Ban list \\u00b7 " + name, engine.toUpperCase() + " \\u2014 loading\\u2026");
+			fetch("/api/banlists/" + engine + "/" + encodeURIComponent(name)).then(function (r) { return r.json(); }).then(function (data) {
+				var list = $("main-list");
+				var total = (data.forbidden || []).length + (data.limited || []).length +
+					(data.semiLimited || []).length + (data.whitelisted || []).length;
+				$("main-sub").textContent = engine.toUpperCase() + " \\u00b7 " + total + " cards";
+				var sections = [
+					banSection("Forbidden", "sec-forbidden", data.forbidden),
+					banSection("Limited", "sec-limited", data.limited),
+					banSection("Semi-Limited", "sec-semi", data.semiLimited),
+					banSection("Whitelisted", "sec-white", data.whitelisted)
+				];
+				sections.forEach(function (s) { if (s) list.appendChild(s); });
+				if (!list.children.length) list.appendChild(el("p", "muted", "This ban list has no entries."));
+			});
+		}
+
+		function selectDatabase(engine, source, offset) {
+			setMain("Database \\u00b7 " + source, engine.toUpperCase() + " \\u2014 loading\\u2026");
+			var url = "/api/databases/cards?engine=" + engine + "&source=" + encodeURIComponent(source) +
+				"&limit=" + PAGE_SIZE + "&offset=" + offset;
+			fetch(url).then(function (r) { return r.json(); }).then(function (data) {
+				var total = data.total || 0;
+				var from = total ? offset + 1 : 0;
+				var to = Math.min(offset + PAGE_SIZE, total);
+				$("main-sub").textContent = engine.toUpperCase() + " \\u00b7 " + total + " cards \\u00b7 showing " + from + "\\u2013" + to;
+				var list = $("main-list");
+				(data.cards || []).forEach(function (c) { list.appendChild(cardRow(c)); });
+				var pager = $("main-pager");
+				var prev = el("button", null, "\\u2039 Prev");
+				prev.disabled = offset <= 0;
+				prev.addEventListener("click", function () { selectDatabase(engine, source, Math.max(0, offset - PAGE_SIZE)); });
+				var next = el("button", null, "Next \\u203a");
+				next.disabled = offset + PAGE_SIZE >= total;
+				next.addEventListener("click", function () { selectDatabase(engine, source, offset + PAGE_SIZE); });
+				pager.appendChild(prev);
+				pager.appendChild(next);
+			});
+		}
+
+		$("engine").addEventListener("change", function () { state.engineFilter = this.value; renderNav(); });
+		$("search").addEventListener("click", doSearch);
+		$("q").addEventListener("keydown", function (e) { if (e.key === "Enter") doSearch(); });
+		loadBanlists();
+		loadDatabases();
+	</script>
+</body>
+</html>`;
+
+export class InspectPageController {
+	run(_req: Request, response: Response): void {
+		response.type("html").status(200).send(PAGE);
+	}
+}

--- a/src/http-server/controllers/SearchCardsController.ts
+++ b/src/http-server/controllers/SearchCardsController.ts
@@ -1,0 +1,17 @@
+import { Request, Response } from "express";
+
+import { SearchCards } from "@shared/card/application/SearchCards";
+import { cardRepositories, isCardEngine } from "../composition/CardRepositories";
+
+const searchCards = new SearchCards(cardRepositories);
+
+export class SearchCardsController {
+	async run(request: Request, response: Response): Promise<void> {
+		const query = typeof request.query.q === "string" ? request.query.q : "";
+		const engine = isCardEngine(request.query.engine) ? request.query.engine : undefined;
+		const limit = typeof request.query.limit === "string" ? Number(request.query.limit) : undefined;
+
+		const results = await searchCards.run({ query, engine, limit });
+		response.status(200).json({ results });
+	}
+}

--- a/src/http-server/middlewares/RateLimitMiddleware.test.ts
+++ b/src/http-server/middlewares/RateLimitMiddleware.test.ts
@@ -1,0 +1,50 @@
+import { isRateLimited, RateLimitStore } from "./RateLimitMiddleware";
+
+class FakeRedis implements RateLimitStore {
+	private counters = new Map<string, number>();
+	expireCalls: Array<{ key: string; seconds: number }> = [];
+
+	async incr(key: string): Promise<number> {
+		const next = (this.counters.get(key) ?? 0) + 1;
+		this.counters.set(key, next);
+
+		return next;
+	}
+
+	async expire(key: string, seconds: number): Promise<unknown> {
+		this.expireCalls.push({ key, seconds });
+
+		return 1;
+	}
+}
+
+describe("isRateLimited", () => {
+	it("allows requests up to the limit and blocks the ones beyond it", async () => {
+		const redis = new FakeRedis();
+		const verdicts: boolean[] = [];
+
+		for (let i = 0; i < 4; i++) {
+			verdicts.push(await isRateLimited(redis, "rate-limit:inspect:1.1.1.1", 3, 60));
+		}
+
+		expect(verdicts).toEqual([false, false, false, true]);
+	});
+
+	it("sets the expiry only on the first request of the window", async () => {
+		const redis = new FakeRedis();
+
+		await isRateLimited(redis, "rate-limit:inspect:1.1.1.1", 3, 60);
+		await isRateLimited(redis, "rate-limit:inspect:1.1.1.1", 3, 60);
+
+		expect(redis.expireCalls).toEqual([{ key: "rate-limit:inspect:1.1.1.1", seconds: 60 }]);
+	});
+
+	it("tracks each ip independently", async () => {
+		const redis = new FakeRedis();
+
+		await isRateLimited(redis, "rate-limit:inspect:1.1.1.1", 1, 60);
+		const firstForSecondIp = await isRateLimited(redis, "rate-limit:inspect:2.2.2.2", 1, 60);
+
+		expect(firstForSecondIp).toBe(false);
+	});
+});

--- a/src/http-server/middlewares/RateLimitMiddleware.ts
+++ b/src/http-server/middlewares/RateLimitMiddleware.ts
@@ -1,0 +1,59 @@
+import { NextFunction, Request, Response } from "express";
+
+import { Redis } from "@shared/db/redis/infrastructure/Redis";
+import { config } from "src/config";
+
+const WINDOW_SECONDS = 60;
+const MAX_REQUESTS = 60;
+
+export interface RateLimitStore {
+	incr(key: string): Promise<number>;
+	expire(key: string, seconds: number): Promise<unknown>;
+}
+
+export async function isRateLimited(
+	store: RateLimitStore,
+	key: string,
+	max: number,
+	windowSeconds: number,
+): Promise<boolean> {
+	const attempts = await store.incr(key);
+	if (attempts === 1) {
+		await store.expire(key, windowSeconds);
+	}
+
+	return attempts > max;
+}
+
+export async function RateLimitMiddleware(
+	request: Request,
+	response: Response,
+	next: NextFunction,
+): Promise<void> {
+	const redis = Redis.getInstance();
+	const ip = request.ip;
+
+	if (!config.rateLimit.enabled || !redis || !ip) {
+		next();
+
+		return;
+	}
+
+	try {
+		const limited = await isRateLimited(
+			redis,
+			`rate-limit:inspect:${ip}`,
+			MAX_REQUESTS,
+			WINDOW_SECONDS,
+		);
+		if (limited) {
+			response.status(429).json({ error: "Too many requests. Please slow down." });
+
+			return;
+		}
+	} catch {
+		// Fail-open: a limiter error must never take down a public read-only page.
+	}
+
+	next();
+}

--- a/src/http-server/routes/index.ts
+++ b/src/http-server/routes/index.ts
@@ -2,17 +2,43 @@ import { Express } from "express";
 
 import { Logger } from "../../shared/logger/domain/Logger";
 import { CreateRoomController } from "../controllers/CreateRoomController";
+import { GetBanListDetailController } from "../controllers/GetBanListDetailController";
+import { GetBanListsController } from "../controllers/GetBanListsController";
+import { GetDatabaseCardsController } from "../controllers/GetDatabaseCardsController";
+import { GetDatabasesController } from "../controllers/GetDatabasesController";
 import { GetRoomListController } from "../controllers/GetRoomListController";
+import { InspectPageController } from "../controllers/InspectPageController";
 import { RoomListController } from "../controllers/RoomListController";
+import { SearchCardsController } from "../controllers/SearchCardsController";
 import { ServerMessagesController } from "../controllers/ServerMessagesController";
 import { AuthAdminMiddleware } from "../middlewares/AuthAdminMiddleware";
 
 export function loadRoutes(app: Express, logger: Logger): void {
+	app.get("/", (req, res) => new InspectPageController().run(req, res));
+
 	app.get("/api/getrooms", (req, res) => new GetRoomListController().run(req, res));
 
 	app.get("/api/rooms", (req, res) => new RoomListController().run(req, res));
 
 	app.post("/api/room", (req, res) => new CreateRoomController(logger).run(req, res));
+
+	app.get("/api/banlists", (req, res) => new GetBanListsController().run(req, res));
+
+	app.get("/api/banlists/:engine/:name", async (req, res) => {
+		await new GetBanListDetailController().run(req, res);
+	});
+
+	app.get("/api/databases", async (req, res) => {
+		await new GetDatabasesController().run(req, res);
+	});
+
+	app.get("/api/databases/cards", async (req, res) => {
+		await new GetDatabaseCardsController().run(req, res);
+	});
+
+	app.get("/api/cards", async (req, res) => {
+		await new SearchCardsController().run(req, res);
+	});
 
 	app.use("/api/admin", AuthAdminMiddleware);
 

--- a/src/http-server/routes/index.ts
+++ b/src/http-server/routes/index.ts
@@ -12,6 +12,7 @@ import { RoomListController } from "../controllers/RoomListController";
 import { SearchCardsController } from "../controllers/SearchCardsController";
 import { ServerMessagesController } from "../controllers/ServerMessagesController";
 import { AuthAdminMiddleware } from "../middlewares/AuthAdminMiddleware";
+import { RateLimitMiddleware } from "../middlewares/RateLimitMiddleware";
 
 export function loadRoutes(app: Express, logger: Logger): void {
 	app.get("/", (req, res) => new InspectPageController().run(req, res));
@@ -22,21 +23,23 @@ export function loadRoutes(app: Express, logger: Logger): void {
 
 	app.post("/api/room", (req, res) => new CreateRoomController(logger).run(req, res));
 
-	app.get("/api/banlists", (req, res) => new GetBanListsController().run(req, res));
+	app.get("/api/banlists", RateLimitMiddleware, (req, res) =>
+		new GetBanListsController().run(req, res),
+	);
 
-	app.get("/api/banlists/:engine/:name", async (req, res) => {
+	app.get("/api/banlists/:engine/:name", RateLimitMiddleware, async (req, res) => {
 		await new GetBanListDetailController().run(req, res);
 	});
 
-	app.get("/api/databases", async (req, res) => {
+	app.get("/api/databases", RateLimitMiddleware, async (req, res) => {
 		await new GetDatabasesController().run(req, res);
 	});
 
-	app.get("/api/databases/cards", async (req, res) => {
+	app.get("/api/databases/cards", RateLimitMiddleware, async (req, res) => {
 		await new GetDatabaseCardsController().run(req, res);
 	});
 
-	app.get("/api/cards", async (req, res) => {
+	app.get("/api/cards", RateLimitMiddleware, async (req, res) => {
 		await new SearchCardsController().run(req, res);
 	});
 

--- a/src/shared/ban-list/application/BanListDetail.test.ts
+++ b/src/shared/ban-list/application/BanListDetail.test.ts
@@ -1,0 +1,63 @@
+import { BanList } from "src/shared/ban-list/BanList";
+
+import { toBanListDetail } from "./BanListDetail";
+
+class FakeBanList extends BanList {
+	add(cardId: number, quantity: number): void {
+		if (quantity === 0) {
+			this.forbidden.push(cardId);
+		} else if (quantity === 1) {
+			this.limited.push(cardId);
+		} else if (quantity === 2) {
+			this.semiLimited.push(cardId);
+		} else {
+			this.all.push(cardId);
+		}
+	}
+}
+
+const names: Record<number, string> = {
+	111: "Forbidden One",
+	222: "Limited One",
+	333: "Semi One",
+};
+const resolve = (id: number): string | null => names[id] ?? null;
+
+describe("toBanListDetail", () => {
+	it("resolves card names per category and leaves unknown ids as null", () => {
+		const banList = new FakeBanList();
+		banList.setName("2024.10 TCG");
+		banList.add(111, 0);
+		banList.add(222, 1);
+		banList.add(333, 2);
+		banList.add(444, 0);
+
+		const detail = toBanListDetail(banList, resolve);
+
+		expect(detail.name).toBe("2024.10 TCG");
+		expect(detail.isWhitelist).toBe(false);
+		expect(detail.forbidden).toEqual([
+			{ id: 111, name: "Forbidden One" },
+			{ id: 444, name: null },
+		]);
+		expect(detail.limited).toEqual([{ id: 222, name: "Limited One" }]);
+		expect(detail.semiLimited).toEqual([{ id: 333, name: "Semi One" }]);
+		expect(detail.whitelisted).toEqual([]);
+	});
+
+	it("exposes the allowed list as whitelisted only for whitelist ban lists", () => {
+		const banList = new FakeBanList();
+		banList.setName("Whitelist Format");
+		banList.whileListed();
+		banList.add(111, 3);
+		banList.add(555, 3);
+
+		const detail = toBanListDetail(banList, resolve);
+
+		expect(detail.isWhitelist).toBe(true);
+		expect(detail.whitelisted).toEqual([
+			{ id: 111, name: "Forbidden One" },
+			{ id: 555, name: null },
+		]);
+	});
+});

--- a/src/shared/ban-list/application/BanListDetail.ts
+++ b/src/shared/ban-list/application/BanListDetail.ts
@@ -1,0 +1,30 @@
+import { BanList } from "src/shared/ban-list/BanList";
+
+export interface BanListEntry {
+	id: number;
+	name: string | null;
+}
+
+export interface BanListDetailView {
+	name: string;
+	isWhitelist: boolean;
+	forbidden: BanListEntry[];
+	limited: BanListEntry[];
+	semiLimited: BanListEntry[];
+	whitelisted: BanListEntry[];
+}
+
+export type CardNameResolver = (id: number) => string | null;
+
+export function toBanListDetail(banList: BanList, resolve: CardNameResolver): BanListDetailView {
+	const entries = (ids: number[]): BanListEntry[] => ids.map((id) => ({ id, name: resolve(id) }));
+
+	return {
+		name: banList.name as string,
+		isWhitelist: banList.isWhiteListed,
+		forbidden: entries(banList.forbidden),
+		limited: entries(banList.limited),
+		semiLimited: entries(banList.semiLimited),
+		whitelisted: banList.isWhiteListed ? entries(banList.all) : [],
+	};
+}

--- a/src/shared/ban-list/application/BanListView.test.ts
+++ b/src/shared/ban-list/application/BanListView.test.ts
@@ -1,0 +1,54 @@
+import { BanList } from "src/shared/ban-list/BanList";
+
+import { toBanListViews } from "./BanListView";
+
+class FakeBanList extends BanList {
+	add(cardId: number, quantity: number): void {
+		if (quantity === 0) {
+			this.forbidden.push(cardId);
+		} else if (quantity === 1) {
+			this.limited.push(cardId);
+		} else if (quantity === 2) {
+			this.semiLimited.push(cardId);
+		} else {
+			this.all.push(cardId);
+		}
+	}
+}
+
+const buildBanList = (name: string | null): FakeBanList => {
+	const banList = new FakeBanList();
+	if (name !== null) {
+		banList.setName(name);
+	}
+
+	return banList;
+};
+
+describe("toBanListViews", () => {
+	it("returns an empty array when there are no ban lists", () => {
+		expect(toBanListViews([])).toEqual([]);
+	});
+
+	it("maps name and per-category counts", () => {
+		const banList = buildBanList("2024.10 TCG");
+		banList.add(111, 0);
+		banList.add(222, 0);
+		banList.add(333, 1);
+		banList.add(444, 2);
+
+		expect(toBanListViews([banList])).toEqual([
+			{ name: "2024.10 TCG", forbidden: 2, limited: 1, semiLimited: 1 },
+		]);
+	});
+
+	it("skips ban lists without a name", () => {
+		const named = buildBanList("2024.10 TCG");
+		const unnamed = buildBanList(null);
+
+		const views = toBanListViews([named, unnamed]);
+
+		expect(views).toHaveLength(1);
+		expect(views[0].name).toBe("2024.10 TCG");
+	});
+});

--- a/src/shared/ban-list/application/BanListView.ts
+++ b/src/shared/ban-list/application/BanListView.ts
@@ -1,0 +1,19 @@
+import { BanList } from "src/shared/ban-list/BanList";
+
+export interface BanListView {
+	name: string;
+	forbidden: number;
+	limited: number;
+	semiLimited: number;
+}
+
+export function toBanListViews(banLists: BanList[]): BanListView[] {
+	return banLists
+		.filter((banList) => banList.name !== null)
+		.map((banList) => ({
+			name: banList.name as string,
+			forbidden: banList.forbidden.length,
+			limited: banList.limited.length,
+			semiLimited: banList.semiLimited.length,
+		}));
+}

--- a/src/shared/card/application/SearchCards.test.ts
+++ b/src/shared/card/application/SearchCards.test.ts
@@ -1,0 +1,97 @@
+import { CardSearchRepository, CardSearchResult } from "../domain/CardSearchRepository";
+import { SearchCards } from "./SearchCards";
+
+class FakeCardSearchRepository implements CardSearchRepository {
+	searchByNameCalls: Array<{ query: string; limit: number }> = [];
+	findByIdCalls: number[] = [];
+
+	constructor(private readonly cards: CardSearchResult[]) {}
+
+	async searchByName(query: string, limit: number): Promise<CardSearchResult[]> {
+		this.searchByNameCalls.push({ query, limit });
+
+		return this.cards
+			.filter((card) => card.name.toLowerCase().includes(query.toLowerCase()))
+			.slice(0, limit);
+	}
+
+	async findById(id: number): Promise<CardSearchResult | null> {
+		this.findByIdCalls.push(id);
+
+		return this.cards.find((card) => card.id === id) ?? null;
+	}
+}
+
+const buildService = () => {
+	const edopro = new FakeCardSearchRepository([
+		{ id: 46986414, name: "Dark Magician", source: "cards.cdb" },
+		{ id: 38033121, name: "Dark Magician Girl", source: "cards.cdb" },
+	]);
+	const ygopro = new FakeCardSearchRepository([
+		{ id: 89631139, name: "Blue-Eyes White Dragon", source: "cards.cdb" },
+	]);
+	const service = new SearchCards({ edopro, ygopro });
+
+	return { service, edopro, ygopro };
+};
+
+describe("SearchCards", () => {
+	it("returns an empty array for a blank query without hitting repositories", async () => {
+		const { service, edopro, ygopro } = buildService();
+
+		expect(await service.run({ query: "   " })).toEqual([]);
+		expect(edopro.searchByNameCalls).toHaveLength(0);
+		expect(ygopro.findByIdCalls).toHaveLength(0);
+	});
+
+	it("searches by name across every engine when none is specified", async () => {
+		const { service } = buildService();
+
+		const results = await service.run({ query: "dark" });
+
+		expect(results).toEqual([
+			{ engine: "edopro", id: 46986414, name: "Dark Magician", source: "cards.cdb" },
+			{ engine: "edopro", id: 38033121, name: "Dark Magician Girl", source: "cards.cdb" },
+		]);
+	});
+
+	it("restricts the search to the requested engine", async () => {
+		const { service, edopro } = buildService();
+
+		const results = await service.run({ query: "blue", engine: "ygopro" });
+
+		expect(results).toEqual([
+			{ engine: "ygopro", id: 89631139, name: "Blue-Eyes White Dragon", source: "cards.cdb" },
+		]);
+		expect(edopro.searchByNameCalls).toHaveLength(0);
+	});
+
+	it("looks up by id when the query is numeric", async () => {
+		const { service, edopro, ygopro } = buildService();
+
+		const results = await service.run({ query: "46986414" });
+
+		expect(results).toEqual([
+			{ engine: "edopro", id: 46986414, name: "Dark Magician", source: "cards.cdb" },
+		]);
+		expect(edopro.findByIdCalls).toEqual([46986414]);
+		expect(edopro.searchByNameCalls).toHaveLength(0);
+		expect(ygopro.findByIdCalls).toEqual([46986414]);
+	});
+
+	it("clamps the limit to the maximum allowed", async () => {
+		const { service, edopro } = buildService();
+
+		await service.run({ query: "dark", engine: "edopro", limit: 9999 });
+
+		expect(edopro.searchByNameCalls[0].limit).toBe(100);
+	});
+
+	it("falls back to the default limit when none is provided", async () => {
+		const { service, edopro } = buildService();
+
+		await service.run({ query: "dark", engine: "edopro" });
+
+		expect(edopro.searchByNameCalls[0].limit).toBe(50);
+	});
+});

--- a/src/shared/card/application/SearchCards.ts
+++ b/src/shared/card/application/SearchCards.ts
@@ -1,0 +1,62 @@
+import { CardSearchRepository, CardSearchResult } from "../domain/CardSearchRepository";
+
+export type CardEngine = "edopro" | "ygopro";
+
+export interface CardSearchResultWithEngine extends CardSearchResult {
+	engine: CardEngine;
+}
+
+export interface SearchCardsParams {
+	query: string;
+	engine?: CardEngine;
+	limit?: number;
+}
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+export class SearchCards {
+	constructor(private readonly repositories: Record<CardEngine, CardSearchRepository>) {}
+
+	async run(params: SearchCardsParams): Promise<CardSearchResultWithEngine[]> {
+		const query = params.query.trim();
+		if (!query) {
+			return [];
+		}
+
+		const limit = this.normalizeLimit(params.limit);
+		const engines = params.engine
+			? [params.engine]
+			: (Object.keys(this.repositories) as CardEngine[]);
+
+		const results: CardSearchResultWithEngine[] = [];
+		for (const engine of engines) {
+			const found = await this.searchOne(this.repositories[engine], query, limit);
+			results.push(...found.map((card) => ({ ...card, engine })));
+		}
+
+		return results;
+	}
+
+	private async searchOne(
+		repository: CardSearchRepository,
+		query: string,
+		limit: number,
+	): Promise<CardSearchResult[]> {
+		if (/^\d+$/.test(query)) {
+			const card = await repository.findById(Number(query));
+
+			return card ? [card] : [];
+		}
+
+		return repository.searchByName(query, limit);
+	}
+
+	private normalizeLimit(limit?: number): number {
+		if (limit === undefined || Number.isNaN(limit) || limit < 1) {
+			return DEFAULT_LIMIT;
+		}
+
+		return Math.min(Math.floor(limit), MAX_LIMIT);
+	}
+}

--- a/src/shared/card/domain/CardCatalog.ts
+++ b/src/shared/card/domain/CardCatalog.ts
@@ -1,0 +1,17 @@
+import { CardSearchResult } from "./CardSearchRepository";
+
+export interface CardSource {
+	source: string;
+	count: number;
+}
+
+export interface CardPage {
+	total: number;
+	cards: CardSearchResult[];
+}
+
+export interface CardCatalog {
+	listSources(): Promise<CardSource[]>;
+	findBySource(source: string, limit: number, offset: number): Promise<CardPage>;
+	resolveNames(ids: number[]): Promise<Map<number, string>>;
+}

--- a/src/shared/card/domain/CardSearchRepository.ts
+++ b/src/shared/card/domain/CardSearchRepository.ts
@@ -1,0 +1,10 @@
+export interface CardSearchResult {
+	id: number;
+	name: string;
+	source: string;
+}
+
+export interface CardSearchRepository {
+	searchByName(query: string, limit: number): Promise<CardSearchResult[]>;
+	findById(id: number): Promise<CardSearchResult | null>;
+}

--- a/src/shared/card/infrastructure/cdb/CdbCardSearchRepository.test.ts
+++ b/src/shared/card/infrastructure/cdb/CdbCardSearchRepository.test.ts
@@ -1,0 +1,159 @@
+import initSqlJs from "sql.js";
+
+import { CdbCardSearchRepository, CdbFile } from "./CdbCardSearchRepository";
+
+interface CardRow {
+	id: number;
+	name: string;
+}
+
+const buildCdb = async (rows: CardRow[]): Promise<Uint8Array> => {
+	const SQL = await initSqlJs();
+	const db = new SQL.Database();
+	db.run("CREATE TABLE texts (id INTEGER PRIMARY KEY, name TEXT)");
+	for (const row of rows) {
+		db.run("INSERT INTO texts (id, name) VALUES (?, ?)", [row.id, row.name]);
+	}
+	const data = db.export();
+	db.close();
+
+	return data;
+};
+
+const cdbFile = (path: string, body: Uint8Array): CdbFile => ({
+	path,
+	read: async () => body,
+});
+
+class InMemoryCdbRepository extends CdbCardSearchRepository {
+	constructor(
+		private readonly files: CdbFile[],
+		lastSourceWins = false,
+	) {
+		super({ lastSourceWins });
+	}
+
+	protected async *cdbFiles(): AsyncIterable<CdbFile> {
+		for (const file of this.files) {
+			yield file;
+		}
+	}
+}
+
+describe("CdbCardSearchRepository", () => {
+	it("indexes names and reports the source .cdb of each card", async () => {
+		const body = await buildCdb([{ id: 46986414, name: "Dark Magician" }]);
+		const repository = new InMemoryCdbRepository([cdbFile("/res/cards.cdb", body)]);
+
+		expect(await repository.searchByName("dark", 10)).toEqual([
+			{ id: 46986414, name: "Dark Magician", source: "cards.cdb" },
+		]);
+		expect(await repository.findById(46986414)).toEqual({
+			id: 46986414,
+			name: "Dark Magician",
+			source: "cards.cdb",
+		});
+	});
+
+	it("returns null for an unknown id", async () => {
+		const body = await buildCdb([{ id: 1, name: "A" }]);
+		const repository = new InMemoryCdbRepository([cdbFile("/res/cards.cdb", body)]);
+
+		expect(await repository.findById(999)).toBeNull();
+	});
+
+	it("merges multiple .cdb files into a single index", async () => {
+		const base = await buildCdb([{ id: 1, name: "Alpha" }]);
+		const extra = await buildCdb([{ id: 2, name: "Beta" }]);
+		const repository = new InMemoryCdbRepository([
+			cdbFile("/folders/base.cdb", base),
+			cdbFile("/extra/extra.cdb", extra),
+		]);
+
+		const results = await repository.searchByName("a", 10);
+
+		expect(results).toEqual([
+			{ id: 1, name: "Alpha", source: "base.cdb" },
+			{ id: 2, name: "Beta", source: "extra.cdb" },
+		]);
+	});
+
+	it("keeps a single entry per id and the first source wins on overlap", async () => {
+		const base = await buildCdb([{ id: 1, name: "Card From Base" }]);
+		const overlapping = await buildCdb([{ id: 1, name: "Card From Extra" }]);
+		const repository = new InMemoryCdbRepository([
+			cdbFile("/folders/base.cdb", base),
+			cdbFile("/extra/overlap.cdb", overlapping),
+		]);
+
+		const results = await repository.searchByName("card", 10);
+
+		expect(results).toHaveLength(1);
+		expect(results[0].source).toBe("base.cdb");
+	});
+
+	it("lets the last source win when configured (merge override semantics)", async () => {
+		const base = await buildCdb([{ id: 1, name: "Card From Base" }]);
+		const overlapping = await buildCdb([{ id: 1, name: "Card From Extra" }]);
+		const repository = new InMemoryCdbRepository(
+			[cdbFile("/folders/base.cdb", base), cdbFile("/extra/overlap.cdb", overlapping)],
+			true,
+		);
+
+		const result = await repository.findById(1);
+
+		expect(result?.source).toBe("overlap.cdb");
+	});
+
+	it("lists each .cdb source with its card count", async () => {
+		const base = await buildCdb([
+			{ id: 1, name: "Alpha" },
+			{ id: 2, name: "Beta" },
+		]);
+		const extra = await buildCdb([{ id: 3, name: "Gamma" }]);
+		const repository = new InMemoryCdbRepository([
+			cdbFile("/extra/zeta.cdb", extra),
+			cdbFile("/folders/base.cdb", base),
+		]);
+
+		expect(await repository.listSources()).toEqual([
+			{ source: "base.cdb", count: 2 },
+			{ source: "zeta.cdb", count: 1 },
+		]);
+	});
+
+	it("returns a paginated, name-sorted page of cards for a given source", async () => {
+		const base = await buildCdb([
+			{ id: 3, name: "Cards C" },
+			{ id: 1, name: "Cards A" },
+			{ id: 2, name: "Cards B" },
+		]);
+		const other = await buildCdb([{ id: 9, name: "Other" }]);
+		const repository = new InMemoryCdbRepository([
+			cdbFile("/folders/base.cdb", base),
+			cdbFile("/extra/other.cdb", other),
+		]);
+
+		const page = await repository.findBySource("base.cdb", 2, 1);
+
+		expect(page.total).toBe(3);
+		expect(page.cards).toEqual([
+			{ id: 2, name: "Cards B", source: "base.cdb" },
+			{ id: 3, name: "Cards C", source: "base.cdb" },
+		]);
+	});
+
+	it("resolves names for known ids and skips unknown ones", async () => {
+		const base = await buildCdb([
+			{ id: 1, name: "Alpha" },
+			{ id: 2, name: "Beta" },
+		]);
+		const repository = new InMemoryCdbRepository([cdbFile("/folders/base.cdb", base)]);
+
+		const names = await repository.resolveNames([1, 2, 999]);
+
+		expect(names.get(1)).toBe("Alpha");
+		expect(names.get(2)).toBe("Beta");
+		expect(names.has(999)).toBe(false);
+	});
+});

--- a/src/shared/card/infrastructure/cdb/CdbCardSearchRepository.test.ts
+++ b/src/shared/card/infrastructure/cdb/CdbCardSearchRepository.test.ts
@@ -143,6 +143,19 @@ describe("CdbCardSearchRepository", () => {
 		]);
 	});
 
+	it("skips an unreadable .cdb and still indexes the readable ones", async () => {
+		const valid = await buildCdb([{ id: 1, name: "Alpha" }]);
+		const corrupt = new Uint8Array([1, 2, 3, 4]);
+		const repository = new InMemoryCdbRepository([
+			cdbFile("/folders/valid.cdb", valid),
+			cdbFile("/folders/broken.cdb", corrupt),
+		]);
+
+		const results = await repository.searchByName("a", 10);
+
+		expect(results).toEqual([{ id: 1, name: "Alpha", source: "valid.cdb" }]);
+	});
+
 	it("resolves names for known ids and skips unknown ones", async () => {
 		const base = await buildCdb([
 			{ id: 1, name: "Alpha" },

--- a/src/shared/card/infrastructure/cdb/CdbCardSearchRepository.ts
+++ b/src/shared/card/infrastructure/cdb/CdbCardSearchRepository.ts
@@ -1,0 +1,151 @@
+import { basename } from "node:path";
+
+import initSqlJs from "sql.js";
+
+import { CardCatalog, CardPage, CardSource } from "@shared/card/domain/CardCatalog";
+import { CardSearchRepository, CardSearchResult } from "@shared/card/domain/CardSearchRepository";
+
+export interface CdbFile {
+	path: string;
+	read(): Promise<Uint8Array>;
+}
+
+interface IndexedCard {
+	name: string;
+	source: string;
+}
+
+const SELECT_NAMES = "SELECT id, name FROM texts WHERE name IS NOT NULL AND name <> ''";
+
+export abstract class CdbCardSearchRepository implements CardSearchRepository, CardCatalog {
+	private readonly lastSourceWins: boolean;
+	private index: Map<number, IndexedCard> | null = null;
+	private building: Promise<Map<number, IndexedCard>> | null = null;
+
+	constructor(options: { lastSourceWins?: boolean } = {}) {
+		this.lastSourceWins = options.lastSourceWins ?? false;
+	}
+
+	protected abstract cdbFiles(): AsyncIterable<CdbFile>;
+
+	async searchByName(query: string, limit: number): Promise<CardSearchResult[]> {
+		const index = await this.getIndex();
+		const needle = query.toLowerCase();
+		const results: CardSearchResult[] = [];
+
+		for (const [id, card] of index) {
+			if (card.name.toLowerCase().includes(needle)) {
+				results.push({ id, name: card.name, source: card.source });
+				if (results.length >= limit) {
+					break;
+				}
+			}
+		}
+
+		return results;
+	}
+
+	async findById(id: number): Promise<CardSearchResult | null> {
+		const index = await this.getIndex();
+		const card = index.get(id);
+
+		return card ? { id, name: card.name, source: card.source } : null;
+	}
+
+	async listSources(): Promise<CardSource[]> {
+		const index = await this.getIndex();
+		const counts = new Map<string, number>();
+
+		for (const { source } of index.values()) {
+			counts.set(source, (counts.get(source) ?? 0) + 1);
+		}
+
+		return [...counts.entries()]
+			.map(([source, count]) => ({ source, count }))
+			.sort((a, b) => a.source.localeCompare(b.source));
+	}
+
+	async findBySource(source: string, limit: number, offset: number): Promise<CardPage> {
+		const index = await this.getIndex();
+		const matches: CardSearchResult[] = [];
+
+		for (const [id, card] of index) {
+			if (card.source === source) {
+				matches.push({ id, name: card.name, source: card.source });
+			}
+		}
+
+		matches.sort((a, b) => a.name.localeCompare(b.name));
+
+		return { total: matches.length, cards: matches.slice(offset, offset + limit) };
+	}
+
+	async resolveNames(ids: number[]): Promise<Map<number, string>> {
+		const index = await this.getIndex();
+		const names = new Map<number, string>();
+
+		for (const id of ids) {
+			const card = index.get(id);
+			if (card) {
+				names.set(id, card.name);
+			}
+		}
+
+		return names;
+	}
+
+	private async getIndex(): Promise<Map<number, IndexedCard>> {
+		if (this.index) {
+			return this.index;
+		}
+
+		if (!this.building) {
+			this.building = this.buildIndex()
+				.then((index) => {
+					this.index = index;
+
+					return index;
+				})
+				.finally(() => {
+					this.building = null;
+				});
+		}
+
+		return this.building;
+	}
+
+	private async buildIndex(): Promise<Map<number, IndexedCard>> {
+		const SQL = await initSqlJs();
+		const index = new Map<number, IndexedCard>();
+
+		for await (const file of this.cdbFiles()) {
+			if (!file.path.endsWith(".cdb")) {
+				continue;
+			}
+
+			const source = basename(file.path);
+			try {
+				const body = await file.read();
+				const db = new SQL.Database(body);
+				try {
+					for (const { values } of db.exec(SELECT_NAMES)) {
+						for (const [id, name] of values) {
+							if (typeof id !== "number" || typeof name !== "string") {
+								continue;
+							}
+							if (this.lastSourceWins || !index.has(id)) {
+								index.set(id, { name, source });
+							}
+						}
+					}
+				} finally {
+					db.close();
+				}
+			} catch {
+				continue;
+			}
+		}
+
+		return index;
+	}
+}

--- a/src/shared/card/infrastructure/cdb/CdbCardSearchRepository.ts
+++ b/src/shared/card/infrastructure/cdb/CdbCardSearchRepository.ts
@@ -4,6 +4,8 @@ import initSqlJs from "sql.js";
 
 import { CardCatalog, CardPage, CardSource } from "@shared/card/domain/CardCatalog";
 import { CardSearchRepository, CardSearchResult } from "@shared/card/domain/CardSearchRepository";
+import { Logger } from "@shared/logger/domain/Logger";
+import LoggerFactory from "@shared/logger/infrastructure/LoggerFactory";
 
 export interface CdbFile {
 	path: string;
@@ -19,6 +21,7 @@ const SELECT_NAMES = "SELECT id, name FROM texts WHERE name IS NOT NULL AND name
 
 export abstract class CdbCardSearchRepository implements CardSearchRepository, CardCatalog {
 	private readonly lastSourceWins: boolean;
+	private readonly logger: Logger = LoggerFactory.getLogger();
 	private index: Map<number, IndexedCard> | null = null;
 	private building: Promise<Map<number, IndexedCard>> | null = null;
 
@@ -141,7 +144,8 @@ export abstract class CdbCardSearchRepository implements CardSearchRepository, C
 				} finally {
 					db.close();
 				}
-			} catch {
+			} catch (error) {
+				this.logger.error(`Failed to read card database ${file.path}: ${error}`);
 				continue;
 			}
 		}

--- a/src/ygopro/card/infrastructure/YGOProCardSearchRepository.ts
+++ b/src/ygopro/card/infrastructure/YGOProCardSearchRepository.ts
@@ -1,0 +1,17 @@
+import { searchYGOProResource } from "koishipro-core.js";
+
+import {
+	CdbCardSearchRepository,
+	CdbFile,
+} from "@shared/card/infrastructure/cdb/CdbCardSearchRepository";
+import { config } from "src/config";
+
+export class YGOProCardSearchRepository extends CdbCardSearchRepository {
+	protected async *cdbFiles(): AsyncIterable<CdbFile> {
+		const folders = [...config.resources.ygopro.folders, ...config.resources.ygopro.extraFolders];
+
+		for await (const file of searchYGOProResource(...folders)) {
+			yield { path: file.path, read: () => file.read() };
+		}
+	}
+}


### PR DESCRIPTION
## Why

One of the most frequent reports on the server is about cards that already
exist in the EDOPro/YGOPro client but are not yet on the server. Until now
there was no way for players (or staff) to check which cards and banlists the
server actually has loaded. This adds a public, read-only inspection surface
so players can self-verify before reporting.

This is the **inspection half** of the problem. Hot reload of the card DB and
banlists is intentionally out of scope (separate follow-up); the YGOPro card
DB already hot-reloads, EDOPro and banlists do not.

## What

Public (no-auth) endpoints on the existing Express server:

- `GET /api/banlists` — available banlists per engine with per-category counts
- `GET /api/banlists/:engine/:name` — full banlist detail with each entry id
  resolved to its card name (forbidden / limited / semi-limited / whitelisted)
- `GET /api/databases` — the `.cdb` files per engine with card counts
- `GET /api/databases/cards?engine&source&limit&offset` — paginated cards in a `.cdb`
- `GET /api/cards?engine&q&limit` — search by name or passcode
- `GET /` — "Arcane Library" page: sidebar filters + list-first main view

## Notes

- **Provenance:** each card reports the source `.cdb` it came from. Since the
  merge discards the origin (EDOPro `INSERT OR REPLACE`, YGOPro flat
  `CardStorage`), it is captured at index time by reading the raw `.cdb` files.
- **YGOPro** indexes both `YGOPRO_FOLDERS` and `YGOPRO_EXTRA_FOLDERS`; overlap
  is deduped by id (first wins, folders first), matching the extended pool.
- Shared abstract `CdbCardSearchRepository` reads `.cdb` via sql.js and is the
  single place the two engine repositories differ (file discovery only).
- Page renders with `textContent` (XSS-safe).

## Tests

733 tests pass, `tsc` and `biome` clean. Application/catalog/banlist logic is
unit-tested (including in-memory `.cdb` fixtures). Endpoints smoke-tested
locally (HTML served, real EDOPro data returned, 400/404 paths). Visual
rendering not verified in a browser.
