### PR TITLE
fix(core): resolve EDOPro scripts under resources/current

### DIFF
--- a/core/src/app/duel.cpp
+++ b/core/src/app/duel.cpp
@@ -1,5 +1,6 @@
 #include "../includes/duel.h"
 #include <stdexcept>
+#include <cstdlib>
 
 template <>
 constexpr LocInfo Read(const uint8_t *&ptr) noexcept
@@ -60,7 +61,11 @@ void Duel::destroy()
 void Duel::load_scripts()
 {
   std::filesystem::path current_path = std::filesystem::current_path();
-  std::filesystem::path scripts_path = current_path / "resources/edopro/scripts";
+  // Resources live under RESOURCES_DIR (default resources/current — the symlink
+  // maintained by the resource refresh), matching the TS config.resources.dir.
+  const char *resources_dir = std::getenv("RESOURCES_DIR");
+  std::filesystem::path scripts_path =
+      current_path / (resources_dir ? resources_dir : "resources/current") / "edopro/scripts";
   const char *path = scripts_path.c_str();
 
   std::vector<char> constants_buffer = this->file_reader.read(path, "constant.lua");

--- a/core/src/modules/shared/ScriptReader.cpp
+++ b/core/src/modules/shared/ScriptReader.cpp
@@ -2,6 +2,7 @@
 #include "ScriptReader.h"
 #include "FileReader.h"
 #include <filesystem>
+#include <cstdlib>
 namespace fs = std::filesystem;
 
 ScriptReader::ScriptReader(OCGRepository repository) : repository(repository) {}
@@ -16,7 +17,11 @@ int ScriptReader::read(void *duel, const char *name)
 {
   FileReader reader;
   std::filesystem::path currentPath = std::filesystem::current_path();
-  std::filesystem::path scriptsPath = currentPath / "resources/edopro/scripts";
+  // Resources live under RESOURCES_DIR (default resources/current — the symlink
+  // maintained by the resource refresh), matching the TS config.resources.dir.
+  const char *resourcesDir = std::getenv("RESOURCES_DIR");
+  std::filesystem::path scriptsPath =
+      currentPath / (resourcesDir ? resourcesDir : "resources/current") / "edopro/scripts";
   const char* path = scriptsPath.c_str();
 
   std::vector<char> buffer = reader.read(path, name);


### PR DESCRIPTION
## Why (regression)

The resources hot-reload work (#296) moved everything under `resources/current/` (a symlink to the active release), and the TS side was migrated to read from `config.resources.dir`. But the **C++ CoreIntegrator** hardcoded `resources/edopro/scripts` in two places, and that grep-and-migrate pass only covered `src/` — never `core/`. So at runtime the core couldn't open the script directory and crashed mid-duel:

```
filesystem error: recursive directory iterator cannot open directory:
No such file or directory [/app/resources/edopro/scripts]
... Core exited
```

## What

`core/src/modules/shared/ScriptReader.cpp` and `core/src/app/duel.cpp` now build the scripts path from `RESOURCES_DIR` (default `resources/current`), matching the TS `config.resources.dir`. The core is spawned by the server and inherits its env, so the two stay in sync — and a future `RESOURCES_DIR` override applies to both.

## Testing

- Pure C++ change; no TS touched (`tsc`/jest unaffected).
- Could **not** compile locally — the CMake configure fails on a missing Boost dev package that only exists in the Docker `core-builder` stage; the change is standard `std::getenv` (`<cstdlib>`) + filesystem path concat. CI / the Docker build compiles the core and is the compile gate here.
- After deploy, EDOPro duels load scripts from `resources/current/edopro/scripts` and no longer crash.
