### PR TITLE
fix(card): disable EDOPro card DB hot-reload crashing the core

### DIFF
--- a/src/bootstrap/bootstrapPersistence.ts
+++ b/src/bootstrap/bootstrapPersistence.ts
@@ -1,5 +1,4 @@
 import { Redis } from "@shared/db/redis/infrastructure/Redis";
-import { EdoProCardDbHotReload } from "@edopro/card/infrastructure/sqlite/EdoProCardDbHotReload";
 import { EdoProSQLiteTypeORM } from "@edopro/card/infrastructure/sqlite/EdoProSQLiteTypeORM";
 import { Logger } from "@shared/logger/domain/Logger";
 
@@ -14,9 +13,11 @@ export async function bootstrapPersistence(logger: Logger): Promise<void> {
 	await sqlite.initialize();
 	logger.info("🗄️  SQLite connected");
 
-	// Hot-reload the EDOPro card DB: rebuild a fresh datasource and swap it in when
-	// the .cdb files change at runtime, with no restart.
-	await new EdoProCardDbHotReload().start();
+	// EDOPro card DB hot-reload is intentionally disabled: the C++ core opens the
+	// fixed path evolution_cards.db (core CardSqliteRepository), and the previous
+	// reloader swapped to a timestamped file and deleted evolution_cards.db, leaving
+	// the core to crash mid-duel with "no such table: datas". Re-enable only once the
+	// reload refreshes evolution_cards.db in place (atomic rename at the fixed path).
 
 	if (config.ranking.enabled) {
 		const postgres = new PostgresTypeORM();


### PR DESCRIPTION
## Problema (prod-down)

Tras un sync de recursos, los duelos EDOPro crasheaban:

```
ERROR: Excepción capturada: no such table: datas  (DuelingState)
INFO: Core exited
```

## Causa raíz

El **core C++** tiene su propio repositorio de cartas y abre un path **fijo**:

```cpp
// core/src/modules/card/infrastructure/CardSqliteRepository.cpp
std::filesystem::path dbPath = currentPath / "evolution_cards.db";
sqlite3_open(path, &db);   // SELECT ... FROM datas WHERE datas.id = ?
```

El reloader de la Slice 2 (`EdoProCardDbHotReload`) construía un archivo nuevo
con timestamp (`evolution_cards.<id>.db`), swapeaba el datasource de TS y en el
`dispose` **borraba `evolution_cards.db`**. Tras el primer reload, el core abría
un path inexistente → SQLite crea un archivo vacío → `no such table: datas` →
crash a mitad de duelo.

Es la **misma clase de bug que #300**: el core C++ accede a recursos por su
cuenta y el hot-reload de TS no lo contemplaba.

## Mitigación

No iniciar el reloader. El server vuelve al `evolution_cards.db` self-contained
que se arma en el boot, que el core lee de forma confiable. Las cartas EDOPro se
actualizan con el rebuild diario de la imagen, hasta que el reload se rehaga para
refrescar `evolution_cards.db` **in place** (rename atómico sobre el path fijo)
y mantener sincronizados el datasource de TS y el core C++.

## Verificación
- `tsc --noEmit` limpio.
- Sin referencias colgando a `EdoProCardDbHotReload` en runtime.
- No se pudo compilar el core C++ localmente (Boost solo en el stage Docker); el gate es CI/Docker.

## Follow-up
Rediseñar el reload para refrescar `evolution_cards.db` in place (build a temp +
rename atómico + reconexión del datasource TS), probado en node 24.