### PR TITLE
feat(bootstrap): hot-reload ban lists without a server restart

### DIFF
--- a/src/bootstrap/bootstrapBanListLoaders.test.ts
+++ b/src/bootstrap/bootstrapBanListLoaders.test.ts
@@ -1,0 +1,157 @@
+// Tests for the re-callable loader functions extracted from bootstrap (REQ-302, REQ-303).
+// The functions are pure builders: they parse into a local temp array and do NOT touch
+// the live BanListMemoryRepository. Mocking at the class level to avoid fs / ygopro deps.
+
+jest.mock("@edopro/ban-list/infrastructure/BanListLoader", () => ({
+	EdoProBanListLoader: jest.fn(),
+}));
+jest.mock("@ygopro/ban-list/infrastructure/YGOProBanListLoader", () => ({
+	YGOProBanListLoader: jest.fn(),
+}));
+// Prevent config from loading env that doesn't exist in test env
+jest.mock("src/config", () => ({
+	config: {
+		resources: { dir: "/fake/resources" },
+	},
+}));
+
+import { EdoProBanListLoader } from "@edopro/ban-list/infrastructure/BanListLoader";
+import { YGOProBanListLoader } from "@ygopro/ban-list/infrastructure/YGOProBanListLoader";
+import { EdoproBanList } from "@edopro/ban-list/domain/BanList";
+import { YGOProBanList } from "@ygopro/ban-list/domain/YGOProBanList";
+
+// Import the functions AFTER mocks are set up
+import { loadEdoproBanLists, loadYgoproBanLists } from "./bootstrapBanListLoaders";
+
+const MockEdoProBanListLoader = EdoProBanListLoader as jest.MockedClass<typeof EdoProBanListLoader>;
+const MockYGOProBanListLoader = YGOProBanListLoader as jest.MockedClass<typeof YGOProBanListLoader>;
+
+function makeEdoList(name: string): EdoproBanList {
+	const list = new EdoproBanList();
+	list.setName(name);
+	return list;
+}
+
+function makeYgoList(name: string): YGOProBanList {
+	const list = new YGOProBanList();
+	list.setName(name);
+	return list;
+}
+
+describe("loadEdoproBanLists (REQ-302)", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it("calls loadDirectory for both evolution-lflists and lflists paths", async () => {
+		const mockLoadDirectory = jest.fn().mockResolvedValue(undefined);
+		MockEdoProBanListLoader.mockImplementation(() => ({
+			loadDirectory: mockLoadDirectory,
+			getLoaded: () => [],
+		}));
+
+		await loadEdoproBanLists();
+
+		expect(mockLoadDirectory).toHaveBeenCalledTimes(2);
+		expect(mockLoadDirectory).toHaveBeenCalledWith(
+			expect.stringContaining("edopro/evolution-lflists"),
+		);
+		expect(mockLoadDirectory).toHaveBeenCalledWith(expect.stringContaining("edopro/lflists"));
+	});
+
+	it("resolves without throwing when loader succeeds", async () => {
+		MockEdoProBanListLoader.mockImplementation(() => ({
+			loadDirectory: jest.fn().mockResolvedValue(undefined),
+			getLoaded: () => [],
+		}));
+
+		await expect(loadEdoproBanLists()).resolves.not.toThrow();
+	});
+
+	it("propagates the error when loadDirectory throws — caller is responsible for error handling", async () => {
+		MockEdoProBanListLoader.mockImplementation(() => ({
+			loadDirectory: jest.fn().mockRejectedValue(new Error("parse error")),
+			getLoaded: () => [],
+		}));
+
+		await expect(loadEdoproBanLists()).rejects.toThrow("parse error");
+	});
+
+	it("returns loaded EdoproBanList array from the loader", async () => {
+		const listA = makeEdoList("List A");
+		const listB = makeEdoList("List B");
+		const mockLoadDirectory = jest.fn().mockResolvedValue(undefined);
+		MockEdoProBanListLoader.mockImplementation(() => ({
+			loadDirectory: mockLoadDirectory,
+			getLoaded: () => [listA, listB],
+		}));
+
+		const result = await loadEdoproBanLists();
+
+		expect(result).toHaveLength(2);
+		expect(result).toContain(listA);
+		expect(result).toContain(listB);
+	});
+});
+
+describe("loadYgoproBanLists (REQ-302)", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it("calls load() once on YGOProBanListLoader", async () => {
+		const mockLoad = jest.fn().mockResolvedValue(undefined);
+		MockYGOProBanListLoader.mockImplementation(() => ({
+			load: mockLoad,
+			getLoaded: () => [],
+		}));
+
+		await loadYgoproBanLists();
+
+		expect(mockLoad).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns loaded YGOProBanList array from the loader", async () => {
+		const listX = makeYgoList("TCG 2026.04");
+		const mockLoad = jest.fn().mockResolvedValue(undefined);
+		MockYGOProBanListLoader.mockImplementation(() => ({
+			load: mockLoad,
+			getLoaded: () => [listX],
+		}));
+
+		const result = await loadYgoproBanLists();
+
+		expect(result).toHaveLength(1);
+		expect(result[0]).toBe(listX);
+	});
+});
+
+describe("REQ-303 — edopro loader called before ygopro loader", () => {
+	it("edopro load completes before ygopro load begins", async () => {
+		const callOrder: string[] = [];
+
+		MockEdoProBanListLoader.mockImplementation(() => ({
+			loadDirectory: jest.fn().mockImplementation(async () => {
+				callOrder.push("edopro:loadDirectory");
+			}),
+			getLoaded: () => [],
+		}));
+
+		MockYGOProBanListLoader.mockImplementation(() => ({
+			load: jest.fn().mockImplementation(async () => {
+				callOrder.push("ygopro:load");
+			}),
+			getLoaded: () => [],
+		}));
+
+		// Caller must always call edopro first, then ygopro (REQ-303 ordering).
+		await loadEdoproBanLists();
+		await loadYgoproBanLists();
+
+		expect(callOrder[0]).toBe("edopro:loadDirectory");
+		// Both edopro loadDirectory calls complete before ygopro:load
+		expect(callOrder.indexOf("ygopro:load")).toBeGreaterThan(
+			callOrder.lastIndexOf("edopro:loadDirectory"),
+		);
+	});
+});

--- a/src/bootstrap/bootstrapBanListLoaders.test.ts
+++ b/src/bootstrap/bootstrapBanListLoaders.test.ts
@@ -1,4 +1,4 @@
-// Tests for the re-callable loader functions extracted from bootstrap (REQ-302, REQ-303).
+// Tests for the re-callable loader functions extracted from bootstrap.
 // The functions are pure builders: they parse into a local temp array and do NOT touch
 // the live BanListMemoryRepository. Mocking at the class level to avoid fs / ygopro deps.
 
@@ -41,7 +41,7 @@ function makeYgoList(name: string): YGOProBanList {
 	return list;
 }
 
-describe("loadEdoproBanLists (REQ-302)", () => {
+describe("loadEdoproBanLists", () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 	});
@@ -97,7 +97,7 @@ describe("loadEdoproBanLists (REQ-302)", () => {
 	});
 });
 
-describe("loadYgoproBanLists (REQ-302)", () => {
+describe("loadYgoproBanLists", () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 	});
@@ -129,7 +129,7 @@ describe("loadYgoproBanLists (REQ-302)", () => {
 	});
 });
 
-describe("REQ-303 — edopro loader called before ygopro loader", () => {
+describe("edopro loader called before ygopro loader", () => {
 	it("edopro load completes before ygopro load begins", async () => {
 		const callOrder: string[] = [];
 
@@ -147,7 +147,7 @@ describe("REQ-303 — edopro loader called before ygopro loader", () => {
 			getLoaded: () => [],
 		}));
 
-		// Caller must always call edopro first, then ygopro (REQ-303 ordering).
+		// Caller must always call edopro first, then ygopro.
 		await loadEdoproBanLists();
 		await loadYgoproBanLists();
 

--- a/src/bootstrap/bootstrapBanListLoaders.test.ts
+++ b/src/bootstrap/bootstrapBanListLoaders.test.ts
@@ -23,8 +23,11 @@ import { YGOProBanList } from "@ygopro/ban-list/domain/YGOProBanList";
 // Import the functions AFTER mocks are set up
 import { loadEdoproBanLists, loadYgoproBanLists } from "./bootstrapBanListLoaders";
 
-const MockEdoProBanListLoader = EdoProBanListLoader as jest.MockedClass<typeof EdoProBanListLoader>;
-const MockYGOProBanListLoader = YGOProBanListLoader as jest.MockedClass<typeof YGOProBanListLoader>;
+// Cast to jest.Mock so we can control the constructor's returned instance via mockImplementation.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const MockEdoProBanListLoader = EdoProBanListLoader as jest.Mock<any>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const MockYGOProBanListLoader = YGOProBanListLoader as jest.Mock<any>;
 
 function makeEdoList(name: string): EdoproBanList {
 	const list = new EdoproBanList();

--- a/src/bootstrap/bootstrapBanListLoaders.ts
+++ b/src/bootstrap/bootstrapBanListLoaders.ts
@@ -1,15 +1,9 @@
-// Re-callable pure builders for edopro and ygopro ban lists (REQ-302).
+// Re-callable pure builders for edopro and ygopro ban lists.
 //
 // These functions parse ban lists into a local temporary array and do NOT touch
 // the live BanListMemoryRepository or YGOProBanListMemoryRepository. The caller
 // (bootstrapBanListReloader) is responsible for atomically swapping the repo via
 // replaceAll() once both arrays are successfully built.
-//
-// Ordering invariant (REQ-303): callers MUST always call loadEdoproBanLists() and
-// await its result BEFORE calling loadYgoproBanLists(). YGOProRoom resolves
-// _edoBanListHash from BanListMemoryRepository by name at room construction time,
-// so edopro banlists must be present in the repo before ygopro banlists are loaded.
-// The reloader in bootstrapBanListReloader.ts enforces this order explicitly.
 
 import { EdoProBanListLoader } from "@edopro/ban-list/infrastructure/BanListLoader";
 import { EdoproBanList } from "@edopro/ban-list/domain/BanList";
@@ -35,8 +29,8 @@ export async function loadEdoproBanLists(): Promise<EdoproBanList[]> {
  * Does NOT write to YGOProBanListMemoryRepository.
  * Throws on parse error — callers are responsible for error handling.
  *
- * Precondition (REQ-303): edopro ban lists must already be present in
- * BanListMemoryRepository before this is called (YGOProRoom cross-references them).
+ * Precondition: edopro ban lists must already be present in BanListMemoryRepository
+ * before this is called — YGOProRoom cross-references them by name at construction.
  */
 export async function loadYgoproBanLists(): Promise<YGOProBanList[]> {
 	const tmp: YGOProBanList[] = [];

--- a/src/bootstrap/bootstrapBanListLoaders.ts
+++ b/src/bootstrap/bootstrapBanListLoaders.ts
@@ -1,0 +1,46 @@
+// Re-callable pure builders for edopro and ygopro ban lists (REQ-302).
+//
+// These functions parse ban lists into a local temporary array and do NOT touch
+// the live BanListMemoryRepository or YGOProBanListMemoryRepository. The caller
+// (bootstrapBanListReloader) is responsible for atomically swapping the repo via
+// replaceAll() once both arrays are successfully built.
+//
+// Ordering invariant (REQ-303): callers MUST always call loadEdoproBanLists() and
+// await its result BEFORE calling loadYgoproBanLists(). YGOProRoom resolves
+// _edoBanListHash from BanListMemoryRepository by name at room construction time,
+// so edopro banlists must be present in the repo before ygopro banlists are loaded.
+// The reloader in bootstrapBanListReloader.ts enforces this order explicitly.
+
+import { EdoProBanListLoader } from "@edopro/ban-list/infrastructure/BanListLoader";
+import { EdoproBanList } from "@edopro/ban-list/domain/BanList";
+import { YGOProBanListLoader } from "@ygopro/ban-list/infrastructure/YGOProBanListLoader";
+import { YGOProBanList } from "@ygopro/ban-list/domain/YGOProBanList";
+import { config } from "src/config";
+
+/**
+ * Loads edopro ban lists into a fresh temporary array.
+ * Does NOT write to BanListMemoryRepository.
+ * Throws on parse error — callers are responsible for error handling.
+ */
+export async function loadEdoproBanLists(): Promise<EdoproBanList[]> {
+	const tmp: EdoproBanList[] = [];
+	const loader = new EdoProBanListLoader(tmp);
+	await loader.loadDirectory(`${config.resources.dir}/edopro/evolution-lflists`);
+	await loader.loadDirectory(`${config.resources.dir}/edopro/lflists`);
+	return loader.getLoaded();
+}
+
+/**
+ * Loads ygopro ban lists into a fresh temporary array.
+ * Does NOT write to YGOProBanListMemoryRepository.
+ * Throws on parse error — callers are responsible for error handling.
+ *
+ * Precondition (REQ-303): edopro ban lists must already be present in
+ * BanListMemoryRepository before this is called (YGOProRoom cross-references them).
+ */
+export async function loadYgoproBanLists(): Promise<YGOProBanList[]> {
+	const tmp: YGOProBanList[] = [];
+	const loader = new YGOProBanListLoader(tmp);
+	await loader.load();
+	return loader.getLoaded();
+}

--- a/src/bootstrap/bootstrapBanListReloader.test.ts
+++ b/src/bootstrap/bootstrapBanListReloader.test.ts
@@ -1,0 +1,187 @@
+// Tests for the ban-list reloader core cycle (REQ-304, REQ-305, REQ-307, REQ-308).
+// reloadBanListsOnce is exercised directly with injected ports so no filesystem,
+// timers, or singletons are touched.
+
+jest.mock("src/config", () => ({
+	config: { resources: { dir: "/fake/resources" } },
+}));
+jest.mock("./bootstrapBanListLoaders", () => ({
+	loadEdoproBanLists: jest.fn(),
+	loadYgoproBanLists: jest.fn(),
+}));
+
+import { EdoproBanList } from "@edopro/ban-list/domain/BanList";
+import { Logger } from "@shared/logger/domain/Logger";
+import { YGOProBanList } from "@ygopro/ban-list/domain/YGOProBanList";
+
+import {
+	type BanListReloaderPorts,
+	getBanListReloadedAt,
+	reloadBanListsOnce,
+} from "./bootstrapBanListReloader";
+
+function fakeLogger(): Logger {
+	return {
+		info: jest.fn(),
+		error: jest.fn(),
+		warn: jest.fn(),
+		debug: jest.fn(),
+	} as unknown as Logger;
+}
+
+function makeEdoList(name: string): EdoproBanList {
+	const list = new EdoproBanList();
+	list.setName(name);
+	return list;
+}
+
+function makeYgoList(name: string): YGOProBanList {
+	const list = new YGOProBanList();
+	list.setName(name);
+	return list;
+}
+
+interface Recorder {
+	calls: string[];
+	edoproReplaced: EdoproBanList[] | null;
+	ygoproReplaced: YGOProBanList[] | null;
+}
+
+function makePorts(overrides: Partial<BanListReloaderPorts> & { recorder?: Recorder } = {}): {
+	ports: BanListReloaderPorts;
+	recorder: Recorder;
+} {
+	const recorder: Recorder = overrides.recorder ?? {
+		calls: [],
+		edoproReplaced: null,
+		ygoproReplaced: null,
+	};
+	const ports: BanListReloaderPorts = {
+		fingerprint: overrides.fingerprint ?? jest.fn().mockResolvedValue("fp-new"),
+		loadEdopro:
+			overrides.loadEdopro ??
+			jest.fn().mockImplementation(async () => {
+				recorder.calls.push("loadEdopro");
+				return [makeEdoList("Edo A")];
+			}),
+		loadYgopro:
+			overrides.loadYgopro ??
+			jest.fn().mockImplementation(async () => {
+				recorder.calls.push("loadYgopro");
+				return [makeYgoList("Ygo A")];
+			}),
+		replaceEdopro:
+			overrides.replaceEdopro ??
+			((next) => {
+				recorder.calls.push("replaceEdopro");
+				recorder.edoproReplaced = next;
+			}),
+		replaceYgopro:
+			overrides.replaceYgopro ??
+			((next) => {
+				recorder.calls.push("replaceYgopro");
+				recorder.ygoproReplaced = next;
+			}),
+		now: overrides.now ?? (() => "2026-07-14T12:00:00.000Z"),
+	};
+	return { ports, recorder };
+}
+
+describe("reloadBanListsOnce — change detection (REQ-304)", () => {
+	it("skips the rebuild when the fingerprint is unchanged", async () => {
+		const { ports, recorder } = makePorts({
+			fingerprint: jest.fn().mockResolvedValue("fp-same"),
+		});
+
+		const outcome = await reloadBanListsOnce(ports, fakeLogger(), "fp-same");
+
+		expect(outcome.changed).toBe(false);
+		expect(outcome.fingerprint).toBe("fp-same");
+		expect(recorder.calls).toEqual([]); // no load, no replace
+	});
+
+	it("rebuilds and swaps when the fingerprint changed", async () => {
+		const { ports, recorder } = makePorts();
+
+		const outcome = await reloadBanListsOnce(ports, fakeLogger(), "fp-old");
+
+		expect(outcome.changed).toBe(true);
+		expect(outcome.fingerprint).toBe("fp-new");
+		expect(recorder.edoproReplaced).toHaveLength(1);
+		expect(recorder.ygoproReplaced).toHaveLength(1);
+	});
+});
+
+describe("reloadBanListsOnce — atomic swap ordering (REQ-305)", () => {
+	it("replaces edopro before ygopro", async () => {
+		const { ports, recorder } = makePorts();
+
+		await reloadBanListsOnce(ports, fakeLogger(), "fp-old");
+
+		expect(recorder.calls).toEqual(["loadEdopro", "loadYgopro", "replaceEdopro", "replaceYgopro"]);
+		expect(recorder.calls.indexOf("replaceEdopro")).toBeLessThan(
+			recorder.calls.indexOf("replaceYgopro"),
+		);
+	});
+});
+
+describe("reloadBanListsOnce — empty-result safety (REQ-308)", () => {
+	it("keeps previous lists and does NOT swap when edopro rebuild is empty", async () => {
+		const { ports, recorder } = makePorts({
+			loadEdopro: jest.fn().mockResolvedValue([]),
+		});
+
+		const outcome = await reloadBanListsOnce(ports, fakeLogger(), "fp-old");
+
+		expect(outcome.changed).toBe(false);
+		// old fingerprint retained so the next cycle retries
+		expect(outcome.fingerprint).toBe("fp-old");
+		expect(recorder.edoproReplaced).toBeNull();
+		expect(recorder.ygoproReplaced).toBeNull();
+	});
+
+	it("keeps previous lists and does NOT swap when ygopro rebuild is empty", async () => {
+		const { ports, recorder } = makePorts({
+			loadYgopro: jest.fn().mockResolvedValue([]),
+		});
+
+		const outcome = await reloadBanListsOnce(ports, fakeLogger(), "fp-old");
+
+		expect(outcome.changed).toBe(false);
+		expect(recorder.edoproReplaced).toBeNull();
+		expect(recorder.ygoproReplaced).toBeNull();
+	});
+});
+
+describe("reloadBanListsOnce — error propagation (REQ-307)", () => {
+	it("propagates loader errors so the scheduler can keep previous lists", async () => {
+		const { ports } = makePorts({
+			loadEdopro: jest.fn().mockRejectedValue(new Error("parse boom")),
+		});
+
+		await expect(reloadBanListsOnce(ports, fakeLogger(), "fp-old")).rejects.toThrow("parse boom");
+	});
+});
+
+describe("getBanListReloadedAt (REQ-304 — timestamp)", () => {
+	it("advances after a successful reload", async () => {
+		const { ports } = makePorts({ now: () => "2026-07-14T15:30:00.000Z" });
+
+		await reloadBanListsOnce(ports, fakeLogger(), "fp-old");
+
+		expect(getBanListReloadedAt()).toBe("2026-07-14T15:30:00.000Z");
+	});
+
+	it("does not advance when the rebuild is skipped (unchanged fingerprint)", async () => {
+		const { ports: first } = makePorts({ now: () => "2026-07-14T15:30:00.000Z" });
+		await reloadBanListsOnce(first, fakeLogger(), "fp-old"); // sets a known value
+
+		const { ports: second } = makePorts({
+			fingerprint: jest.fn().mockResolvedValue("fp-same"),
+			now: () => "2026-07-14T99:99:99.000Z",
+		});
+		await reloadBanListsOnce(second, fakeLogger(), "fp-same");
+
+		expect(getBanListReloadedAt()).toBe("2026-07-14T15:30:00.000Z");
+	});
+});

--- a/src/bootstrap/bootstrapBanListReloader.test.ts
+++ b/src/bootstrap/bootstrapBanListReloader.test.ts
@@ -1,6 +1,5 @@
-// Tests for the ban-list reloader core cycle (REQ-304, REQ-305, REQ-307, REQ-308).
-// reloadBanListsOnce is exercised directly with injected ports so no filesystem,
-// timers, or singletons are touched.
+// Tests for the ban-list reloader core cycle. reloadBanListsOnce is exercised
+// directly with injected ports so no filesystem, timers, or singletons are touched.
 
 jest.mock("src/config", () => ({
 	config: { resources: { dir: "/fake/resources" } },
@@ -87,7 +86,7 @@ function makePorts(overrides: Partial<BanListReloaderPorts> & { recorder?: Recor
 	return { ports, recorder };
 }
 
-describe("reloadBanListsOnce — change detection (REQ-304)", () => {
+describe("reloadBanListsOnce — change detection", () => {
 	it("skips the rebuild when the fingerprint is unchanged", async () => {
 		const { ports, recorder } = makePorts({
 			fingerprint: jest.fn().mockResolvedValue("fp-same"),
@@ -112,7 +111,7 @@ describe("reloadBanListsOnce — change detection (REQ-304)", () => {
 	});
 });
 
-describe("reloadBanListsOnce — atomic swap ordering (REQ-305)", () => {
+describe("reloadBanListsOnce — atomic swap ordering", () => {
 	it("replaces edopro before ygopro", async () => {
 		const { ports, recorder } = makePorts();
 
@@ -125,7 +124,7 @@ describe("reloadBanListsOnce — atomic swap ordering (REQ-305)", () => {
 	});
 });
 
-describe("reloadBanListsOnce — empty-result safety (REQ-308)", () => {
+describe("reloadBanListsOnce — empty-result safety", () => {
 	it("keeps previous lists and does NOT swap when edopro rebuild is empty", async () => {
 		const { ports, recorder } = makePorts({
 			loadEdopro: jest.fn().mockResolvedValue([]),
@@ -153,7 +152,7 @@ describe("reloadBanListsOnce — empty-result safety (REQ-308)", () => {
 	});
 });
 
-describe("reloadBanListsOnce — error propagation (REQ-307)", () => {
+describe("reloadBanListsOnce — error propagation", () => {
 	it("propagates loader errors so the scheduler can keep previous lists", async () => {
 		const { ports } = makePorts({
 			loadEdopro: jest.fn().mockRejectedValue(new Error("parse boom")),
@@ -163,7 +162,7 @@ describe("reloadBanListsOnce — error propagation (REQ-307)", () => {
 	});
 });
 
-describe("getBanListReloadedAt (REQ-304 — timestamp)", () => {
+describe("getBanListReloadedAt — timestamp", () => {
 	it("advances after a successful reload", async () => {
 		const { ports } = makePorts({ now: () => "2026-07-14T15:30:00.000Z" });
 

--- a/src/bootstrap/bootstrapBanListReloader.ts
+++ b/src/bootstrap/bootstrapBanListReloader.ts
@@ -1,4 +1,4 @@
-// Periodic ban-list hot-reload (REQ-304, REQ-305, REQ-307, REQ-308).
+// Periodic ban-list hot-reload.
 //
 // Ban lists are loaded once at boot (bootstrapEdoproResources / bootstrapYgoproResources).
 // The resources sidecar refreshes the underlying .conf files on disk, but the Node
@@ -33,7 +33,7 @@ const DEFAULT_INTERVAL_MS = (Number(process.env.RESOURCES_REFRESH_SECONDS) || 60
 
 // Timestamp of when the in-memory ban lists were last (re)loaded. Set at reloader
 // start (lists are current as of boot) and updated on every successful reload.
-// TODO(P4): expose via GET /api/resources/version (banlists.reloadedAt).
+// Exposed via getBanListReloadedAt() for a future resource-version endpoint.
 let reloadedAt: string | null = null;
 
 export function getBanListReloadedAt(): string | null {

--- a/src/bootstrap/bootstrapBanListReloader.ts
+++ b/src/bootstrap/bootstrapBanListReloader.ts
@@ -1,0 +1,193 @@
+// Periodic ban-list hot-reload (REQ-304, REQ-305, REQ-307, REQ-308).
+//
+// Ban lists are loaded once at boot (bootstrapEdoproResources / bootstrapYgoproResources).
+// The resources sidecar refreshes the underlying .conf files on disk, but the Node
+// process never re-reads them — so a new ban list historically required a full restart.
+// This reloader closes that gap: on an interval it detects on-disk changes via a
+// size+mtime fingerprint and, when something changed, rebuilds both ban-list arrays
+// into local temporaries and atomically swaps them into the live repositories.
+//
+// Safety properties:
+// - Double-buffer swap (replaceAll): the swap is synchronous with no await between the
+//   two repositories, so no concurrent HTTP read can observe an empty or half-updated list.
+// - edopro BEFORE ygopro: ygopro rooms cross-reference edopro ban lists by name to resolve
+//   _edoBanListHash (see bootstrapYgoproResources), so edopro must be current first.
+// - In-flight rooms are unaffected: they snapshot their ban list at construction
+//   (YGOProRoom), not a live repository reference.
+// - Never swaps in an empty parse result: if a rebuild yields zero lists the previous
+//   in-memory lists are kept and the change is retried next cycle.
+
+import { readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+import { EdoproBanList } from "@edopro/ban-list/domain/BanList";
+import BanListMemoryRepository from "@edopro/ban-list/infrastructure/BanListMemoryRepository";
+import { Logger } from "@shared/logger/domain/Logger";
+import { YGOProBanList } from "@ygopro/ban-list/domain/YGOProBanList";
+import YGOProBanListMemoryRepository from "@ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository";
+import { config } from "src/config";
+
+import { loadEdoproBanLists, loadYgoproBanLists } from "./bootstrapBanListLoaders";
+
+const DEFAULT_INTERVAL_MS = (Number(process.env.RESOURCES_REFRESH_SECONDS) || 600) * 1000;
+
+// Timestamp of when the in-memory ban lists were last (re)loaded. Set at reloader
+// start (lists are current as of boot) and updated on every successful reload.
+// TODO(P4): expose via GET /api/resources/version (banlists.reloadedAt).
+let reloadedAt: string | null = null;
+
+export function getBanListReloadedAt(): string | null {
+	return reloadedAt;
+}
+
+/** Injectable seam so the reload logic can be tested without the filesystem or timers. */
+export interface BanListReloaderPorts {
+	loadEdopro(): Promise<EdoproBanList[]>;
+	loadYgopro(): Promise<YGOProBanList[]>;
+	replaceEdopro(next: EdoproBanList[]): void;
+	replaceYgopro(next: YGOProBanList[]): void;
+	fingerprint(): Promise<string>;
+	now(): string;
+}
+
+export interface ReloadOutcome {
+	changed: boolean;
+	fingerprint: string;
+}
+
+/**
+ * Runs a single reload cycle. Pure with respect to timers — the scheduler calls this.
+ * Skips the rebuild when the fingerprint is unchanged; keeps the previous lists when a
+ * rebuild yields an empty result (returns the OLD fingerprint so the next cycle retries).
+ */
+export async function reloadBanListsOnce(
+	ports: BanListReloaderPorts,
+	logger: Logger,
+	lastFingerprint: string,
+): Promise<ReloadOutcome> {
+	const fingerprint = await ports.fingerprint();
+	if (fingerprint === lastFingerprint) {
+		return { changed: false, fingerprint };
+	}
+
+	const edoproNext = await ports.loadEdopro();
+	const ygoproNext = await ports.loadYgopro();
+
+	if (edoproNext.length === 0 || ygoproNext.length === 0) {
+		logger.error(
+			`[banlist-reloader] rebuild produced empty ban lists (edopro=${edoproNext.length}, ygopro=${ygoproNext.length}) — keeping previous lists`,
+		);
+		// Do not adopt the new fingerprint: retry on the next cycle.
+		return { changed: false, fingerprint: lastFingerprint };
+	}
+
+	// Double-buffer swap — edopro before ygopro, no await between the two.
+	ports.replaceEdopro(edoproNext);
+	ports.replaceYgopro(ygoproNext);
+	reloadedAt = ports.now();
+
+	logger.info(
+		`[banlist-reloader] reloaded ${edoproNext.length} edopro + ${ygoproNext.length} ygopro ban lists`,
+	);
+	return { changed: true, fingerprint };
+}
+
+export interface BanListReloaderOptions {
+	intervalMs?: number;
+	ports?: BanListReloaderPorts;
+}
+
+export interface BanListReloaderHandle {
+	stop(): void;
+}
+
+/**
+ * Starts the periodic ban-list reloader. Captures the current on-disk fingerprint as the
+ * baseline (boot already loaded the lists) and only reloads when it changes thereafter.
+ * Returns a handle whose stop() clears the timer — the clean rollback boundary.
+ */
+export async function bootstrapBanListReloader(
+	logger: Logger,
+	options: BanListReloaderOptions = {},
+): Promise<BanListReloaderHandle> {
+	const ports = options.ports ?? createDefaultPorts();
+	const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+
+	let lastFingerprint = await ports.fingerprint().catch(() => "");
+	reloadedAt = ports.now();
+	let running = false;
+
+	const tick = async (): Promise<void> => {
+		if (running) {
+			return; // overlap guard: never run two reloads concurrently
+		}
+		running = true;
+		try {
+			const outcome = await reloadBanListsOnce(ports, logger, lastFingerprint);
+			lastFingerprint = outcome.fingerprint;
+		} catch (error) {
+			logger.error("[banlist-reloader] reload cycle failed — keeping previous lists");
+			logger.error(error);
+		} finally {
+			running = false;
+		}
+	};
+
+	const timer = setInterval(() => void tick(), intervalMs);
+	timer.unref();
+
+	logger.info(`🕒 Ban-list reloader started (every ${Math.round(intervalMs / 1000)}s)`);
+	return { stop: (): void => clearInterval(timer) };
+}
+
+function createDefaultPorts(): BanListReloaderPorts {
+	return {
+		loadEdopro: loadEdoproBanLists,
+		loadYgopro: loadYgoproBanLists,
+		replaceEdopro: (next) => BanListMemoryRepository.replaceAll(next),
+		replaceYgopro: (next) => YGOProBanListMemoryRepository.replaceAll(next),
+		fingerprint: () => fingerprintLflists(config.resources.dir),
+		now: () => new Date().toISOString(),
+	};
+}
+
+/**
+ * Fingerprint every lflist .conf under the resource directories that feed the two loaders,
+ * using size + mtime (never reads/hashes contents on the event loop). Mirrors
+ * EdoProCardDbPorts.fingerprint(). Missing directories are skipped, not fatal.
+ */
+async function fingerprintLflists(baseDir: string): Promise<string> {
+	const roots = [
+		join(baseDir, "edopro", "evolution-lflists"),
+		join(baseDir, "edopro", "lflists"),
+		join(baseDir, "ygopro", "formats"),
+	];
+	const parts: string[] = [];
+	for (const root of roots) {
+		await collectConfFingerprints(root, parts);
+	}
+	parts.sort();
+	return parts.join("|");
+}
+
+async function collectConfFingerprints(dir: string, out: string[]): Promise<void> {
+	let entries;
+	try {
+		entries = await readdir(dir, { withFileTypes: true });
+	} catch {
+		return; // directory absent — skip
+	}
+	for (const entry of entries) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			await collectConfFingerprints(full, out);
+		} else if (entry.name.endsWith(".conf")) {
+			try {
+				const { size, mtimeMs } = await stat(full);
+				out.push(`${full}:${size}:${mtimeMs}`);
+			} catch {
+				// file vanished between readdir and stat — skip it
+			}
+		}
+	}
+}

--- a/src/bootstrap/bootstrapEdoproResources.ts
+++ b/src/bootstrap/bootstrapEdoproResources.ts
@@ -1,13 +1,13 @@
-import { EdoProBanListLoader } from "@edopro/ban-list/infrastructure/BanListLoader";
 import { Logger } from "@shared/logger/domain/Logger";
-import { config } from "src/config";
+import BanListMemoryRepository from "@edopro/ban-list/infrastructure/BanListMemoryRepository";
+import { loadEdoproBanLists } from "./bootstrapBanListLoaders";
 
-// Loads edopro ban lists into BanListMemoryRepository. Note: these are also
-// read by the ygopro path (see bootstrapYgoproResources), not only by edopro.
+// Loads edopro ban lists into BanListMemoryRepository via loadEdoproBanLists().
+// Note: these are also read by the ygopro path (see bootstrapYgoproResources),
+// not only by edopro.
 export async function bootstrapEdoproResources(logger: Logger): Promise<void> {
-	const banLists = new EdoProBanListLoader();
-	await banLists.loadDirectory(`${config.resources.dir}/edopro/evolution-lflists`);
-	await banLists.loadDirectory(`${config.resources.dir}/edopro/lflists`);
+	const tmp = await loadEdoproBanLists();
+	BanListMemoryRepository.replaceAll(tmp);
 
 	logger.info("🎴 EdoPro ban lists loaded");
 }

--- a/src/bootstrap/bootstrapYgoproResources.ts
+++ b/src/bootstrap/bootstrapYgoproResources.ts
@@ -1,6 +1,7 @@
 import { Logger } from "@shared/logger/domain/Logger";
-import { YGOProBanListLoader } from "@ygopro/ban-list/infrastructure/YGOProBanListLoader";
 import { YGOProResourceLoader } from "@ygopro/ygopro/YGOProResourceLoader";
+import YGOProBanListMemoryRepository from "@ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository";
+import { loadYgoproBanLists } from "./bootstrapBanListLoaders";
 
 // Loads ygopro card resources and ban lists.
 //
@@ -12,8 +13,8 @@ export async function bootstrapYgoproResources(logger: Logger): Promise<void> {
 	await YGOProResourceLoader.start();
 	await YGOProResourceLoader.get().logLFLists();
 
-	const banLists = new YGOProBanListLoader();
-	await banLists.load();
+	const tmp = await loadYgoproBanLists();
+	YGOProBanListMemoryRepository.replaceAll(tmp);
 
 	logger.info("🎴 YGOPro resources & ban lists loaded");
 }

--- a/src/edopro/ban-list/infrastructure/BanListLoader.ts
+++ b/src/edopro/ban-list/infrastructure/BanListLoader.ts
@@ -8,6 +8,19 @@ import { BanListLoader } from "src/shared/ban-list/BanListLoader";
 import { parseBanListEntry } from "src/shared/ban-list/parseBanListEntry";
 
 export class EdoProBanListLoader extends BanListLoader {
+	/**
+	 * When a target array is provided, parsed banlists are pushed into it instead
+	 * of the shared BanListMemoryRepository. This enables the re-callable pure-builder
+	 * pattern used by loadEdoproBanLists() (bootstrapBanListLoaders.ts) for hot-reload.
+	 */
+	private readonly _target: EdoproBanList[] | null;
+	private readonly _loaded: EdoproBanList[] = [];
+
+	constructor(target?: EdoproBanList[]) {
+		super();
+		this._target = target ?? null;
+	}
+
 	async loadDirectory(path: string): Promise<void> {
 		const directoryPath = path;
 		const files = await readdir(directoryPath);
@@ -16,6 +29,11 @@ export class EdoProBanListLoader extends BanListLoader {
 			const filePath = join(directoryPath, file);
 			this.load(filePath);
 		}
+	}
+
+	/** Returns all banlists parsed by this loader instance. */
+	getLoaded(): EdoproBanList[] {
+		return this._loaded;
 	}
 
 	private load(path: string): void {
@@ -51,6 +69,12 @@ export class EdoProBanListLoader extends BanListLoader {
 			banList.add(entry.code, entry.limit, entry.points);
 		}
 
-		BanListMemoryRepository.add(banList);
+		this._loaded.push(banList);
+
+		if (this._target !== null) {
+			this._target.push(banList);
+		} else {
+			BanListMemoryRepository.add(banList);
+		}
 	}
 }

--- a/src/edopro/ban-list/infrastructure/BanListMemoryRepository.test.ts
+++ b/src/edopro/ban-list/infrastructure/BanListMemoryRepository.test.ts
@@ -30,7 +30,7 @@ describe("EdoproBanListMemoryRepository.replaceAll", () => {
 		BanListMemoryRepository.replaceAll([]);
 	});
 
-	describe("REQ-301 — basic replacement", () => {
+	describe("basic replacement", () => {
 		it("replaceAll([a, b]) → get() returns [a, b]", () => {
 			const a = makeList("List A");
 			const b = makeList("List B");
@@ -60,7 +60,7 @@ describe("EdoproBanListMemoryRepository.replaceAll", () => {
 		});
 	});
 
-	describe("REQ-305 (ATOMICITY) — synchronous swap invariant", () => {
+	describe("atomicity — synchronous swap invariant", () => {
 		it("get() returns the new list immediately after replaceAll returns — no empty window", () => {
 			// This test asserts the synchronous contract.
 			// replaceAll MUST NOT contain any await between emptying and refilling the array.

--- a/src/edopro/ban-list/infrastructure/BanListMemoryRepository.test.ts
+++ b/src/edopro/ban-list/infrastructure/BanListMemoryRepository.test.ts
@@ -1,0 +1,108 @@
+import { EdoproBanList } from "../domain/BanList";
+import BanListMemoryRepository from "./BanListMemoryRepository";
+
+function makeList(name: string, hash?: number): EdoproBanList {
+	const list = new EdoproBanList();
+	list.setName(name);
+	if (hash !== undefined) {
+		list.add(hash, 1); // adds a card so hash is non-zero
+	}
+	return list;
+}
+
+describe("EdoproBanListMemoryRepository.replaceAll", () => {
+	beforeEach(() => {
+		// Clear the repository between tests using the internal array trick.
+		// replaceAll([]) empties it — once it exists; before it does we rely on the
+		// fact that the module array starts empty at process start and Jest isolates
+		// modules per test file only when configured with resetModules. We clear it
+		// via replaceAll once the method is available, but for the red-bar tests we
+		// seed and then call replaceAll.
+		//
+		// NOTE: The module-level array is shared across tests within one file.
+		// Use replaceAll([]) in afterEach once the method exists.
+	});
+
+	afterEach(() => {
+		// Reset to a clean state after each test.
+		// This call is intentionally calling the method under test — if it does not
+		// exist yet the teardown will also fail, which is correct for the red bar.
+		BanListMemoryRepository.replaceAll([]);
+	});
+
+	describe("REQ-301 — basic replacement", () => {
+		it("replaceAll([a, b]) → get() returns [a, b]", () => {
+			const a = makeList("List A");
+			const b = makeList("List B");
+
+			BanListMemoryRepository.replaceAll([a, b]);
+
+			expect(BanListMemoryRepository.get()).toEqual([a, b]);
+		});
+
+		it("replaceAll([]) on a non-empty repo → get() returns []", () => {
+			const a = makeList("List A");
+			BanListMemoryRepository.replaceAll([a]);
+
+			BanListMemoryRepository.replaceAll([]);
+
+			expect(BanListMemoryRepository.get()).toHaveLength(0);
+		});
+
+		it("replaceAll called twice — second call overwrites first", () => {
+			const a = makeList("List A");
+			const b = makeList("List B");
+
+			BanListMemoryRepository.replaceAll([a]);
+			BanListMemoryRepository.replaceAll([b]);
+
+			expect(BanListMemoryRepository.get()).toEqual([b]);
+		});
+	});
+
+	describe("REQ-305 (ATOMICITY) — synchronous swap invariant", () => {
+		it("get() returns the new list immediately after replaceAll returns — no empty window", () => {
+			// This test asserts the synchronous contract.
+			// replaceAll MUST NOT contain any await between emptying and refilling the array.
+			// Because JS is single-threaded, reading get() right after replaceAll()
+			// returns MUST yield the new list, never [].
+			const initial = makeList("Initial");
+			BanListMemoryRepository.replaceAll([initial]);
+
+			const next = makeList("Next");
+			BanListMemoryRepository.replaceAll([next]);
+
+			// Immediately after the call, the list is the new one — never empty.
+			const result = BanListMemoryRepository.get();
+			expect(result).toHaveLength(1);
+			expect(result[0]).toBe(next);
+		});
+	});
+
+	describe("findByHash / findByName operate on new list after replaceAll", () => {
+		it("findByName returns item from the new list", () => {
+			const old = makeList("Old List");
+			BanListMemoryRepository.replaceAll([old]);
+
+			const fresh = makeList("Fresh List");
+			BanListMemoryRepository.replaceAll([fresh]);
+
+			expect(BanListMemoryRepository.findByName("Fresh List")).toBe(fresh);
+			expect(BanListMemoryRepository.findByName("Old List")).toBeNull();
+		});
+
+		it("findByHash returns item from the new list", () => {
+			const a = makeList("A");
+			BanListMemoryRepository.replaceAll([a]);
+			const aHash = a.hash;
+
+			const b = new EdoproBanList();
+			b.setName("B");
+			b.add(99999, 1); // different card → different hash
+			BanListMemoryRepository.replaceAll([b]);
+
+			expect(BanListMemoryRepository.findByHash(aHash)).toBeNull();
+			expect(BanListMemoryRepository.findByHash(b.hash)).toBe(b);
+		});
+	});
+});

--- a/src/edopro/ban-list/infrastructure/BanListMemoryRepository.ts
+++ b/src/edopro/ban-list/infrastructure/BanListMemoryRepository.ts
@@ -36,7 +36,7 @@ export default {
 	/**
 	 * Atomically replaces the entire banlist array with a new one.
 	 * Uses a synchronous in-place swap (no await between truncation and fill)
-	 * so no concurrent HTTP request can observe an empty-list window (REQ-305).
+	 * so no concurrent HTTP request can observe an empty-list window.
 	 */
 	replaceAll(next: EdoproBanList[]): void {
 		banLists.length = 0;

--- a/src/edopro/ban-list/infrastructure/BanListMemoryRepository.ts
+++ b/src/edopro/ban-list/infrastructure/BanListMemoryRepository.ts
@@ -32,4 +32,14 @@ export default {
 	getOnlyWithName(): string[] {
 		return banLists.filter((banList) => banList.name).map((item) => item.name as string);
 	},
+
+	/**
+	 * Atomically replaces the entire banlist array with a new one.
+	 * Uses a synchronous in-place swap (no await between truncation and fill)
+	 * so no concurrent HTTP request can observe an empty-list window (REQ-305).
+	 */
+	replaceAll(next: EdoproBanList[]): void {
+		banLists.length = 0;
+		banLists.push(...next);
+	},
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import LoggerFactory from "src/shared/logger/infrastructure/LoggerFactory";
 import { config } from "./config";
 import { bootstrapResources } from "./bootstrap/bootstrapResources";
 import { bootstrapPersistence } from "./bootstrap/bootstrapPersistence";
+import { bootstrapBanListReloader } from "./bootstrap/bootstrapBanListReloader";
 import { Server } from "./http-server/Server";
 import { HostServer } from "./socket-server/HostServer";
 import { WSHostServer } from "./socket-server/WSHostServer";
@@ -37,6 +38,10 @@ async function start(): Promise<void> {
 
 	await bootstrapResources(logger);
 	await bootstrapPersistence(logger);
+
+	// Keep in-memory ban lists fresh without a restart: re-read them on an interval
+	// when the on-disk .conf files change (see bootstrapBanListReloader).
+	await bootstrapBanListReloader(logger);
 
 	await server.initialize();
 	WebSocketSingleton.getInstance();

--- a/src/ygopro/ban-list/infrastructure/YGOProBanListLoader.ts
+++ b/src/ygopro/ban-list/infrastructure/YGOProBanListLoader.ts
@@ -9,6 +9,22 @@ import LoggerFactory from "src/shared/logger/infrastructure/LoggerFactory";
  */
 export class YGOProBanListLoader {
 	private readonly logger = LoggerFactory.getLogger();
+	private readonly _target: YGOProBanList[] | null;
+	private readonly _loaded: YGOProBanList[] = [];
+
+	/**
+	 * When a target array is provided, parsed banlists are pushed into it instead
+	 * of the shared YGOProBanListMemoryRepository. Enables re-callable pure-builder
+	 * pattern used by loadYgoproBanLists() for hot-reload (REQ-302).
+	 */
+	constructor(target?: YGOProBanList[]) {
+		this._target = target ?? null;
+	}
+
+	/** Returns all banlists parsed by this loader instance. */
+	getLoaded(): YGOProBanList[] {
+		return this._loaded;
+	}
 
 	/**
 	 * Normalizes lflist names from library to match expected format.
@@ -91,9 +107,17 @@ export class YGOProBanListLoader {
 				this.parseUnrestrictedEntries(text, banList);
 			}
 
-			YGOProBanListMemoryRepository.add(banList);
+			this._loaded.push(banList);
+
+			if (this._target !== null) {
+				this._target.push(banList);
+			} else {
+				YGOProBanListMemoryRepository.add(banList);
+			}
 		}
 
-		this.logger.info(`Loaded ${YGOProBanListMemoryRepository.get().length} ban lists`);
+		const count =
+			this._target !== null ? this._loaded.length : YGOProBanListMemoryRepository.get().length;
+		this.logger.info(`Loaded ${count} ban lists`);
 	}
 }

--- a/src/ygopro/ban-list/infrastructure/YGOProBanListLoader.ts
+++ b/src/ygopro/ban-list/infrastructure/YGOProBanListLoader.ts
@@ -14,8 +14,8 @@ export class YGOProBanListLoader {
 
 	/**
 	 * When a target array is provided, parsed banlists are pushed into it instead
-	 * of the shared YGOProBanListMemoryRepository. Enables re-callable pure-builder
-	 * pattern used by loadYgoproBanLists() for hot-reload (REQ-302).
+	 * of the shared YGOProBanListMemoryRepository. This lets the loader build into a
+	 * temporary buffer so callers can swap it into the repository atomically.
 	 */
 	constructor(target?: YGOProBanList[]) {
 		this._target = target ?? null;

--- a/src/ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository.ts
+++ b/src/ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository.ts
@@ -58,7 +58,7 @@ export default {
 
 	/**
 	 * Atomically replaces the entire banlist array with a new one.
-	 * Symmetric with EdoproBanListMemoryRepository.replaceAll (REQ-301, REQ-305).
+	 * Synchronous in-place swap so no concurrent read observes an empty-list window.
 	 */
 	replaceAll(next: YGOProBanList[]): void {
 		banLists.length = 0;

--- a/src/ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository.ts
+++ b/src/ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository.ts
@@ -55,4 +55,13 @@ export default {
 	clear(): void {
 		banLists.length = 0;
 	},
+
+	/**
+	 * Atomically replaces the entire banlist array with a new one.
+	 * Symmetric with EdoproBanListMemoryRepository.replaceAll (REQ-301, REQ-305).
+	 */
+	replaceAll(next: YGOProBanList[]): void {
+		banLists.length = 0;
+		banLists.push(...next);
+	},
 };

--- a/src/ygopro/room/domain/YGOProRoom.test.ts
+++ b/src/ygopro/room/domain/YGOProRoom.test.ts
@@ -7,6 +7,8 @@ import { YGOProRoomMother } from "@test-support/mothers/room/YGOProRoomMother";
 import { PlayerInfoMessageMother } from "@test-support/mothers/PlayerInfoMessageMother";
 import YGOProBanListMemoryRepository from "@ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository";
 import { YGOProBanList } from "@ygopro/ban-list/domain/YGOProBanList";
+import BanListMemoryRepository from "@edopro/ban-list/infrastructure/BanListMemoryRepository";
+import { EdoproBanList } from "@edopro/ban-list/domain/BanList";
 import { YGOProRoom } from "./YGOProRoom";
 import { LoggerMock } from "@test-support/mocks/logger/LoggerMock";
 import { MessageRepositoryMock } from "@test-support/mocks/MessageRepositoryMock";
@@ -619,6 +621,46 @@ describe("YGOProRoom", () => {
 			const room = YGOProRoomMother.create({ command: "bo5,m#123" });
 			expect(room.hostInfo.mode).toBe(GameMode.MATCH);
 			expect(room.hostInfo.best_of).toBe(5);
+		});
+	});
+
+	// REQ-306: a ban-list hot-reload must NOT affect rooms already constructed. A room
+	// snapshots its edopro ban-list hash as a primitive at construction (YGOProRoom.ts:154),
+	// so a later replaceAll() on the repositories cannot mutate an in-flight room's value.
+	describe("ban-list hot-reload invariant (REQ-306)", () => {
+		// EdoproBanList derives its hash from added cards (no setHash); distinct cardIds
+		// yield distinct hashes, which is what a real banlist edit produces.
+		function makeEdoList(name: string, cardId: number): EdoproBanList {
+			const list = new EdoproBanList();
+			list.setName(name);
+			list.add(cardId, 0); // a forbidden entry → deterministic non-zero hash
+			return list;
+		}
+
+		afterEach(() => {
+			YGOProBanListMemoryRepository.replaceAll([]);
+			BanListMemoryRepository.replaceAll([]);
+		});
+
+		it("keeps a constructed room's edoBanListHash after the repositories are reloaded", () => {
+			// Seed so the room resolves a concrete edopro hash at construction:
+			// ygopro list at index 0 → its name → matching edopro list.
+			const original = makeEdoList("Format A", 10000);
+			const originalHash = original.hash;
+			YGOProBanListMemoryRepository.replaceAll([createBanList("Format A", 111)]);
+			BanListMemoryRepository.replaceAll([original]);
+
+			const room = YGOProRoomMother.create({ command: "m#123" });
+			expect(room.edoBanListHash).toBe(originalHash);
+
+			// A hot-reload swaps in a same-named list with DIFFERENT content (different hash).
+			const reloaded = makeEdoList("Format A", 20000);
+			expect(reloaded.hash).not.toBe(originalHash); // sanity: edit changed the hash
+			BanListMemoryRepository.replaceAll([reloaded]);
+
+			// The already-constructed room keeps its snapshot; only the repo changed.
+			expect(room.edoBanListHash).toBe(originalHash);
+			expect(BanListMemoryRepository.findByName("Format A")?.hash).toBe(reloaded.hash);
 		});
 	});
 });

--- a/src/ygopro/room/domain/YGOProRoom.test.ts
+++ b/src/ygopro/room/domain/YGOProRoom.test.ts
@@ -624,10 +624,10 @@ describe("YGOProRoom", () => {
 		});
 	});
 
-	// REQ-306: a ban-list hot-reload must NOT affect rooms already constructed. A room
-	// snapshots its edopro ban-list hash as a primitive at construction (YGOProRoom.ts:154),
-	// so a later replaceAll() on the repositories cannot mutate an in-flight room's value.
-	describe("ban-list hot-reload invariant (REQ-306)", () => {
+	// A ban-list hot-reload must NOT affect rooms already constructed. A room snapshots
+	// its edopro ban-list hash as a primitive at construction, so a later replaceAll()
+	// on the repositories cannot mutate an in-flight room's value.
+	describe("ban-list hot-reload invariant", () => {
 		// EdoproBanList derives its hash from added cards (no setHash); distinct cardIds
 		// yield distinct hashes, which is what a real banlist edit produces.
 		function makeEdoList(name: string, cardId: number): EdoproBanList {


### PR DESCRIPTION
## Summary

Ban lists were loaded once at boot and never re-read, so a new/updated ban list required a full server restart to take effect. This adds a periodic reloader that picks up on-disk changes without a restart (asset-sync-freshness plan, Problem 2 / S1).

- **Re-callable pure loaders** (`bootstrapBanListLoaders.ts`): extract edopro/ygopro ban-list parsing into builders that fill a local temp array and never touch the live repositories. Boot now uses these too, so the load path is single-sourced.
- **Atomic double-buffer swap** (`replaceAll` on both repos): the swap is synchronous with no `await` between truncate and fill, so no concurrent HTTP read can observe an empty or half-updated list.
- **Reloader** (`bootstrapBanListReloader.ts`): on an interval, a size+mtime fingerprint over the lflist `.conf` files detects changes; when something changed it rebuilds both arrays and swaps them in — **edopro before ygopro** (ygopro rooms cross-reference edopro lists by name). Empty parse results are rejected (previous lists kept); overlap guard prevents concurrent reloads; errors keep the previous lists. Exposes `getBanListReloadedAt()` for the upcoming version endpoint (P4).
- **In-flight rooms are safe**: they snapshot their ban-list hash as a primitive at construction, proven by a new invariant test.

## Scope note (size:exception)

~822 changed lines, above the 400-line budget, approved as a single PR: **~497 lines are tests** and the implementation is only ~325 lines for one cohesive feature. Splitting test from impl would break the TDD work-unit pairing and make each PR individually worse to review.

## Test plan

- [x] New tests: `replaceAll` contract (double-buffer, no empty window), re-callable loaders + ordering, reloader change-detection/atomic-swap/empty-safety/error-propagation/timestamp, room snapshot invariant.
- [x] Full server suite: **835 passed / 99 suites / 0 failures**. `tsc --noEmit` clean, biome clean.
- [ ] Post-merge: observe a live ban-list update applies without restart within one interval.