### PR TITLE
feat: refresh the card inspection index on a TTL (#295)

### DIFF
--- a/src/shared/card/infrastructure/cdb/CdbCardSearchRepository.test.ts
+++ b/src/shared/card/infrastructure/cdb/CdbCardSearchRepository.test.ts
@@ -26,14 +26,17 @@ const cdbFile = (path: string, body: Uint8Array): CdbFile => ({
 });
 
 class InMemoryCdbRepository extends CdbCardSearchRepository {
+	builds = 0;
+
 	constructor(
 		private readonly files: CdbFile[],
-		lastSourceWins = false,
+		options: { lastSourceWins?: boolean; ttlMs?: number; now?: () => number } = {},
 	) {
-		super({ lastSourceWins });
+		super(options);
 	}
 
 	protected async *cdbFiles(): AsyncIterable<CdbFile> {
+		this.builds++;
 		for (const file of this.files) {
 			yield file;
 		}
@@ -97,12 +100,32 @@ describe("CdbCardSearchRepository", () => {
 		const overlapping = await buildCdb([{ id: 1, name: "Card From Extra" }]);
 		const repository = new InMemoryCdbRepository(
 			[cdbFile("/folders/base.cdb", base), cdbFile("/extra/overlap.cdb", overlapping)],
-			true,
+			{ lastSourceWins: true },
 		);
 
 		const result = await repository.findById(1);
 
 		expect(result?.source).toBe("overlap.cdb");
+	});
+
+	it("serves the cached index within the TTL and rebuilds after it lapses", async () => {
+		let clock = 0;
+		const body = await buildCdb([{ id: 1, name: "Alpha" }]);
+		const repository = new InMemoryCdbRepository([cdbFile("/folders/base.cdb", body)], {
+			ttlMs: 1000,
+			now: () => clock,
+		});
+
+		await repository.searchByName("a", 10); // first build at t=0
+		expect(repository.builds).toBe(1);
+
+		clock = 999;
+		await repository.searchByName("a", 10); // still fresh → cached
+		expect(repository.builds).toBe(1);
+
+		clock = 1000;
+		await repository.searchByName("a", 10); // TTL lapsed → rebuild
+		expect(repository.builds).toBe(2);
 	});
 
 	it("lists each .cdb source with its card count", async () => {

--- a/src/shared/card/infrastructure/cdb/CdbCardSearchRepository.ts
+++ b/src/shared/card/infrastructure/cdb/CdbCardSearchRepository.ts
@@ -18,15 +18,21 @@ interface IndexedCard {
 }
 
 const SELECT_NAMES = "SELECT id, name FROM texts WHERE name IS NOT NULL AND name <> ''";
+const DEFAULT_INDEX_TTL_MS = 10 * 60 * 1000;
 
 export abstract class CdbCardSearchRepository implements CardSearchRepository, CardCatalog {
 	private readonly lastSourceWins: boolean;
+	private readonly ttlMs: number;
+	private readonly now: () => number;
 	private readonly logger: Logger = LoggerFactory.getLogger();
 	private index: Map<number, IndexedCard> | null = null;
 	private building: Promise<Map<number, IndexedCard>> | null = null;
+	private builtAt = 0;
 
-	constructor(options: { lastSourceWins?: boolean } = {}) {
+	constructor(options: { lastSourceWins?: boolean; ttlMs?: number; now?: () => number } = {}) {
 		this.lastSourceWins = options.lastSourceWins ?? false;
+		this.ttlMs = options.ttlMs ?? DEFAULT_INDEX_TTL_MS;
+		this.now = options.now ?? Date.now;
 	}
 
 	protected abstract cdbFiles(): AsyncIterable<CdbFile>;
@@ -97,8 +103,10 @@ export abstract class CdbCardSearchRepository implements CardSearchRepository, C
 		return names;
 	}
 
+	// Cache the index but rebuild it once the TTL lapses, so the inspection page
+	// reflects hot-reloaded .cdb files instead of serving a process-lifetime cache.
 	private async getIndex(): Promise<Map<number, IndexedCard>> {
-		if (this.index) {
+		if (this.index !== null && this.now() - this.builtAt < this.ttlMs) {
 			return this.index;
 		}
 
@@ -106,6 +114,7 @@ export abstract class CdbCardSearchRepository implements CardSearchRepository, C
 			this.building = this.buildIndex()
 				.then((index) => {
 					this.index = index;
+					this.builtAt = this.now();
 
 					return index;
 				})


### PR DESCRIPTION
## Why

The card inspection index (`CdbCardSearchRepository`) was cached for the whole process lifetime, so the `/` inspection page kept showing stale data after the card hot-reloads (Slices 1 & 2) changed the underlying `.cdb` files — exactly issue #295.

## What

Rebuild the index once a TTL (10 min) lapses instead of caching it forever, keyed off an injectable clock so it's unit-testable. Within the TTL the cached index is served; after it, the next access rebuilds. This keeps the inspection page in sync with hot-reloaded resources (≤ TTL stale instead of forever).

## Scope note

This slice was originally going to also add **additive ban list hot-reload**, but a code review found the additive-append model doesn't fit YGOPro's index-based lflist selection (`findLFListByIndex`): appending an edited ban list leaves the new version unreachable by the client's index, and the EDOPro `findByName` path returns the stale first match. Given ban lists change rarely (format updates every few months) and getting it correct for both engines is non-trivial, that part was dropped. It can be designed properly as its own slice if ever needed.

## Testing

`tsc` clean, 743 tests pass (new unit test for the TTL refresh with an injected clock), biome clean.
