### PR TITLE
fix(ygopro): resolve genesys ban list by alias and reject join when missing

### DIFF
--- a/src/ygopro/room/application/YGOProJoinHandler.ts
+++ b/src/ygopro/room/application/YGOProJoinHandler.ts
@@ -7,7 +7,7 @@ import { JoinMessageHandler } from "@shared/room/domain/JoinMessageHandler";
 import { ISocket } from "@shared/socket/domain/ISocket";
 import { PlayerInfoMessage } from "@edopro/messages/client-to-server/PlayerInfoMessage";
 
-import { YGOProCtosJoinGame } from "ygopro-msg-encode";
+import { ErrorMessageType, YGOProCtosJoinGame } from "ygopro-msg-encode";
 import { MessageRepository } from "@shared/messages/MessageRepository";
 
 import { JoinStrategyRegistry } from "./join-strategies/JoinStrategyRegistry";
@@ -64,6 +64,15 @@ export class YGOProJoinHandler implements JoinMessageHandler {
 		};
 
 		const strategy = this.registry.resolve(ctx);
-		await strategy.handle(ctx);
+		try {
+			await strategy.handle(ctx);
+		} catch (error) {
+			this.logger.error(`JOIN_GAME rejected: ${error instanceof Error ? error.message : error}`);
+			const errorBuf = this.messageRepository.errorMessage(ErrorMessageType.JOINERROR, 0);
+			this.socket.send(errorBuf);
+			// close() (not destroy()): flush the JOINERROR frame before tearing down,
+			// consistent with the other join error paths.
+			this.socket.close();
+		}
 	}
 }

--- a/src/ygopro/room/domain/RuleMappings.ts
+++ b/src/ygopro/room/domain/RuleMappings.ts
@@ -505,9 +505,14 @@ export const formatRuleMappings: RuleMappings = {
 				max_deck_points = 100;
 			}
 
+			const genesysIndex = MercuryBanListMemoryRepository.findIndexByAlias("genesys");
+			if (genesysIndex === -1) {
+				throw new Error("Genesys ban list is not loaded");
+			}
+
 			return {
 				rule: 1,
-				lflist: 0,
+				lflist: genesysIndex,
 				duel_rule: 5,
 				max_deck_points,
 				time_limit: 450,

--- a/src/ygopro/room/domain/YGOProRoom.test.ts
+++ b/src/ygopro/room/domain/YGOProRoom.test.ts
@@ -296,11 +296,25 @@ describe("YGOProRoom", () => {
 	});
 
 	describe("Genesys Format", () => {
+		const GENESYS_HASH = 999;
+
+		beforeEach(() => {
+			YGOProBanListMemoryRepository.clear();
+			YGOProBanListMemoryRepository.add(createBanList("2026.04 OCG", 100));
+			YGOProBanListMemoryRepository.add(createBanList("2026.05 TCG", 200));
+			YGOProBanListMemoryRepository.add(createBanList("Genesys", GENESYS_HASH));
+		});
+
+		afterEach(() => {
+			YGOProBanListMemoryRepository.clear();
+		});
+
 		it("Should create a room with Genesys format if command contains genesys and the default points should be 100", () => {
 			const room = YGOProRoomMother.create({ command: "genesys#123" });
 
 			expect(room.hostInfo.rule).toBe(1);
-			expect(room.hostInfo.lflist).toBe(0);
+			expect(room.banListHash).toBe(GENESYS_HASH);
+			expect(room.hostInfo.max_deck_points).toBe(100);
 			expect(room.hostInfo.time_limit).toBe(450);
 			expect(room.hostInfo.duel_rule).toBe(5);
 		});
@@ -309,7 +323,8 @@ describe("YGOProRoom", () => {
 			const room = YGOProRoomMother.create({ command: "genesys250#123" });
 
 			expect(room.hostInfo.rule).toBe(1);
-			expect(room.hostInfo.lflist).toBe(0);
+			expect(room.banListHash).toBe(GENESYS_HASH);
+			expect(room.hostInfo.max_deck_points).toBe(250);
 			expect(room.hostInfo.time_limit).toBe(450);
 			expect(room.hostInfo.duel_rule).toBe(5);
 		});
@@ -317,7 +332,8 @@ describe("YGOProRoom", () => {
 		it("Should create a room with Genesys format if command contains g and the default points should be 100", () => {
 			const room = YGOProRoomMother.create({ command: "g#123" });
 			expect(room.hostInfo.rule).toBe(1);
-			expect(room.hostInfo.lflist).toBe(0);
+			expect(room.banListHash).toBe(GENESYS_HASH);
+			expect(room.hostInfo.max_deck_points).toBe(100);
 			expect(room.hostInfo.time_limit).toBe(450);
 			expect(room.hostInfo.duel_rule).toBe(5);
 		});
@@ -326,9 +342,19 @@ describe("YGOProRoom", () => {
 			const room = YGOProRoomMother.create({ command: "G300#123" });
 
 			expect(room.hostInfo.rule).toBe(1);
-			expect(room.hostInfo.lflist).toBe(0);
+			expect(room.banListHash).toBe(GENESYS_HASH);
+			expect(room.hostInfo.max_deck_points).toBe(300);
 			expect(room.hostInfo.time_limit).toBe(450);
 			expect(room.hostInfo.duel_rule).toBe(5);
+		});
+
+		it("Should throw when creating a Genesys room and the Genesys ban list is not loaded", () => {
+			YGOProBanListMemoryRepository.clear();
+			YGOProBanListMemoryRepository.add(createBanList("2026.04 OCG", 100));
+
+			expect(() => YGOProRoomMother.create({ command: "genesys#123" })).toThrow(
+				"Genesys ban list is not loaded",
+			);
 		});
 	});
 


### PR DESCRIPTION
## Summary

- Rooms created with the `genesys`/`gN` command on the ygopro path hardcoded `lflist: 0`, which resolves to the first loaded ban list (an OCG list at runtime, with the Genesys list sitting at index ~103). `isGenesys()` was therefore always false and the point/copy validation wired in #303 never ran — decks were silently validated against the wrong list.
- The genesys mapping now resolves the index via `findIndexByAlias("genesys")` (same as goat) and throws when the Genesys ban list is not loaded, so a misconfigured server fails the join instead of silently skipping Genesys rules.
- `YGOProJoinHandler` now catches join-strategy errors, sends `JOINERROR` to the client and closes the socket. Previously any strategy throw (including the pre-existing "param match with two rules") ended as an unhandled promise rejection.

## Changes

| File | Change |
|------|--------|
| `src/ygopro/room/domain/RuleMappings.ts` | Genesys mapping resolves lflist by alias; throws if the list is missing |
| `src/ygopro/room/application/YGOProJoinHandler.ts` | try/catch around strategy dispatch → JOINERROR + socket close |
| `src/ygopro/room/domain/YGOProRoom.test.ts` | Genesys tests seed the ban list repo and assert `banListHash` resolves to Genesys; new throw test |

## Test plan

- [x] New tests fail on the old code (they assert the Genesys hash, not index 0 — the old assertions `lflist === 0` were actually asserting "ban list not found")
- [x] Full suite green: 94 suites, 781 tests
- [x] `tsc --noEmit` and `biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)