### PR TITLE
feat(version): add GET /api/resources/version endpoint

### DIFF
--- a/src/edopro/card/infrastructure/sqlite/EdoProCardDbHotReload.ts
+++ b/src/edopro/card/infrastructure/sqlite/EdoProCardDbHotReload.ts
@@ -11,6 +11,8 @@ const RELOAD_INTERVAL_MS = 10 * 60 * 1000;
 // Reload mechanics (atomic in-place replace) live in EdoProCardDbPorts. Mirrors
 // the YGOPro reload timer.
 export class EdoProCardDbHotReload {
+	private static shared: EdoProCardDbHotReload | null = null;
+
 	private readonly logger: Logger = LoggerFactory.getLogger();
 	private readonly reloader: CardDbReloader;
 
@@ -20,9 +22,21 @@ export class EdoProCardDbHotReload {
 		);
 	}
 
+	// The running instance, or null before start() runs. Lets the resource-version
+	// endpoint reach the card-db fingerprint without threading the instance through DI.
+	static getShared(): EdoProCardDbHotReload | null {
+		return EdoProCardDbHotReload.shared;
+	}
+
+	// The fingerprint of the currently loaded EDOPro card DB, or null before the first prime().
+	get fingerprint(): string | null {
+		return this.reloader.currentFingerprintValue;
+	}
+
 	// Record the boot fingerprint, then poll for changes. The boot datasource is
 	// already built/merged by bootstrapPersistence, so we only prime here.
 	async start(): Promise<void> {
+		EdoProCardDbHotReload.shared = this;
 		await this.reloader.prime();
 		setInterval(() => {
 			this.reloader.reloadIfChanged().catch((error) => {

--- a/src/http-server/controllers/GetResourceVersionController.test.ts
+++ b/src/http-server/controllers/GetResourceVersionController.test.ts
@@ -1,0 +1,147 @@
+import type { Request, Response } from "express";
+
+const loaderState = {
+	isInitialized: true,
+	standardSha512Hex: null as string | null,
+	extendedSha512Hex: null as string | null,
+};
+const cardDbState = { shared: null as { fingerprint: string | null } | null };
+const banlistState = {
+	edopro: [] as Array<{ name: string | null; hash: number }>,
+	ygopro: [] as Array<{ name: string | null; hash: number }>,
+	reloadedAt: null as string | null,
+};
+
+jest.mock("@ygopro/ygopro/YGOProResourceLoader", () => ({
+	YGOProResourceLoader: {
+		get isInitialized() {
+			return loaderState.isInitialized;
+		},
+		get: () => loaderState,
+	},
+}));
+jest.mock("@edopro/card/infrastructure/sqlite/EdoProCardDbHotReload", () => ({
+	EdoProCardDbHotReload: { getShared: () => cardDbState.shared },
+}));
+jest.mock("@edopro/ban-list/infrastructure/BanListMemoryRepository", () => ({
+	__esModule: true,
+	default: { get: () => banlistState.edopro },
+}));
+jest.mock("@ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository", () => ({
+	__esModule: true,
+	default: { get: () => banlistState.ygopro },
+}));
+jest.mock("src/bootstrap/bootstrapBanListReloader", () => ({
+	getBanListReloadedAt: () => banlistState.reloadedAt,
+}));
+
+import { GetResourceVersionController } from "./GetResourceVersionController";
+
+function fakeResponse(): { res: Response; body: () => unknown; status: () => number } {
+	let statusCode = 0;
+	let payload: unknown;
+	const res = {
+		status(code: number) {
+			statusCode = code;
+			return this;
+		},
+		json(data: unknown) {
+			payload = data;
+			return this;
+		},
+	} as unknown as Response;
+	return { res, body: () => payload, status: () => statusCode };
+}
+
+function run(): ReturnType<typeof fakeResponse> {
+	const out = fakeResponse();
+	new GetResourceVersionController().run({} as Request, out.res);
+	return out;
+}
+
+describe("GetResourceVersionController", () => {
+	beforeEach(() => {
+		loaderState.isInitialized = true;
+		loaderState.standardSha512Hex = null;
+		loaderState.extendedSha512Hex = null;
+		cardDbState.shared = null;
+		banlistState.edopro = [];
+		banlistState.ygopro = [];
+		banlistState.reloadedAt = null;
+	});
+
+	it("returns schemaVersion 1 and all sections with a 200 status", () => {
+		const out = run();
+
+		expect(out.status()).toBe(200);
+		expect(out.body()).toMatchObject({
+			schemaVersion: 1,
+			ygopro: expect.any(Object),
+			edopro: expect.any(Object),
+			banlists: expect.any(Object),
+		});
+	});
+
+	it("reports the ygopro sha512 hexes when the loader has them", () => {
+		loaderState.standardSha512Hex = "abc123";
+		loaderState.extendedSha512Hex = "def456";
+
+		const body = run().body() as { ygopro: { standardSha512: string; extendedSha512: string } };
+
+		expect(body.ygopro.standardSha512).toBe("abc123");
+		expect(body.ygopro.extendedSha512).toBe("def456");
+	});
+
+	it("reports null ygopro hashes before the loader is initialized", () => {
+		loaderState.isInitialized = false;
+
+		const body = run().body() as { ygopro: { standardSha512: string | null } };
+
+		expect(body.ygopro.standardSha512).toBeNull();
+	});
+
+	it("reports null cardDbFingerprint when no hot-reload instance exists yet", () => {
+		cardDbState.shared = null;
+
+		const body = run().body() as { edopro: { cardDbFingerprint: string | null } };
+
+		expect(body.edopro.cardDbFingerprint).toBeNull();
+	});
+
+	it("reports the cardDbFingerprint from the shared hot-reload instance", () => {
+		cardDbState.shared = { fingerprint: "fp-xyz" };
+
+		const body = run().body() as { edopro: { cardDbFingerprint: string } };
+
+		expect(body.edopro.cardDbFingerprint).toBe("fp-xyz");
+	});
+
+	it("maps banlists to name+hash and passes through reloadedAt", () => {
+		banlistState.edopro = [{ name: "2026.04 OCG", hash: 111 }];
+		banlistState.ygopro = [{ name: "2026.04", hash: 222 }];
+		banlistState.reloadedAt = "2026-07-14T12:00:00.000Z";
+
+		const body = run().body() as {
+			banlists: {
+				edopro: Array<{ name: string; hash: number }>;
+				ygopro: Array<{ name: string; hash: number }>;
+				reloadedAt: string;
+			};
+		};
+
+		expect(body.banlists.edopro).toEqual([{ name: "2026.04 OCG", hash: 111 }]);
+		expect(body.banlists.ygopro).toEqual([{ name: "2026.04", hash: 222 }]);
+		expect(body.banlists.reloadedAt).toBe("2026-07-14T12:00:00.000Z");
+	});
+
+	it("skips unnamed banlists", () => {
+		banlistState.edopro = [
+			{ name: null, hash: 1 },
+			{ name: "Named", hash: 2 },
+		];
+
+		const body = run().body() as { banlists: { edopro: Array<{ name: string; hash: number }> } };
+
+		expect(body.banlists.edopro).toEqual([{ name: "Named", hash: 2 }]);
+	});
+});

--- a/src/http-server/controllers/GetResourceVersionController.ts
+++ b/src/http-server/controllers/GetResourceVersionController.ts
@@ -1,0 +1,43 @@
+import { Request, Response } from "express";
+
+import EdoProBanListMemoryRepository from "@edopro/ban-list/infrastructure/BanListMemoryRepository";
+import { EdoProCardDbHotReload } from "@edopro/card/infrastructure/sqlite/EdoProCardDbHotReload";
+import YGOProBanListMemoryRepository from "@ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository";
+import { YGOProResourceLoader } from "@ygopro/ygopro/YGOProResourceLoader";
+import { BanList } from "src/shared/ban-list/BanList";
+import { getBanListReloadedAt } from "src/bootstrap/bootstrapBanListReloader";
+
+// Reports the versions/hashes of the resources this server has actually loaded, so a
+// client can compare them against what it downloaded and detect drift. Every field is
+// nullable: a freshly booted server may not have computed a given hash yet, and the
+// endpoint must still answer 200 rather than fail.
+export class GetResourceVersionController {
+	run(_req: Request, response: Response): void {
+		// get() would lazily construct a loader (with filesystem + timer side effects),
+		// so only read it once something has actually initialized it.
+		const loader = YGOProResourceLoader.isInitialized ? YGOProResourceLoader.get() : null;
+		const cardDb = EdoProCardDbHotReload.getShared();
+
+		response.status(200).json({
+			schemaVersion: 1,
+			ygopro: {
+				standardSha512: loader?.standardSha512Hex ?? null,
+				extendedSha512: loader?.extendedSha512Hex ?? null,
+			},
+			edopro: {
+				cardDbFingerprint: cardDb?.fingerprint ?? null,
+			},
+			banlists: {
+				edopro: toBanListVersions(EdoProBanListMemoryRepository.get()),
+				ygopro: toBanListVersions(YGOProBanListMemoryRepository.get()),
+				reloadedAt: getBanListReloadedAt(),
+			},
+		});
+	}
+}
+
+function toBanListVersions(banLists: BanList[]): Array<{ name: string; hash: number }> {
+	return banLists
+		.filter((banList) => banList.name !== null)
+		.map((banList) => ({ name: banList.name as string, hash: banList.hash }));
+}

--- a/src/http-server/routes/index.ts
+++ b/src/http-server/routes/index.ts
@@ -6,6 +6,7 @@ import { GetBanListDetailController } from "../controllers/GetBanListDetailContr
 import { GetBanListsController } from "../controllers/GetBanListsController";
 import { GetDatabaseCardsController } from "../controllers/GetDatabaseCardsController";
 import { GetDatabasesController } from "../controllers/GetDatabasesController";
+import { GetResourceVersionController } from "../controllers/GetResourceVersionController";
 import { GetRoomListController } from "../controllers/GetRoomListController";
 import { InspectPageController } from "../controllers/InspectPageController";
 import { RoomListController } from "../controllers/RoomListController";
@@ -34,6 +35,10 @@ export function loadRoutes(app: Express, logger: Logger): void {
 	app.get("/api/databases", RateLimitMiddleware, async (req, res) => {
 		await new GetDatabasesController().run(req, res);
 	});
+
+	app.get("/api/resources/version", RateLimitMiddleware, (req, res) =>
+		new GetResourceVersionController().run(req, res),
+	);
 
 	app.get("/api/databases/cards", RateLimitMiddleware, async (req, res) => {
 		await new GetDatabaseCardsController().run(req, res);

--- a/src/shared/db/sqlite/infrastructure/CardDbReloader.test.ts
+++ b/src/shared/db/sqlite/infrastructure/CardDbReloader.test.ts
@@ -64,4 +64,23 @@ describe("CardDbReloader", () => {
 		expect(await reloader.reloadIfChanged()).toBe(false);
 		expect(ports.builds).toBe(1);
 	});
+
+	it("exposes null as the current fingerprint before priming", () => {
+		const reloader = new CardDbReloader(new FakePorts());
+
+		expect(reloader.currentFingerprintValue).toBeNull();
+	});
+
+	it("exposes the primed fingerprint, and updates it after a reload", async () => {
+		const ports = new FakePorts();
+		const reloader = new CardDbReloader(ports);
+		await reloader.prime();
+
+		expect(reloader.currentFingerprintValue).toBe("a");
+
+		ports.fp = "b";
+		await reloader.reloadIfChanged();
+
+		expect(reloader.currentFingerprintValue).toBe("b");
+	});
 });

--- a/src/shared/db/sqlite/infrastructure/CardDbReloader.ts
+++ b/src/shared/db/sqlite/infrastructure/CardDbReloader.ts
@@ -30,6 +30,12 @@ export class CardDbReloader {
 		this.currentFingerprint = await this.ports.fingerprint();
 	}
 
+	// The fingerprint of the currently loaded .cdb files, or null before the first
+	// prime(). Read by the resource-version endpoint to report what the server has loaded.
+	get currentFingerprintValue(): string | null {
+		return this.currentFingerprint;
+	}
+
 	async reloadIfChanged(): Promise<boolean> {
 		return this.lock.acquire(async () => {
 			const nextFingerprint = await this.ports.fingerprint();

--- a/src/ygopro/ygopro/YGOProResourceLoader.ts
+++ b/src/ygopro/ygopro/YGOProResourceLoader.ts
@@ -75,6 +75,17 @@ export class YGOProResourceLoader {
 
 	private reloadTimerRegistered = false;
 
+	// Hex of the SHA-512 over the loaded standard/extended card pools, or null before a
+	// pool has been loaded. Read by the resource-version endpoint to report what the
+	// server has loaded so clients can detect drift.
+	get standardSha512Hex(): string | null {
+		return this.standardSha512?.toString("hex") ?? null;
+	}
+
+	get extendedSha512Hex(): string | null {
+		return this.extendedSha512?.toString("hex") ?? null;
+	}
+
 	get hasExtraFolderPaths(): boolean {
 		return this.extraFolderPaths.length > 0;
 	}


### PR DESCRIPTION
## Summary

Adds a read-only endpoint so clients can see which resource versions the server has actually loaded, and detect drift between what they downloaded and what the server validates against. Part of the asset-freshness visibility work.

- **`GET /api/resources/version`** (rate-limited, no auth) returns per-source hashes: ygopro standard/extended card-pool SHA-512, edopro card-db fingerprint, and every ban list as `{ name, hash }`, plus `reloadedAt` (from the ban-list reloader shipped previously).
- All fields are **nullable and the endpoint always answers 200** — a freshly booted server that hasn't computed a hash yet returns `null` rather than failing.
- Exposes already-computed internal state through small getters (`standardSha512Hex` / `extendedSha512Hex` on the YGOPro loader, `currentFingerprintValue` on `CardDbReloader`, `fingerprint` + a static `getShared()` on `EdoProCardDbHotReload`) — no new hashing work, no behavior change to the reload paths.

## Test plan

- [x] New unit tests: controller composition + null-safety (7 cases: schema, ygopro hashes present/absent, edopro fingerprint present/absent, banlist name+hash mapping, unnamed-list skipping) and the `CardDbReloader` fingerprint getter.
- [x] Full server suite: **844 passed / 100 suites / 0 failures**. `tsc --noEmit` clean, biome clean.
- [ ] Post-merge: `curl /api/resources/version` returns 200 JSON on a running server.