### PR TITLE
fix(card): refresh EDOPro card DB in place so the C++ core sees hot-reloads

### DIFF
--- a/src/bootstrap/bootstrapPersistence.ts
+++ b/src/bootstrap/bootstrapPersistence.ts
@@ -1,4 +1,5 @@
 import { Redis } from "@shared/db/redis/infrastructure/Redis";
+import { EdoProCardDbHotReload } from "@edopro/card/infrastructure/sqlite/EdoProCardDbHotReload";
 import { EdoProSQLiteTypeORM } from "@edopro/card/infrastructure/sqlite/EdoProSQLiteTypeORM";
 import { Logger } from "@shared/logger/domain/Logger";
 
@@ -13,11 +14,9 @@ export async function bootstrapPersistence(logger: Logger): Promise<void> {
 	await sqlite.initialize();
 	logger.info("🗄️  SQLite connected");
 
-	// EDOPro card DB hot-reload is intentionally disabled: the C++ core opens the
-	// fixed path evolution_cards.db (core CardSqliteRepository), and the previous
-	// reloader swapped to a timestamped file and deleted evolution_cards.db, leaving
-	// the core to crash mid-duel with "no such table: datas". Re-enable only once the
-	// reload refreshes evolution_cards.db in place (atomic rename at the fixed path).
+	// Hot-reload the EDOPro card DB when the .cdb files change at runtime, refreshing
+	// evolution_cards.db in place so the C++ core (which opens that fixed path) sees it.
+	await new EdoProCardDbHotReload().start();
 
 	if (config.ranking.enabled) {
 		const postgres = new PostgresTypeORM();

--- a/src/edopro/card/infrastructure/sqlite/EdoProCardDbHotReload.ts
+++ b/src/edopro/card/infrastructure/sqlite/EdoProCardDbHotReload.ts
@@ -1,38 +1,23 @@
-import { readdir, rm, stat } from "node:fs/promises";
-import { join } from "node:path";
-import { DataSource } from "typeorm";
-
 import { CardDbReloader } from "@shared/db/sqlite/infrastructure/CardDbReloader";
-import { CARD_DB_FILE, swapCardDataSource } from "@shared/db/sqlite/infrastructure/data-source";
 import { Logger } from "@shared/logger/domain/Logger";
 import LoggerFactory from "@shared/logger/infrastructure/LoggerFactory";
 import { config } from "src/config";
 
+import { EdoProCardDbPorts } from "./EdoProCardDbPorts";
 import { EdoProSQLiteTypeORM } from "./EdoProSQLiteTypeORM";
 
 const RELOAD_INTERVAL_MS = 10 * 60 * 1000;
-const DISPOSE_GRACE_MS = 60 * 1000;
 
-// Wires the EDOPro card DB into the generic CardDbReloader: fingerprints the .cdb
-// directory, rebuilds into a fresh file, swaps the datasource holder, and disposes
-// the replaced datasource + its file. Mirrors the YGOPro reload timer.
+// Reload mechanics (atomic in-place replace) live in EdoProCardDbPorts. Mirrors
+// the YGOPro reload timer.
 export class EdoProCardDbHotReload {
 	private readonly logger: Logger = LoggerFactory.getLogger();
-	private readonly orm: EdoProSQLiteTypeORM;
-	private readonly directory: string;
-	private currentFile = CARD_DB_FILE;
-	private fileToDelete?: string;
 	private readonly reloader: CardDbReloader;
 
 	constructor(directory: string = `${config.resources.dir}/edopro/databases`) {
-		this.directory = directory;
-		this.orm = new EdoProSQLiteTypeORM([directory]);
-		this.reloader = new CardDbReloader({
-			fingerprint: () => this.fingerprint(),
-			build: () => this.buildNext(),
-			swap: (next) => swapCardDataSource(next),
-			destroy: (previous) => this.dispose(previous),
-		});
+		this.reloader = new CardDbReloader(
+			new EdoProCardDbPorts(new EdoProSQLiteTypeORM([directory]), directory),
+		);
 	}
 
 	// Record the boot fingerprint, then poll for changes. The boot datasource is
@@ -45,59 +30,5 @@ export class EdoProCardDbHotReload {
 				this.logger.error(error);
 			});
 		}, RELOAD_INTERVAL_MS);
-	}
-
-	// Fingerprint from each file's size + mtime instead of hashing contents, so the
-	// periodic check never reads/hashes hundreds of MB on the shared event loop.
-	private async fingerprint(): Promise<string> {
-		const files = (await readdir(this.directory)).filter((file) => file.endsWith(".cdb")).sort();
-		const parts: string[] = [];
-		for (const file of files) {
-			try {
-				const { size, mtimeMs } = await stat(join(this.directory, file));
-				parts.push(`${file}:${size}:${mtimeMs}`);
-			} catch {
-				// file vanished between readdir and stat — skip it
-			}
-		}
-
-		return parts.join("|");
-	}
-
-	private async buildNext(): Promise<DataSource> {
-		const nextFile = `evolution_cards.${Date.now()}.db`;
-		const dataSource = await this.orm.build(nextFile);
-		this.fileToDelete = this.currentFile;
-		this.currentFile = nextFile;
-
-		return dataSource;
-	}
-
-	private dispose(previous: DataSource): Promise<void> {
-		const stale = this.fileToDelete;
-		this.fileToDelete = undefined;
-		// Defer the close + file deletion so in-flight findByCode calls on the old
-		// datasource can finish before its connection and file disappear.
-		setTimeout(() => void this.retire(previous, stale), DISPOSE_GRACE_MS).unref();
-
-		return Promise.resolve();
-	}
-
-	private async retire(previous: DataSource, stale?: string): Promise<void> {
-		try {
-			await previous.destroy();
-		} catch (error) {
-			this.logger.error("Failed disposing the previous EDOPro card datasource");
-			this.logger.error(error);
-		}
-
-		if (stale) {
-			try {
-				await rm(stale, { force: true });
-			} catch (error) {
-				this.logger.error(`Failed deleting stale EDOPro card DB file ${stale}`);
-				this.logger.error(error);
-			}
-		}
 	}
 }

--- a/src/edopro/card/infrastructure/sqlite/EdoProCardDbPorts.test.ts
+++ b/src/edopro/card/infrastructure/sqlite/EdoProCardDbPorts.test.ts
@@ -1,0 +1,83 @@
+import { rename, rm } from "node:fs/promises";
+import type { DataSource } from "typeorm";
+
+import { CARD_DB_FILE } from "@shared/db/sqlite/infrastructure/data-source";
+
+import { EdoProCardDbPorts } from "./EdoProCardDbPorts";
+import type { EdoProSQLiteTypeORM } from "./EdoProSQLiteTypeORM";
+
+jest.mock("node:fs/promises", () => ({
+	rename: jest.fn(async () => undefined),
+	rm: jest.fn(async () => undefined),
+	readdir: jest.fn(async () => []),
+	stat: jest.fn(async () => ({ size: 0, mtimeMs: 0 })),
+}));
+
+const renameMock = rename as jest.Mock;
+const rmMock = rm as jest.Mock;
+
+const fakeOrm = (build: jest.Mock): EdoProSQLiteTypeORM =>
+	({ build }) as unknown as EdoProSQLiteTypeORM;
+
+describe("EdoProCardDbPorts", () => {
+	beforeEach(() => {
+		renameMock.mockClear();
+		renameMock.mockResolvedValue(undefined);
+		rmMock.mockClear();
+		rmMock.mockResolvedValue(undefined);
+	});
+
+	it("builds into a temp file then renames it onto the canonical evolution_cards.db", async () => {
+		const builtDs = { isInitialized: true } as unknown as DataSource;
+		const build = jest.fn((_file: string) => Promise.resolve(builtDs));
+		const ports = new EdoProCardDbPorts(fakeOrm(build), "dir");
+
+		const result = await ports.build();
+
+		expect(build).toHaveBeenCalledTimes(1);
+		const tempFile = build.mock.calls[0][0] as string;
+		expect(tempFile).not.toBe(CARD_DB_FILE);
+		expect(renameMock).toHaveBeenCalledWith(tempFile, CARD_DB_FILE);
+		expect(result).toBe(builtDs);
+	});
+
+	it("propagates an orm.build failure and never renames a failed build onto the canonical file", async () => {
+		const build = jest.fn((_file: string) => Promise.reject(new Error("merge failed")));
+		const ports = new EdoProCardDbPorts(fakeOrm(build), "dir");
+
+		await expect(ports.build()).rejects.toThrow("merge failed");
+		expect(renameMock).not.toHaveBeenCalled();
+	});
+
+	it("never deletes the canonical file when disposing the previous datasource", async () => {
+		jest.useFakeTimers();
+		const previous = { destroy: jest.fn(async () => undefined) } as unknown as DataSource;
+		const ports = new EdoProCardDbPorts(fakeOrm(jest.fn()), "dir", 1000);
+
+		await ports.destroy(previous);
+		expect(previous.destroy).not.toHaveBeenCalled(); // deferred by the grace
+
+		await jest.advanceTimersByTimeAsync(1000);
+
+		expect(previous.destroy).toHaveBeenCalledTimes(1);
+		expect(rmMock).not.toHaveBeenCalled(); // the C++ core depends on evolution_cards.db
+		jest.useRealTimers();
+	});
+
+	it("cleans up the temp and rethrows if the rename fails, leaving the canonical file untouched", async () => {
+		const builtDs = {
+			isInitialized: true,
+			destroy: jest.fn(async () => undefined),
+		} as unknown as DataSource;
+		const build = jest.fn((_file: string) => Promise.resolve(builtDs));
+		renameMock.mockRejectedValueOnce(new Error("EXDEV"));
+		const ports = new EdoProCardDbPorts(fakeOrm(build), "dir");
+
+		await expect(ports.build()).rejects.toThrow("EXDEV");
+
+		const tempFile = build.mock.calls[0][0] as string;
+		expect(builtDs.destroy).toHaveBeenCalledTimes(1);
+		expect(rmMock).toHaveBeenCalledWith(tempFile, { force: true });
+		expect(rmMock).not.toHaveBeenCalledWith(CARD_DB_FILE, expect.anything());
+	});
+});

--- a/src/edopro/card/infrastructure/sqlite/EdoProCardDbPorts.ts
+++ b/src/edopro/card/infrastructure/sqlite/EdoProCardDbPorts.ts
@@ -1,0 +1,86 @@
+import { readdir, rename, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { DataSource } from "typeorm";
+
+import { CardDbReloaderPorts } from "@shared/db/sqlite/infrastructure/CardDbReloader";
+import { CARD_DB_FILE, swapCardDataSource } from "@shared/db/sqlite/infrastructure/data-source";
+import { Logger } from "@shared/logger/domain/Logger";
+import LoggerFactory from "@shared/logger/infrastructure/LoggerFactory";
+
+import type { EdoProSQLiteTypeORM } from "./EdoProSQLiteTypeORM";
+
+const DISPOSE_GRACE_MS = 60 * 1000;
+const TEMP_DB_FILE = `${CARD_DB_FILE}.tmp`;
+
+// CardDbReloader ports for the EDOPro card DB. The C++ core (CardSqliteRepository)
+// opens the fixed path CARD_DB_FILE fresh per duel, so the reload must keep that
+// file as the single canonical artifact: build into a temp, then atomically rename
+// it onto CARD_DB_FILE. A running duel keeps its already-open inode (untouched); a
+// new duel opens the replaced file. The file is never a sidecar the core can't see
+// and is never deleted.
+export class EdoProCardDbPorts implements CardDbReloaderPorts {
+	private readonly logger: Logger = LoggerFactory.getLogger();
+
+	constructor(
+		private readonly orm: EdoProSQLiteTypeORM,
+		private readonly directory: string,
+		private readonly graceMs: number = DISPOSE_GRACE_MS,
+	) {}
+
+	// Fingerprint from each file's size + mtime instead of hashing contents, so the
+	// periodic check never reads/hashes hundreds of MB on the shared event loop.
+	async fingerprint(): Promise<string> {
+		const files = (await readdir(this.directory)).filter((file) => file.endsWith(".cdb")).sort();
+		const parts: string[] = [];
+		for (const file of files) {
+			try {
+				const { size, mtimeMs } = await stat(join(this.directory, file));
+				parts.push(`${file}:${size}:${mtimeMs}`);
+			} catch {
+				// file vanished between readdir and stat — skip it
+			}
+		}
+
+		return parts.join("|");
+	}
+
+	async build(): Promise<DataSource> {
+		// Drop any temp left by a crashed earlier build so we merge from a clean slate.
+		await rm(TEMP_DB_FILE, { force: true }).catch(() => undefined);
+		const dataSource = await this.orm.build(TEMP_DB_FILE);
+		try {
+			// Atomic on the same filesystem: the just-built datasource's open fd follows
+			// the inode, so it becomes CARD_DB_FILE; the previous file's inode lives on
+			// (held by the old datasource) until it is disposed.
+			await rename(TEMP_DB_FILE, CARD_DB_FILE);
+
+			return dataSource;
+		} catch (error) {
+			await dataSource.destroy().catch(() => undefined);
+			await rm(TEMP_DB_FILE, { force: true }).catch(() => undefined);
+			throw error;
+		}
+	}
+
+	swap(next: DataSource): DataSource {
+		return swapCardDataSource(next);
+	}
+
+	// Defer the close so in-flight findByCode calls on the old datasource finish.
+	// Only the connection is closed — CARD_DB_FILE is never removed (build() already
+	// replaced it in place, and the C++ core opens that path).
+	destroy(previous: DataSource): Promise<void> {
+		setTimeout(() => void this.retire(previous), this.graceMs).unref();
+
+		return Promise.resolve();
+	}
+
+	private async retire(previous: DataSource): Promise<void> {
+		try {
+			await previous.destroy();
+		} catch (error) {
+			this.logger.error("Failed disposing the previous EDOPro card datasource");
+			this.logger.error(error);
+		}
+	}
+}


### PR DESCRIPTION
## Contexto

#301 deshabilitó el hot-reload de la card DB EDOPro porque crasheaba el core C++
(`no such table: datas`). Este PR lo rehace bien y lo re-habilita.

## Causa raíz (recordatorio)

El core C++ (`CardSqliteRepository`) abre el path **fijo** `evolution_cards.db`
fresco por duelo. El reloader anterior construía `evolution_cards.<id>.db`,
swapeaba solo el datasource de TS y **borraba `evolution_cards.db`** en el
dispose → el siguiente duelo abría un path inexistente. Misma clase que #300.

## El fix: replace atómico in-place

`evolution_cards.db` es un **contrato compartido** TS↔C++. El reload ahora lo
mantiene como único artefacto canónico:

1. `build()` mergea los `.cdb` en `evolution_cards.db.tmp`.
2. `rename(tmp, evolution_cards.db)` — **atómico** (mismo FS). El fd del datasource
   recién armado sigue al inode → pasa a ser el canónico.
3. `swap()` apunta el holder al datasource nuevo.
4. `destroy()` cierra el datasource viejo tras un grace de 60s — **nunca borra el archivo**.

### Garantía de cero interrupción
| Actor | Resultado |
|---|---|
| Duelo en curso (core ya abrió la DB) | Sostiene su inode viejo → intacto |
| Duelo nuevo (`sqlite3_open` fresh) | Abre el inode nuevo completo → cartas actualizadas |
| El archivo en disco | Siempre existe y completo; nunca un sidecar invisible al core, nunca borrado |

**El fix vive en TS, no en C++**: el core es consumidor read-only y su contrato
(path fijo + open por duelo) ya es ideal para hot-reload.

## Cambios
- `EdoProCardDbPorts.ts` (nuevo): los ports del `CardDbReloader` con la lógica de rename/dispose.
- `EdoProCardDbPorts.test.ts` (nuevo): 4 tests (rename sobre el canónico, dispose sin `rm`, cleanup en fallo de rename, propagación de fallo de build).
- `EdoProCardDbHotReload.ts`: thin (timer + reloader).
- `bootstrapPersistence.ts`: reloader re-habilitado.

## Verificación
- TDD (RED→GREEN→REFACTOR). 747 tests pasan, `tsc --noEmit` limpio.
- `/code-review` corrido; findings aplicados (guard muerto, `import type`, test de fallo de build, comentario).
- **Pendiente de validación real**: el rename-while-open con better-sqlite3 no se puede correr local (ABI node 26 vs 24). Gate = CI/Docker + crear un duelo EDOPro en prod tras un reload y confirmar que no aparece `no such table`.

## Caveats
- Requiere journal mode default (rollback, **no WAL**) y temp en el mismo filesystem (CWD).
- Mejora futura opcional: abrir la DB del core en `READONLY` para que un archivo faltante falle fuerte en vez de crear uno vacío.