### PR TITLE
feat: hot-reload the EDOPro card DB via atomic datasource swap

### DIFF
--- a/src/bootstrap/bootstrapPersistence.ts
+++ b/src/bootstrap/bootstrapPersistence.ts
@@ -1,4 +1,5 @@
 import { Redis } from "@shared/db/redis/infrastructure/Redis";
+import { EdoProCardDbHotReload } from "@edopro/card/infrastructure/sqlite/EdoProCardDbHotReload";
 import { EdoProSQLiteTypeORM } from "@edopro/card/infrastructure/sqlite/EdoProSQLiteTypeORM";
 import { Logger } from "@shared/logger/domain/Logger";
 
@@ -12,6 +13,10 @@ export async function bootstrapPersistence(logger: Logger): Promise<void> {
 	await sqlite.connect();
 	await sqlite.initialize();
 	logger.info("🗄️  SQLite connected");
+
+	// Hot-reload the EDOPro card DB: rebuild a fresh datasource and swap it in when
+	// the .cdb files change at runtime, with no restart.
+	await new EdoProCardDbHotReload().start();
 
 	if (config.ranking.enabled) {
 		const postgres = new PostgresTypeORM();

--- a/src/edopro/card/infrastructure/sqlite/CardSQLiteTYpeORMRepository.ts
+++ b/src/edopro/card/infrastructure/sqlite/CardSQLiteTYpeORMRepository.ts
@@ -1,11 +1,11 @@
-import { dataSource } from "../../../../shared/db/sqlite/infrastructure/data-source";
+import { getCardDataSource } from "../../../../shared/db/sqlite/infrastructure/data-source";
 import { Card } from "../../../../shared/card/domain/Card";
 import { CardRepository } from "../../../../shared/card/domain/CardRepository";
 import { CardEntity } from "@shared/db/sqlite/infrastructure/CardEntity";
 
 export class CardSQLiteTYpeORMRepository implements CardRepository {
 	async findByCode(code: string): Promise<Card | null> {
-		const repository = dataSource.getRepository(CardEntity);
+		const repository = getCardDataSource().getRepository(CardEntity);
 		const card = await repository.findOneBy({ id: code });
 		if (!card) {
 			return null;

--- a/src/edopro/card/infrastructure/sqlite/EdoProCardDbHotReload.ts
+++ b/src/edopro/card/infrastructure/sqlite/EdoProCardDbHotReload.ts
@@ -1,0 +1,84 @@
+import { createHash } from "node:crypto";
+import { readdir, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { DataSource } from "typeorm";
+
+import { CardDbReloader } from "@shared/db/sqlite/infrastructure/CardDbReloader";
+import { CARD_DB_FILE, swapCardDataSource } from "@shared/db/sqlite/infrastructure/data-source";
+import { Logger } from "@shared/logger/domain/Logger";
+import LoggerFactory from "@shared/logger/infrastructure/LoggerFactory";
+import { config } from "src/config";
+
+import { EdoProSQLiteTypeORM } from "./EdoProSQLiteTypeORM";
+
+const RELOAD_INTERVAL_MS = 10 * 60 * 1000;
+
+// Wires the EDOPro card DB into the generic CardDbReloader: fingerprints the .cdb
+// directory, rebuilds into a fresh file, swaps the datasource holder, and disposes
+// the replaced datasource + its file. Mirrors the YGOPro reload timer.
+export class EdoProCardDbHotReload {
+	private readonly logger: Logger = LoggerFactory.getLogger();
+	private readonly orm: EdoProSQLiteTypeORM;
+	private readonly directory: string;
+	private currentFile = CARD_DB_FILE;
+	private fileToDelete?: string;
+	private readonly reloader: CardDbReloader;
+
+	constructor(directory: string = `${config.resources.dir}/edopro/databases`) {
+		this.directory = directory;
+		this.orm = new EdoProSQLiteTypeORM([directory]);
+		this.reloader = new CardDbReloader({
+			fingerprint: () => this.fingerprint(),
+			build: () => this.buildNext(),
+			swap: (next) => swapCardDataSource(next),
+			destroy: (previous) => this.dispose(previous),
+		});
+	}
+
+	// Record the boot fingerprint, then poll for changes. The boot datasource is
+	// already built/merged by bootstrapPersistence, so we only prime here.
+	async start(): Promise<void> {
+		await this.reloader.prime();
+		setInterval(() => {
+			this.reloader.reloadIfChanged().catch((error) => {
+				this.logger.error("Failed reloading EDOPro card DB");
+				this.logger.error(error);
+			});
+		}, RELOAD_INTERVAL_MS);
+	}
+
+	private async fingerprint(): Promise<string> {
+		const hash = createHash("sha512");
+		const files = (await readdir(this.directory)).filter((file) => file.endsWith(".cdb")).sort();
+		for (const file of files) {
+			hash.update(file);
+			hash.update(await readFile(join(this.directory, file)));
+		}
+
+		return hash.digest("hex");
+	}
+
+	private async buildNext(): Promise<DataSource> {
+		const nextFile = `evolution_cards.${Date.now()}.db`;
+		const dataSource = await this.orm.build(nextFile);
+		this.fileToDelete = this.currentFile;
+		this.currentFile = nextFile;
+
+		return dataSource;
+	}
+
+	private async dispose(previous: DataSource): Promise<void> {
+		try {
+			await previous.destroy();
+		} catch (error) {
+			this.logger.error("Failed disposing the previous EDOPro card datasource");
+			this.logger.error(error);
+		}
+
+		const stale = this.fileToDelete;
+		this.fileToDelete = undefined;
+		if (stale) {
+			await rm(stale, { force: true }).catch(() => undefined);
+		}
+	}
+}

--- a/src/edopro/card/infrastructure/sqlite/EdoProCardDbHotReload.ts
+++ b/src/edopro/card/infrastructure/sqlite/EdoProCardDbHotReload.ts
@@ -1,5 +1,4 @@
-import { createHash } from "node:crypto";
-import { readdir, readFile, rm } from "node:fs/promises";
+import { readdir, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { DataSource } from "typeorm";
 
@@ -12,6 +11,7 @@ import { config } from "src/config";
 import { EdoProSQLiteTypeORM } from "./EdoProSQLiteTypeORM";
 
 const RELOAD_INTERVAL_MS = 10 * 60 * 1000;
+const DISPOSE_GRACE_MS = 60 * 1000;
 
 // Wires the EDOPro card DB into the generic CardDbReloader: fingerprints the .cdb
 // directory, rebuilds into a fresh file, swaps the datasource holder, and disposes
@@ -47,15 +47,21 @@ export class EdoProCardDbHotReload {
 		}, RELOAD_INTERVAL_MS);
 	}
 
+	// Fingerprint from each file's size + mtime instead of hashing contents, so the
+	// periodic check never reads/hashes hundreds of MB on the shared event loop.
 	private async fingerprint(): Promise<string> {
-		const hash = createHash("sha512");
 		const files = (await readdir(this.directory)).filter((file) => file.endsWith(".cdb")).sort();
+		const parts: string[] = [];
 		for (const file of files) {
-			hash.update(file);
-			hash.update(await readFile(join(this.directory, file)));
+			try {
+				const { size, mtimeMs } = await stat(join(this.directory, file));
+				parts.push(`${file}:${size}:${mtimeMs}`);
+			} catch {
+				// file vanished between readdir and stat — skip it
+			}
 		}
 
-		return hash.digest("hex");
+		return parts.join("|");
 	}
 
 	private async buildNext(): Promise<DataSource> {
@@ -67,7 +73,17 @@ export class EdoProCardDbHotReload {
 		return dataSource;
 	}
 
-	private async dispose(previous: DataSource): Promise<void> {
+	private dispose(previous: DataSource): Promise<void> {
+		const stale = this.fileToDelete;
+		this.fileToDelete = undefined;
+		// Defer the close + file deletion so in-flight findByCode calls on the old
+		// datasource can finish before its connection and file disappear.
+		setTimeout(() => void this.retire(previous, stale), DISPOSE_GRACE_MS).unref();
+
+		return Promise.resolve();
+	}
+
+	private async retire(previous: DataSource, stale?: string): Promise<void> {
 		try {
 			await previous.destroy();
 		} catch (error) {
@@ -75,10 +91,13 @@ export class EdoProCardDbHotReload {
 			this.logger.error(error);
 		}
 
-		const stale = this.fileToDelete;
-		this.fileToDelete = undefined;
 		if (stale) {
-			await rm(stale, { force: true }).catch(() => undefined);
+			try {
+				await rm(stale, { force: true });
+			} catch (error) {
+				this.logger.error(`Failed deleting stale EDOPro card DB file ${stale}`);
+				this.logger.error(error);
+			}
 		}
 	}
 }

--- a/src/edopro/card/infrastructure/sqlite/EdoProSQLiteTypeORM.ts
+++ b/src/edopro/card/infrastructure/sqlite/EdoProSQLiteTypeORM.ts
@@ -3,33 +3,49 @@ import { join } from "path";
 import { DataSource } from "typeorm";
 
 import { Database } from "../../../../evolution-types/src/Database";
-import { dataSource } from "@shared/db/sqlite/infrastructure/data-source";
+import {
+	buildCardDataSource,
+	getCardDataSource,
+} from "@shared/db/sqlite/infrastructure/data-source";
 import { config } from "src/config";
 
 export class EdoProSQLiteTypeORM implements Database {
-	private readonly dataSource: DataSource;
 	private readonly directoryPaths: string[];
 
 	constructor(directoryPaths?: string[]) {
-		this.dataSource = dataSource;
 		this.directoryPaths = directoryPaths ?? [`${config.resources.dir}/edopro/databases`];
 	}
 
 	async connect(): Promise<void> {
-		await this.dataSource.initialize();
+		await getCardDataSource().initialize();
 	}
 
 	async initialize(): Promise<void> {
-		for (const dirPath of this.directoryPaths) {
-			const files = await readdir(dirPath);
+		await this.mergeAll(getCardDataSource());
+	}
+
+	// Build a fresh datasource backed by `databaseFile`, merge every .cdb into it,
+	// and return it ready to be swapped in. Never touches the live datasource, so a
+	// rebuild can run while the current one is still serving lookups.
+	async build(databaseFile: string): Promise<DataSource> {
+		const dataSource = buildCardDataSource(databaseFile);
+		await dataSource.initialize();
+		await this.mergeAll(dataSource);
+
+		return dataSource;
+	}
+
+	private async mergeAll(dataSource: DataSource): Promise<void> {
+		for (const directoryPath of this.directoryPaths) {
+			const files = await readdir(directoryPath);
 			const cdbFiles = files.filter((file) => file.endsWith(".cdb"));
 			for (const file of cdbFiles) {
-				await this.merge(join(dirPath, file));
+				await this.merge(dataSource, join(directoryPath, file));
 			}
 		}
 	}
 
-	private async merge(path: string): Promise<void> {
+	private async merge(dataSource: DataSource, path: string): Promise<void> {
 		const queryRunner = dataSource.createQueryRunner();
 		await queryRunner.connect();
 		await queryRunner.startTransaction();

--- a/src/edopro/card/infrastructure/sqlite/EdoProSQLiteTypeORM.ts
+++ b/src/edopro/card/infrastructure/sqlite/EdoProSQLiteTypeORM.ts
@@ -1,4 +1,4 @@
-import { readdir } from "fs/promises";
+import { readdir, rm } from "fs/promises";
 import { join } from "path";
 import { DataSource } from "typeorm";
 
@@ -29,10 +29,19 @@ export class EdoProSQLiteTypeORM implements Database {
 	// rebuild can run while the current one is still serving lookups.
 	async build(databaseFile: string): Promise<DataSource> {
 		const dataSource = buildCardDataSource(databaseFile);
-		await dataSource.initialize();
-		await this.mergeAll(dataSource);
+		try {
+			await dataSource.initialize();
+			await this.mergeAll(dataSource);
 
-		return dataSource;
+			return dataSource;
+		} catch (error) {
+			// A half-built datasource would otherwise leak its connection + file.
+			if (dataSource.isInitialized) {
+				await dataSource.destroy().catch(() => undefined);
+			}
+			await rm(databaseFile, { force: true }).catch(() => undefined);
+			throw error;
+		}
 	}
 
 	private async mergeAll(dataSource: DataSource): Promise<void> {

--- a/src/shared/db/sqlite/infrastructure/CardDbReloader.test.ts
+++ b/src/shared/db/sqlite/infrastructure/CardDbReloader.test.ts
@@ -1,0 +1,67 @@
+import { DataSource } from "typeorm";
+
+import { CardDbReloader, CardDbReloaderPorts } from "./CardDbReloader";
+
+class FakePorts implements CardDbReloaderPorts {
+	fp = "a";
+	builds = 0;
+	swapped: DataSource[] = [];
+	destroyed: DataSource[] = [];
+	readonly builtDs = { tag: "new" } as unknown as DataSource;
+	readonly oldDs = { tag: "old" } as unknown as DataSource;
+
+	async fingerprint(): Promise<string> {
+		return this.fp;
+	}
+
+	async build(): Promise<DataSource> {
+		this.builds++;
+
+		return this.builtDs;
+	}
+
+	swap(next: DataSource): DataSource {
+		this.swapped.push(next);
+
+		return this.oldDs;
+	}
+
+	async destroy(previous: DataSource): Promise<void> {
+		this.destroyed.push(previous);
+	}
+}
+
+describe("CardDbReloader", () => {
+	it("does not rebuild when the fingerprint is unchanged after priming", async () => {
+		const ports = new FakePorts();
+		const reloader = new CardDbReloader(ports);
+		await reloader.prime();
+
+		expect(await reloader.reloadIfChanged()).toBe(false);
+		expect(ports.builds).toBe(0);
+		expect(ports.swapped).toHaveLength(0);
+	});
+
+	it("rebuilds, swaps, and destroys the old datasource when the fingerprint changes", async () => {
+		const ports = new FakePorts();
+		const reloader = new CardDbReloader(ports);
+		await reloader.prime();
+		ports.fp = "b";
+
+		expect(await reloader.reloadIfChanged()).toBe(true);
+		expect(ports.builds).toBe(1);
+		expect(ports.swapped).toEqual([ports.builtDs]);
+		expect(ports.destroyed).toEqual([ports.oldDs]);
+	});
+
+	it("no-ops on the next check once the new fingerprint is recorded", async () => {
+		const ports = new FakePorts();
+		const reloader = new CardDbReloader(ports);
+		await reloader.prime();
+		ports.fp = "b";
+		await reloader.reloadIfChanged();
+
+		expect(await reloader.reloadIfChanged()).toBe(false);
+		expect(ports.builds).toBe(1);
+	});
+});

--- a/src/shared/db/sqlite/infrastructure/CardDbReloader.ts
+++ b/src/shared/db/sqlite/infrastructure/CardDbReloader.ts
@@ -1,0 +1,49 @@
+import BetterLock from "better-lock";
+import { DataSource } from "typeorm";
+
+import { Logger } from "@shared/logger/domain/Logger";
+import LoggerFactory from "@shared/logger/infrastructure/LoggerFactory";
+
+export interface CardDbReloaderPorts {
+	// Stable fingerprint of the source .cdb files (changes when their contents do).
+	fingerprint(): Promise<string>;
+	// Build + merge a fresh DataSource into a new file (never touches the live one).
+	build(): Promise<DataSource>;
+	// Install `next` as the current datasource and return the replaced one.
+	swap(next: DataSource): DataSource;
+	// Dispose the replaced datasource (after in-flight queries drained).
+	destroy(previous: DataSource): Promise<void>;
+}
+
+// Mirrors the YGOPro reload pattern for the EDOPro card DB: on a content change,
+// rebuild a fresh datasource and atomically swap it in. A BetterLock serializes
+// overlapping checks so two timers can never rebuild at once.
+export class CardDbReloader {
+	private readonly logger: Logger = LoggerFactory.getLogger();
+	private readonly lock = new BetterLock();
+	private currentFingerprint: string | null = null;
+
+	constructor(private readonly ports: CardDbReloaderPorts) {}
+
+	// Record the current fingerprint without rebuilding — call once after the boot build.
+	async prime(): Promise<void> {
+		this.currentFingerprint = await this.ports.fingerprint();
+	}
+
+	async reloadIfChanged(): Promise<boolean> {
+		return this.lock.acquire(async () => {
+			const nextFingerprint = await this.ports.fingerprint();
+			if (nextFingerprint === this.currentFingerprint) {
+				return false;
+			}
+
+			const dataSource = await this.ports.build();
+			const previous = this.ports.swap(dataSource);
+			this.currentFingerprint = nextFingerprint;
+			await this.ports.destroy(previous);
+			this.logger.info("EDOPro card DB changed — swapped to a fresh datasource");
+
+			return true;
+		});
+	}
+}

--- a/src/shared/db/sqlite/infrastructure/data-source.test.ts
+++ b/src/shared/db/sqlite/infrastructure/data-source.test.ts
@@ -1,0 +1,23 @@
+import { DataSource } from "typeorm";
+
+import { buildCardDataSource, getCardDataSource, swapCardDataSource } from "./data-source";
+
+describe("card datasource holder", () => {
+	it("starts with a usable datasource", () => {
+		expect(getCardDataSource()).toBeInstanceOf(DataSource);
+	});
+
+	it("swaps the current datasource and returns the replaced one", () => {
+		const original = getCardDataSource();
+		const next = buildCardDataSource("evolution_cards.test.db");
+
+		const replaced = swapCardDataSource(next);
+
+		expect(replaced).toBe(original);
+		expect(getCardDataSource()).toBe(next);
+
+		// restore so the swap does not leak into other tests in this file
+		swapCardDataSource(original);
+		expect(getCardDataSource()).toBe(original);
+	});
+});

--- a/src/shared/db/sqlite/infrastructure/data-source.ts
+++ b/src/shared/db/sqlite/infrastructure/data-source.ts
@@ -2,15 +2,38 @@ import { CardEntity } from "./CardEntity";
 import { CardTextEntity } from "./CardTextEntity";
 import { DataSource, DataSourceOptions } from "typeorm";
 
-const options: DataSourceOptions = {
+export const CARD_DB_FILE = "evolution_cards.db";
+
+const cardOptions = (database: string): DataSourceOptions => ({
 	type: "better-sqlite3",
-	database: "evolution_cards.db",
+	database,
 	synchronize: true,
 	logging: false,
 	entities: [CardEntity, CardTextEntity],
 	subscribers: [],
 	migrations: [],
-};
+});
+
+// Build a fresh card DataSource for a given file. Used at boot and to rebuild a
+// new one on hot reload before atomically swapping it in.
+export function buildCardDataSource(database: string = CARD_DB_FILE): DataSource {
+	return new DataSource(cardOptions(database));
+}
+
+// Holder: consumers must read getCardDataSource() per query (not capture it), so
+// a hot-reload swap takes effect on their next call.
+let current = buildCardDataSource(CARD_DB_FILE);
+
+export function getCardDataSource(): DataSource {
+	return current;
+}
+
+export function swapCardDataSource(next: DataSource): DataSource {
+	const previous = current;
+	current = next;
+
+	return previous;
+}
 
 const mercuryOptions: DataSourceOptions = {
 	type: "better-sqlite3",
@@ -22,4 +45,3 @@ const mercuryOptions: DataSourceOptions = {
 	migrations: [],
 };
 export const mercuryDataSource = new DataSource(mercuryOptions);
-export const dataSource = new DataSource(options);


### PR DESCRIPTION
## Why

Slice 1 made the on-disk resources updatable at runtime, but the **EDOPro card DB** (the merged `evolution_cards.db`) was still loaded once at boot and never refreshed — so new EDOPro cards needed a restart. This slice adds live reload for it, with no restart and no interruption to in-flight lookups.

## What

- **Datasource holder.** `data-source.ts` exposes `buildCardDataSource(file)`, `getCardDataSource()`, and `swapCardDataSource(next)`. The single SQLite card datasource can now be swapped without consumers capturing a stale reference; `CardSQLiteTYpeORMRepository` reads `getCardDataSource()` per query.
- **`CardDbReloader`** (generic, unit-tested): fingerprint → build-new → swap → destroy-old, serialized by `BetterLock`. `prime()` records the boot fingerprint so the first tick doesn't rebuild.
- **`EdoProSQLiteTypeORM.build(file)`**: builds + merges every `.cdb` into a **fresh** datasource (never touches the live one), so a rebuild is safe while lookups run. Cleans up the half-built datasource + file if the merge fails.
- **`EdoProCardDbHotReload`**: fingerprints `resources/current/edopro/databases` (by size+mtime, so the periodic check never reads/hashes hundreds of MB on the shared event loop), rebuilds into a new file, swaps the holder, and disposes the previous datasource + file after a grace period (lets in-flight `findByCode` calls drain). Started from `bootstrapPersistence` on a 10-min timer. Mirrors the YGOPro reload pattern.

## Review

A `/code-review` ran on the diff; its findings are fixed in this branch: grace period before disposing the swapped-out datasource, `build()` cleanup on failure, size+mtime fingerprint instead of full-content hashing, and logging of dispose/delete errors.

## Scope / follow-ups

- Live now: EDOPro card DB (this) + YGOPro card pool (Slice 1).
- Still pending: banlists hot reload + inspection-index invalidation (Slice 3, issue #295), and removing the dead mercury pre-release merged-DB subsystem (chore).

## Testing

- `tsc` clean, 742 tests pass (new unit tests for the holder and the reloader), biome clean.
- **Not run here:** the real-DB end-to-end (a better-sqlite3 native binding ABI mismatch in the reviewer's node v26 vs the project's node 24) — runs under node 24 via `npm run dev`. The merge logic is unchanged from the proven boot path; only its target datasource is parameterized.
