### PR TITLE
feat(matchmaking): auto-pairing queue with ranked + windbot fallback

### DIFF
--- a/config/botlist.example.json
+++ b/config/botlist.example.json
@@ -6,5 +6,33 @@
 	{
 		"name": "Yugi",
 		"deck": "Yugi"
+	},
+	{
+		"name": "Salamangreat Bot",
+		"deck": "Salamangreat"
+	},
+	{
+		"name": "Sky Striker Bot",
+		"deck": "SkyStriker"
+	},
+	{
+		"name": "Labrynth Bot",
+		"deck": "Labrynth"
+	},
+	{
+		"name": "Yubel Bot",
+		"deck": "Yubel"
+	},
+	{
+		"name": "Swordsoul Bot",
+		"deck": "Swordsoul"
+	},
+	{
+		"name": "Ryzeal Bot",
+		"deck": "Ryzeal"
+	},
+	{
+		"name": "Maliss Bot",
+		"deck": "Maliss"
 	}
 ]

--- a/src/bootstrap/bootstrapMatchmaking.test.ts
+++ b/src/bootstrap/bootstrapMatchmaking.test.ts
@@ -1,0 +1,90 @@
+// Verifies the composition-root wiring: the spawnBot dependency injected into
+// MatchmakingQueue must request a bot with a deckOverride taken from the curated
+// TCG pool, so a bot dropped into a TCG matchmaking room plays a TCG-legal deck.
+//
+// All singleton collaborators are mocked so no timers, sockets, or real windbot
+// are touched. We capture the deps object passed to MatchmakingQueue.init and
+// invoke its spawnBot directly.
+
+import { Logger } from "@shared/logger/domain/Logger";
+
+import { MatchmakingQueue } from "@ygopro/matchmaking/domain/MatchmakingQueue";
+import { MATCHMAKING_TCG_BOT_DECKS } from "@ygopro/matchmaking/domain/MatchmakingTcgBotDecks";
+import YGOProRoomList from "@ygopro/room/infrastructure/YGOProRoomList";
+import { WindbotModule } from "@ygopro/windbot/application/WindbotModule";
+
+import { bootstrapMatchmaking } from "./bootstrapMatchmaking";
+
+jest.mock("@ygopro/matchmaking/application/MatchmakingRoomFactory", () => ({
+	createMatchmakingRoom: jest.fn(),
+}));
+jest.mock("@ygopro/room/application/FinalizeYGOProRoom", () => ({
+	FinalizeYGOProRoom: { run: jest.fn() },
+}));
+
+function fakeLogger(): Logger {
+	const logger = {
+		info: jest.fn(),
+		error: jest.fn(),
+		warn: jest.fn(),
+		debug: jest.fn(),
+		child: jest.fn(),
+	} as unknown as Logger;
+	(logger.child as jest.Mock).mockReturnValue(logger);
+	return logger;
+}
+
+describe("bootstrapMatchmaking — spawnBot TCG deck wiring", () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	function captureSpawnBot(): (roomId: number) => void {
+		const captured: { spawnBot?: (roomId: number) => void } = {};
+		jest.spyOn(MatchmakingQueue, "init").mockImplementation((d) => {
+			captured.spawnBot = (d as unknown as { spawnBot: (roomId: number) => void }).spawnBot;
+		});
+		jest
+			.spyOn(MatchmakingQueue, "getInstance")
+			.mockReturnValue({ start: jest.fn() } as unknown as MatchmakingQueue);
+
+		bootstrapMatchmaking(fakeLogger());
+
+		if (!captured.spawnBot) throw new Error("MatchmakingQueue.init was not called");
+		return captured.spawnBot;
+	}
+
+	it("requests a bot with a deckOverride from the TCG pool", () => {
+		const requestBot = jest.fn().mockResolvedValue({ bot: { name: "Bot", deck: "x" } });
+		jest.spyOn(WindbotModule, "isInitialized").mockReturnValue(true);
+		jest.spyOn(WindbotModule, "getInstance").mockReturnValue({
+			isEnabled: () => true,
+			requestBot,
+		} as unknown as WindbotModule);
+		jest
+			.spyOn(YGOProRoomList, "findById")
+			.mockReturnValue({ finalizing: false } as unknown as ReturnType<
+				typeof YGOProRoomList.findById
+			>);
+
+		const spawnBot = captureSpawnBot();
+		spawnBot(123);
+
+		expect(requestBot).toHaveBeenCalledTimes(1);
+		const [roomId, botName, isFinalizing, deckOverride] = requestBot.mock.calls[0];
+		expect(roomId).toBe(123);
+		expect(botName).toBeNull();
+		expect(typeof isFinalizing).toBe("function");
+		expect(MATCHMAKING_TCG_BOT_DECKS).toContain(deckOverride);
+	});
+
+	it("is a no-op when windbot is not initialized", () => {
+		jest.spyOn(WindbotModule, "isInitialized").mockReturnValue(false);
+		const getInstance = jest.spyOn(WindbotModule, "getInstance");
+
+		const spawnBot = captureSpawnBot();
+		spawnBot(123);
+
+		expect(getInstance).not.toHaveBeenCalled();
+	});
+});

--- a/src/bootstrap/bootstrapMatchmaking.ts
+++ b/src/bootstrap/bootstrapMatchmaking.ts
@@ -3,7 +3,10 @@ import { EventEmitter } from "stream";
 import { Logger } from "@shared/logger/domain/Logger";
 
 import { createMatchmakingRoom } from "@ygopro/matchmaking/application/MatchmakingRoomFactory";
+import { MatchmakingRoomReaper } from "@ygopro/matchmaking/application/MatchmakingRoomReaper";
+import { CLEANUP_INTERVAL_MS } from "@ygopro/matchmaking/domain/QueueEntry";
 import { MatchmakingQueue } from "@ygopro/matchmaking/domain/MatchmakingQueue";
+import { FinalizeYGOProRoom } from "@ygopro/room/application/FinalizeYGOProRoom";
 import YGOProRoomList from "@ygopro/room/infrastructure/YGOProRoomList";
 import { WindbotModule } from "@ygopro/windbot/application/WindbotModule";
 
@@ -18,6 +21,14 @@ import { WindbotModule } from "@ygopro/windbot/application/WindbotModule";
 export function bootstrapMatchmaking(logger: Logger): void {
 	const mmLogger = logger.child({ file: "Matchmaking" });
 
+	// Reaps matchmaking-created rooms that are never joined (rage-quit before join,
+	// ticket expiry between match and WS handshake, network drop). Reuses the SAME
+	// canonical teardown as every other reap path.
+	const reaper = new MatchmakingRoomReaper({
+		now: () => Date.now(),
+		finalize: (room) => FinalizeYGOProRoom.run(room),
+	});
+
 	MatchmakingQueue.init({
 		now: () => Date.now(),
 
@@ -26,6 +37,7 @@ export function bootstrapMatchmaking(logger: Logger): void {
 				rankedOverride: true,
 				logger: mmLogger,
 				emitter: new EventEmitter(),
+				onRoomCreated: (room) => reaper.track(room),
 			});
 			return { roomPassword };
 		},
@@ -35,6 +47,7 @@ export function bootstrapMatchmaking(logger: Logger): void {
 				rankedOverride: false,
 				logger: mmLogger,
 				emitter: new EventEmitter(),
+				onRoomCreated: (room) => reaper.track(room),
 			});
 			return { roomPassword, roomId: room.id };
 		},
@@ -67,7 +80,22 @@ export function bootstrapMatchmaking(logger: Logger): void {
 		// Bot fallback only makes sense when windbot is up; otherwise entries keep
 		// waiting for a human (or TTL-drop) instead of dead-ending on a bot game.
 		botAvailable: () => WindbotModule.isInitialized() && WindbotModule.getInstance().isEnabled(),
+
+		// A synchronous room-creation failure is caught inside the queue's sweep so
+		// it never aborts the sweep or 500s an unrelated poller; log it here.
+		onRoomCreationError: (error: unknown) => {
+			mmLogger.error(
+				`Matchmaking room creation failed during sweep: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+		},
 	});
 
 	MatchmakingQueue.getInstance().start();
+
+	// Drive the empty-room sweep on its own unref'd timer so it never keeps the
+	// process alive. Reuses the queue's cleanup cadence.
+	const sweepTimer = setInterval(() => reaper.sweep(), CLEANUP_INTERVAL_MS);
+	sweepTimer.unref();
 }

--- a/src/bootstrap/bootstrapMatchmaking.ts
+++ b/src/bootstrap/bootstrapMatchmaking.ts
@@ -1,0 +1,73 @@
+import { EventEmitter } from "stream";
+
+import { Logger } from "@shared/logger/domain/Logger";
+
+import { createMatchmakingRoom } from "@ygopro/matchmaking/application/MatchmakingRoomFactory";
+import { MatchmakingQueue } from "@ygopro/matchmaking/domain/MatchmakingQueue";
+import YGOProRoomList from "@ygopro/room/infrastructure/YGOProRoomList";
+import { WindbotModule } from "@ygopro/windbot/application/WindbotModule";
+
+/**
+ * Wires the matchmaking queue's ports to concrete infrastructure and starts the
+ * background sweep. Kept in the composition root so the queue domain stays free
+ * of YGOProRoom, windbot, and Date.now dependencies.
+ *
+ * - createRankedRoom / createBotRoom → additive YGOProRoom factory (matchmaking seam).
+ * - spawnBot → windbot fire-and-forget, guarded by WindbotModule.isInitialized().
+ */
+export function bootstrapMatchmaking(logger: Logger): void {
+	const mmLogger = logger.child({ file: "Matchmaking" });
+
+	MatchmakingQueue.init({
+		now: () => Date.now(),
+
+		createRankedRoom: () => {
+			const { roomPassword } = createMatchmakingRoom({
+				rankedOverride: true,
+				logger: mmLogger,
+				emitter: new EventEmitter(),
+			});
+			return { roomPassword };
+		},
+
+		createBotRoom: () => {
+			const { room, roomPassword } = createMatchmakingRoom({
+				rankedOverride: false,
+				logger: mmLogger,
+				emitter: new EventEmitter(),
+			});
+			return { roomPassword, roomId: room.id };
+		},
+
+		spawnBot: (roomId: number) => {
+			if (!WindbotModule.isInitialized() || !WindbotModule.getInstance().isEnabled()) {
+				return;
+			}
+			const room = YGOProRoomList.findById(roomId);
+			if (!room) return;
+
+			// Fire-and-forget, mirroring WindBotJoinStrategy: abort retries once the
+			// room begins teardown. On failure, tear the empty bot room down so it
+			// does not linger in the lobby.
+			void WindbotModule.getInstance()
+				.requestBot(roomId, null, () => room.finalizing)
+				.then(({ bot }) => {
+					room.windbot = { name: bot.name, deck: bot.deck };
+				})
+				.catch((error: unknown) => {
+					mmLogger.error(
+						`Matchmaking bot spawn failed for room ${roomId}: ${
+							error instanceof Error ? error.message : String(error)
+						}`,
+					);
+					YGOProRoomList.deleteRoom(room);
+				});
+		},
+
+		// Bot fallback only makes sense when windbot is up; otherwise entries keep
+		// waiting for a human (or TTL-drop) instead of dead-ending on a bot game.
+		botAvailable: () => WindbotModule.isInitialized() && WindbotModule.getInstance().isEnabled(),
+	});
+
+	MatchmakingQueue.getInstance().start();
+}

--- a/src/bootstrap/bootstrapMatchmaking.ts
+++ b/src/bootstrap/bootstrapMatchmaking.ts
@@ -5,6 +5,7 @@ import { Logger } from "@shared/logger/domain/Logger";
 import { createMatchmakingRoom } from "@ygopro/matchmaking/application/MatchmakingRoomFactory";
 import { MatchmakingRoomReaper } from "@ygopro/matchmaking/application/MatchmakingRoomReaper";
 import { CLEANUP_INTERVAL_MS } from "@ygopro/matchmaking/domain/QueueEntry";
+import { pickRandomTcgBotDeck } from "@ygopro/matchmaking/domain/MatchmakingTcgBotDecks";
 import { MatchmakingQueue } from "@ygopro/matchmaking/domain/MatchmakingQueue";
 import { FinalizeYGOProRoom } from "@ygopro/room/application/FinalizeYGOProRoom";
 import YGOProRoomList from "@ygopro/room/infrastructure/YGOProRoomList";
@@ -59,11 +60,17 @@ export function bootstrapMatchmaking(logger: Logger): void {
 			const room = YGOProRoomList.findById(roomId);
 			if (!room) return;
 
+			// Matchmaking v1 rooms are TCG (rule 1 + TCG banlist). The server botlist
+			// is format-blind, so pick a curated TCG-legal deck here and pass it as a
+			// deckOverride — otherwise a non-TCG bot deck fails the deck-check and the
+			// human is ejected before the duel can start.
+			const tcgDeck = pickRandomTcgBotDeck();
+
 			// Fire-and-forget, mirroring WindBotJoinStrategy: abort retries once the
 			// room begins teardown. On failure, tear the empty bot room down so it
 			// does not linger in the lobby.
 			void WindbotModule.getInstance()
-				.requestBot(roomId, null, () => room.finalizing)
+				.requestBot(roomId, null, () => room.finalizing, tcgDeck)
 				.then(({ bot }) => {
 					room.windbot = { name: bot.name, deck: bot.deck };
 				})

--- a/src/http-server/Server.ts
+++ b/src/http-server/Server.ts
@@ -2,6 +2,7 @@ import express, { Express } from "express";
 import { config } from "src/config";
 
 import { Logger } from "../shared/logger/domain/Logger";
+import { TicketRepository } from "../shared/ticket/domain/TicketRepository";
 import { createDirectoryIfNotExists } from "../utils";
 import { loadRoutes } from "./routes";
 
@@ -9,7 +10,7 @@ export class Server {
 	private readonly app: Express;
 	private readonly logger: Logger;
 
-	constructor(logger: Logger) {
+	constructor(logger: Logger, tickets: TicketRepository) {
 		this.logger = logger;
 		this.app = express();
 		this.app.use(express.json());
@@ -32,7 +33,7 @@ export class Server {
 				next();
 			}
 		});
-		loadRoutes(this.app, this.logger);
+		loadRoutes(this.app, this.logger, tickets);
 	}
 
 	async initialize(): Promise<void> {

--- a/src/http-server/controllers/CancelMatchmakingController.test.ts
+++ b/src/http-server/controllers/CancelMatchmakingController.test.ts
@@ -1,0 +1,65 @@
+import type { Request, Response } from "express";
+
+import { MatchmakingQueue } from "@ygopro/matchmaking/domain/MatchmakingQueue";
+import { SUPPORTED_FORMAT } from "@ygopro/matchmaking/domain/QueueEntry";
+
+import { CancelMatchmakingController } from "./CancelMatchmakingController";
+
+function fakeResponse(): { res: Response; body: () => unknown; status: () => number } {
+	let statusCode = 0;
+	let payload: unknown;
+	const res = {
+		status(code: number) {
+			statusCode = code;
+			return this;
+		},
+		json(data: unknown) {
+			payload = data;
+			return this;
+		},
+	} as unknown as Response;
+	return { res, body: () => payload, status: () => statusCode };
+}
+
+const makeDeps = () => ({
+	now: () => 0,
+	createRankedRoom: () => ({ roomPassword: "to,mm-r#pw" }),
+	createBotRoom: () => ({ roomPassword: "to,mm-b#pw", roomId: 1 }),
+	spawnBot: jest.fn(),
+});
+
+const run = (query: unknown) => {
+	const out = fakeResponse();
+	new CancelMatchmakingController().run({ query } as Request, out.res);
+	return out;
+};
+
+describe("CancelMatchmakingController", () => {
+	beforeEach(() => {
+		MatchmakingQueue.resetForTests();
+		MatchmakingQueue.init(makeDeps());
+	});
+	afterEach(() => {
+		MatchmakingQueue.resetForTests();
+	});
+
+	it("returns 400 when ticketId is missing", () => {
+		expect(run({}).status()).toBe(400);
+	});
+
+	it("returns 404 for an unknown ticketId", () => {
+		expect(run({ ticketId: "nope" }).status()).toBe(404);
+	});
+
+	it("removes a queued entry and returns 200", () => {
+		MatchmakingQueue.getInstance().enqueue({
+			ticketId: "t1",
+			userId: "user-1",
+			format: SUPPORTED_FORMAT,
+		});
+
+		const out = run({ ticketId: "t1" });
+		expect(out.status()).toBe(200);
+		expect(MatchmakingQueue.getInstance().get("t1")).toBeUndefined();
+	});
+});

--- a/src/http-server/controllers/CancelMatchmakingController.ts
+++ b/src/http-server/controllers/CancelMatchmakingController.ts
@@ -1,0 +1,33 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+
+import { MatchmakingQueue } from "@ygopro/matchmaking/domain/MatchmakingQueue";
+
+export const CancelMatchmakingSchema = z.object({
+	ticketId: z.string().min(1),
+});
+
+/**
+ * DELETE /api/matchmaking/queue?ticketId=… — cancel the search.
+ *
+ * Idempotent: a ticketId that is already gone (cancelled, matched-and-cleared,
+ * or TTL-dropped) returns 404 so the client can distinguish "removed now" from
+ * "was never there", but never errors.
+ */
+export class CancelMatchmakingController {
+	run(req: Request, res: Response): void {
+		const validation = CancelMatchmakingSchema.safeParse(req.query);
+		if (!validation.success) {
+			res.status(400).json({ success: false, errors: validation.error.issues });
+			return;
+		}
+
+		const removed = MatchmakingQueue.getInstance().cancel(validation.data.ticketId);
+		if (!removed) {
+			res.status(404).json({ success: false, error: "Unknown ticketId" });
+			return;
+		}
+
+		res.status(200).json({ success: true });
+	}
+}

--- a/src/http-server/controllers/EnqueueMatchmakingController.test.ts
+++ b/src/http-server/controllers/EnqueueMatchmakingController.test.ts
@@ -1,0 +1,101 @@
+import type { Request, Response } from "express";
+
+import { TicketRepository } from "@shared/ticket/domain/TicketRepository";
+
+import { MatchmakingQueue } from "@ygopro/matchmaking/domain/MatchmakingQueue";
+
+import { EnqueueMatchmakingController } from "./EnqueueMatchmakingController";
+
+const makeLogger = () =>
+	({
+		child: jest.fn().mockReturnThis(),
+		info: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+		debug: jest.fn(),
+	}) as never;
+
+const makeTickets = (userId: string | null): TicketRepository => ({
+	consume: jest.fn().mockResolvedValue(userId),
+});
+
+function fakeResponse(): { res: Response; body: () => unknown; status: () => number } {
+	let statusCode = 0;
+	let payload: unknown;
+	const res = {
+		status(code: number) {
+			statusCode = code;
+			return this;
+		},
+		json(data: unknown) {
+			payload = data;
+			return this;
+		},
+	} as unknown as Response;
+	return { res, body: () => payload, status: () => statusCode };
+}
+
+const makeDeps = () => ({
+	now: () => 0,
+	createRankedRoom: () => ({ roomPassword: "to,mm-r#pw" }),
+	createBotRoom: () => ({ roomPassword: "to,mm-b#pw", roomId: 1 }),
+	spawnBot: jest.fn(),
+});
+
+describe("EnqueueMatchmakingController", () => {
+	beforeEach(() => {
+		MatchmakingQueue.resetForTests();
+		MatchmakingQueue.init(makeDeps());
+	});
+	afterEach(() => {
+		MatchmakingQueue.resetForTests();
+	});
+
+	const run = async (body: unknown, tickets: TicketRepository) => {
+		const out = fakeResponse();
+		await new EnqueueMatchmakingController(makeLogger(), tickets).run({ body } as Request, out.res);
+		return out;
+	};
+
+	it("returns a ticketId (200) for a valid ticket and queues the user", async () => {
+		const out = await run(
+			{ format: "tcg", queue: "ranked", ticket: "the-ticket" },
+			makeTickets("user-1"),
+		);
+
+		expect(out.status()).toBe(200);
+		const body = out.body() as { ticketId: string };
+		expect(typeof body.ticketId).toBe("string");
+		expect(MatchmakingQueue.getInstance().get(body.ticketId)).toBeDefined();
+	});
+
+	it("rejects a request with a missing/invalid schema (400)", async () => {
+		const out = await run({ format: "tcg" }, makeTickets("user-1"));
+		expect(out.status()).toBe(400);
+	});
+
+	it("rejects an unsupported format (400)", async () => {
+		const out = await run(
+			{ format: "ocg", queue: "ranked", ticket: "the-ticket" },
+			makeTickets("user-1"),
+		);
+		expect(out.status()).toBe(400);
+	});
+
+	it("rejects when the ticket does not resolve to a user (401)", async () => {
+		const out = await run(
+			{ format: "tcg", queue: "ranked", ticket: "bad-ticket" },
+			makeTickets(null),
+		);
+		expect(out.status()).toBe(401);
+	});
+
+	it("returns the existing ticketId when the same user enqueues twice (409-safe idempotency)", async () => {
+		const tickets = makeTickets("user-1");
+		const first = await run({ format: "tcg", queue: "ranked", ticket: "t-a" }, tickets);
+		const second = await run({ format: "tcg", queue: "ranked", ticket: "t-b" }, tickets);
+
+		expect(first.status()).toBe(200);
+		expect(second.status()).toBe(409);
+	});
+});

--- a/src/http-server/controllers/EnqueueMatchmakingController.ts
+++ b/src/http-server/controllers/EnqueueMatchmakingController.ts
@@ -1,0 +1,71 @@
+import { randomUUID } from "crypto";
+
+import { Request, Response } from "express";
+import { z } from "zod";
+
+import { Logger } from "@shared/logger/domain/Logger";
+import { TicketRepository } from "@shared/ticket/domain/TicketRepository";
+
+import {
+	DuplicateQueueEntryError,
+	MatchmakingQueue,
+} from "@ygopro/matchmaking/domain/MatchmakingQueue";
+import { SUPPORTED_FORMAT, SUPPORTED_QUEUE } from "@ygopro/matchmaking/domain/QueueEntry";
+
+export const EnqueueMatchmakingSchema = z.object({
+	format: z.literal(SUPPORTED_FORMAT),
+	queue: z.literal(SUPPORTED_QUEUE),
+	ticket: z.string().min(1),
+});
+
+/**
+ * POST /api/matchmaking/queue — enter the auto-pairing queue.
+ *
+ * The auth `ticket` is consumed once to derive the player identity (userId).
+ * NOTE: the ticket is single-use; the WS handshake performed on `matched` needs
+ * a FRESH ticket. The returned `ticketId` is an opaque queue handle for the
+ * status/cancel calls, NOT an auth token.
+ */
+export class EnqueueMatchmakingController {
+	constructor(
+		private readonly logger: Logger,
+		private readonly tickets: TicketRepository,
+	) {}
+
+	async run(req: Request, res: Response): Promise<void> {
+		const validation = EnqueueMatchmakingSchema.safeParse(req.body);
+		if (!validation.success) {
+			res.status(400).json({ success: false, errors: validation.error.issues });
+			return;
+		}
+
+		const userId = await this.tickets.consume(validation.data.ticket);
+		if (userId === null) {
+			res.status(401).json({ success: false, error: "Invalid or expired ticket" });
+			return;
+		}
+
+		const ticketId = randomUUID();
+		try {
+			MatchmakingQueue.getInstance().enqueue({
+				ticketId,
+				userId,
+				format: validation.data.format,
+			});
+		} catch (error) {
+			if (error instanceof DuplicateQueueEntryError) {
+				// One active entry per user. The client should keep polling its existing
+				// ticketId; a fresh enqueue is a no-op it must not proceed with.
+				res.status(409).json({ success: false, error: "Already in queue" });
+				return;
+			}
+			this.logger.error(
+				`Matchmaking enqueue failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			res.status(500).json({ success: false, error: "Failed to enqueue" });
+			return;
+		}
+
+		res.status(200).json({ ticketId });
+	}
+}

--- a/src/http-server/controllers/MatchmakingStatusController.test.ts
+++ b/src/http-server/controllers/MatchmakingStatusController.test.ts
@@ -1,0 +1,79 @@
+import type { Request, Response } from "express";
+
+import { MatchmakingQueue } from "@ygopro/matchmaking/domain/MatchmakingQueue";
+import { SUPPORTED_FORMAT } from "@ygopro/matchmaking/domain/QueueEntry";
+
+import { MatchmakingStatusController } from "./MatchmakingStatusController";
+
+function fakeResponse(): { res: Response; body: () => unknown; status: () => number } {
+	let statusCode = 0;
+	let payload: unknown;
+	const res = {
+		status(code: number) {
+			statusCode = code;
+			return this;
+		},
+		json(data: unknown) {
+			payload = data;
+			return this;
+		},
+	} as unknown as Response;
+	return { res, body: () => payload, status: () => statusCode };
+}
+
+const makeDeps = () => ({
+	now: () => 0,
+	createRankedRoom: () => ({ roomPassword: "to,mm-r#pw" }),
+	createBotRoom: () => ({ roomPassword: "to,mm-b#pw", roomId: 1 }),
+	spawnBot: jest.fn(),
+});
+
+const run = (query: unknown) => {
+	const out = fakeResponse();
+	new MatchmakingStatusController().run({ query } as Request, out.res);
+	return out;
+};
+
+describe("MatchmakingStatusController", () => {
+	beforeEach(() => {
+		MatchmakingQueue.resetForTests();
+		MatchmakingQueue.init(makeDeps());
+	});
+	afterEach(() => {
+		MatchmakingQueue.resetForTests();
+	});
+
+	it("returns 400 when ticketId is missing", () => {
+		expect(run({}).status()).toBe(400);
+	});
+
+	it("returns 404 for an unknown ticketId", () => {
+		expect(run({ ticketId: "nope" }).status()).toBe(404);
+	});
+
+	it("returns 200 searching with waitedMs for a queued ticket", () => {
+		MatchmakingQueue.getInstance().enqueue({
+			ticketId: "t1",
+			userId: "user-1",
+			format: SUPPORTED_FORMAT,
+		});
+
+		const out = run({ ticketId: "t1" });
+		expect(out.status()).toBe(200);
+		expect(out.body()).toEqual({ state: "searching", waitedMs: 0 });
+	});
+
+	it("returns 200 matched once paired", () => {
+		const q = MatchmakingQueue.getInstance();
+		q.enqueue({ ticketId: "t1", userId: "user-1", format: SUPPORTED_FORMAT });
+		q.enqueue({ ticketId: "t2", userId: "user-2", format: SUPPORTED_FORMAT });
+
+		const out = run({ ticketId: "t1" });
+		expect(out.status()).toBe(200);
+		expect(out.body()).toMatchObject({
+			state: "matched",
+			opponentType: "human",
+			rated: true,
+		});
+	});
+});

--- a/src/http-server/controllers/MatchmakingStatusController.ts
+++ b/src/http-server/controllers/MatchmakingStatusController.ts
@@ -1,0 +1,33 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+
+import { MatchmakingQueue } from "@ygopro/matchmaking/domain/MatchmakingQueue";
+
+export const MatchmakingStatusSchema = z.object({
+	ticketId: z.string().min(1),
+});
+
+/**
+ * GET /api/matchmaking/status?ticketId=… — poll for the outcome.
+ *
+ * This poll doubles as the client heartbeat: it refreshes the entry's lastPollAt
+ * (inside queue.poll) so the TTL sweep keeps the entry alive. An unknown ticketId
+ * (never queued, cancelled, or TTL-dropped) returns 404.
+ */
+export class MatchmakingStatusController {
+	run(req: Request, res: Response): void {
+		const validation = MatchmakingStatusSchema.safeParse(req.query);
+		if (!validation.success) {
+			res.status(400).json({ success: false, errors: validation.error.issues });
+			return;
+		}
+
+		const status = MatchmakingQueue.getInstance().poll(validation.data.ticketId);
+		if (status === null) {
+			res.status(404).json({ success: false, error: "Unknown ticketId" });
+			return;
+		}
+
+		res.status(200).json(status);
+	}
+}

--- a/src/http-server/routes/index.ts
+++ b/src/http-server/routes/index.ts
@@ -1,7 +1,11 @@
 import { Express } from "express";
 
+import { TicketRepository } from "../../shared/ticket/domain/TicketRepository";
 import { Logger } from "../../shared/logger/domain/Logger";
+import { CancelMatchmakingController } from "../controllers/CancelMatchmakingController";
 import { CreateRoomController } from "../controllers/CreateRoomController";
+import { EnqueueMatchmakingController } from "../controllers/EnqueueMatchmakingController";
+import { MatchmakingStatusController } from "../controllers/MatchmakingStatusController";
 import { GetBanListDetailController } from "../controllers/GetBanListDetailController";
 import { GetBanListsController } from "../controllers/GetBanListsController";
 import { GetDatabaseCardsController } from "../controllers/GetDatabaseCardsController";
@@ -15,10 +19,20 @@ import { ServerMessagesController } from "../controllers/ServerMessagesControlle
 import { AuthAdminMiddleware } from "../middlewares/AuthAdminMiddleware";
 import { RateLimitMiddleware } from "../middlewares/RateLimitMiddleware";
 
-export function loadRoutes(app: Express, logger: Logger): void {
+export function loadRoutes(app: Express, logger: Logger, tickets: TicketRepository): void {
 	app.get("/", (req, res) => new InspectPageController().run(req, res));
 
 	app.get("/api/getrooms", (req, res) => new GetRoomListController().run(req, res));
+
+	app.post("/api/matchmaking/queue", (req, res) =>
+		new EnqueueMatchmakingController(logger, tickets).run(req, res),
+	);
+
+	app.get("/api/matchmaking/status", (req, res) => new MatchmakingStatusController().run(req, res));
+
+	app.delete("/api/matchmaking/queue", (req, res) =>
+		new CancelMatchmakingController().run(req, res),
+	);
 
 	app.get("/api/rooms", (req, res) => new RoomListController().run(req, res));
 

--- a/src/http-server/routes/index.ts
+++ b/src/http-server/routes/index.ts
@@ -28,9 +28,11 @@ export function loadRoutes(app: Express, logger: Logger, tickets: TicketReposito
 		new EnqueueMatchmakingController(logger, tickets).run(req, res),
 	);
 
-	app.get("/api/matchmaking/status", (req, res) => new MatchmakingStatusController().run(req, res));
+	app.get("/api/matchmaking/status", RateLimitMiddleware, (req, res) =>
+		new MatchmakingStatusController().run(req, res),
+	);
 
-	app.delete("/api/matchmaking/queue", (req, res) =>
+	app.delete("/api/matchmaking/queue", RateLimitMiddleware, (req, res) =>
 		new CancelMatchmakingController().run(req, res),
 	);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { config } from "./config";
 import { bootstrapResources } from "./bootstrap/bootstrapResources";
 import { bootstrapPersistence } from "./bootstrap/bootstrapPersistence";
 import { bootstrapBanListReloader } from "./bootstrap/bootstrapBanListReloader";
+import { bootstrapMatchmaking } from "./bootstrap/bootstrapMatchmaking";
 import { Server } from "./http-server/Server";
 import { HostServer } from "./socket-server/HostServer";
 import { WSHostServer } from "./socket-server/WSHostServer";
@@ -26,11 +27,12 @@ async function start(): Promise<void> {
 
 	logger.info("🚀 Evolution server starting…");
 
-	const server = new Server(logger);
+	const ticketRepository = new RedisTicketRepository();
+	const server = new Server(logger, ticketRepository);
 	const ygoproServer = new YGOProServer(logger);
 	const wsYgoproServer = new WSYGOProServer(
 		logger,
-		new HandshakeTicketAuthenticator(new RedisTicketRepository()),
+		new HandshakeTicketAuthenticator(ticketRepository),
 	);
 
 	const hostServer = new HostServer(logger);
@@ -56,6 +58,9 @@ async function start(): Promise<void> {
 	if (windbotModule) {
 		logger.info("🤖 Windbot enabled");
 	}
+
+	// After windbot so the queue's bot-fallback availability check reflects it.
+	bootstrapMatchmaking(logger);
 
 	ygoproServer.initialize();
 	wsYgoproServer.initialize();

--- a/src/ygopro/matchmaking/application/MatchmakingRoomFactory.test.ts
+++ b/src/ygopro/matchmaking/application/MatchmakingRoomFactory.test.ts
@@ -66,6 +66,62 @@ describe("createMatchmakingRoom", () => {
 		expect(room.password).toBe(password);
 	});
 
+	it("produces a join string that fits the CTOS_JOIN_GAME pass field (<= 19 chars)", () => {
+		// The client encodes CTOS_JOIN_GAME { pass } as a FIXED utf16[20] field
+		// (ygopro-msg-encode: BinaryField("utf16", 8, 20)). A join string longer
+		// than the field is silently truncated on the wire, destroying the
+		// password segment and breaking the human join. 19 is the safe ceiling
+		// (leaves one wchar of margin for a terminator); 20 is the hard cap.
+		for (let i = 0; i < 200; i++) {
+			const { roomPassword } = createMatchmakingRoom({
+				rankedOverride: true,
+				logger: makeLogger(),
+				emitter: new EventEmitter(),
+			});
+
+			expect(roomPassword.length).toBeLessThanOrEqual(19);
+			expect(roomPassword.length).toBeLessThanOrEqual(20);
+		}
+	});
+
+	it("keeps a non-empty TCG name prefix and a non-empty password segment", () => {
+		const { roomPassword } = createMatchmakingRoom({
+			rankedOverride: true,
+			logger: makeLogger(),
+			emitter: new EventEmitter(),
+		});
+
+		const [name, password] = roomPassword.split("#");
+		// The name must still start with the shortest TCG-only token so the room
+		// resolves to rule 1 + TCG banlist.
+		expect(name.startsWith("to,")).toBe(true);
+		// A non-empty password keeps the room private (needpass: true) so random
+		// players in the open list cannot join a matchmaking room.
+		expect(password.length).toBeGreaterThan(0);
+	});
+
+	it("resolves both paired players to the SAME room via the identical join string", () => {
+		// Matchmaking hands the SAME join string to both matched players. Each
+		// sends it in CTOS_JOIN_GAME { pass }; both must land in this one room.
+		const { room, roomPassword } = createMatchmakingRoom({
+			rankedOverride: true,
+			logger: makeLogger(),
+			emitter: new EventEmitter(),
+		});
+
+		const joinStringPlayerA = roomPassword;
+		const joinStringPlayerB = roomPassword;
+		expect(joinStringPlayerA).toBe(joinStringPlayerB);
+
+		const [nameA, passwordA] = joinStringPlayerA.split("#");
+		const [nameB, passwordB] = joinStringPlayerB.split("#");
+
+		expect(YGOProRoomList.findByName(nameA)).toBe(room);
+		expect(YGOProRoomList.findByName(nameB)).toBe(room);
+		expect(room.password).toBe(passwordA);
+		expect(room.password).toBe(passwordB);
+	});
+
 	it("generates a unique room name/password per pair (no collision across calls)", () => {
 		const a = createMatchmakingRoom({
 			rankedOverride: true,

--- a/src/ygopro/matchmaking/application/MatchmakingRoomFactory.test.ts
+++ b/src/ygopro/matchmaking/application/MatchmakingRoomFactory.test.ts
@@ -1,0 +1,95 @@
+import { EventEmitter } from "stream";
+
+import { RoomLeague } from "@shared/room/admission/domain/RoomLeague";
+
+import YGOProRoomList from "../../room/infrastructure/YGOProRoomList";
+import { createMatchmakingRoom } from "./MatchmakingRoomFactory";
+
+const makeLogger = () =>
+	({
+		child: jest.fn().mockReturnThis(),
+		info: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+		debug: jest.fn(),
+	}) as never;
+
+const clearRooms = () => {
+	const rooms = YGOProRoomList.getRooms();
+	while (rooms.length) {
+		YGOProRoomList.deleteRoom(rooms[0]);
+	}
+};
+
+describe("createMatchmakingRoom", () => {
+	beforeEach(clearRooms);
+	afterEach(clearRooms);
+
+	it("creates a ranked (Verified) TCG room and registers it in the room list", () => {
+		const { room, roomPassword } = createMatchmakingRoom({
+			rankedOverride: true,
+			logger: makeLogger(),
+			emitter: new EventEmitter(),
+		});
+
+		expect(room.league).toBe(RoomLeague.Verified);
+		expect(room.ranked).toBe(true);
+		// rule 1 = strict TCG (from the "to" token)
+		expect(room.hostInfo.rule).toBe(1);
+		expect(YGOProRoomList.findById(room.id)).toBe(room);
+	});
+
+	it("creates an unrated (Casual) room for bot games when rankedOverride is false", () => {
+		const { room } = createMatchmakingRoom({
+			rankedOverride: false,
+			logger: makeLogger(),
+			emitter: new EventEmitter(),
+		});
+
+		expect(room.league).toBe(RoomLeague.Casual);
+		expect(room.ranked).toBe(false);
+	});
+
+	it("returns roomPassword as the exact command#password join string", () => {
+		const { room, roomPassword } = createMatchmakingRoom({
+			rankedOverride: true,
+			logger: makeLogger(),
+			emitter: new EventEmitter(),
+		});
+
+		// The join string the client sends in CTOS_JOIN_GAME { pass }:
+		// "<room-name>#<password>", where room.name is the config segment.
+		expect(roomPassword).toBe(`${room.name}#${room.password}`);
+		// Both halves must be resolvable by TicketJoinStrategy:
+		const [command, password] = roomPassword.split("#");
+		expect(YGOProRoomList.findByName(command)).toBe(room);
+		expect(room.password).toBe(password);
+	});
+
+	it("generates a unique room name/password per pair (no collision across calls)", () => {
+		const a = createMatchmakingRoom({
+			rankedOverride: true,
+			logger: makeLogger(),
+			emitter: new EventEmitter(),
+		});
+		const b = createMatchmakingRoom({
+			rankedOverride: true,
+			logger: makeLogger(),
+			emitter: new EventEmitter(),
+		});
+
+		expect(a.roomPassword).not.toBe(b.roomPassword);
+		expect(a.room.name).not.toBe(b.room.name);
+	});
+
+	it("builds the room without any client PlayerInfo wire bytes (additive path)", () => {
+		// Must not throw despite no connected client / PlayerInfoMessage.
+		expect(() =>
+			createMatchmakingRoom({
+				rankedOverride: true,
+				logger: makeLogger(),
+				emitter: new EventEmitter(),
+			}),
+		).not.toThrow();
+	});
+});

--- a/src/ygopro/matchmaking/application/MatchmakingRoomFactory.ts
+++ b/src/ygopro/matchmaking/application/MatchmakingRoomFactory.ts
@@ -1,0 +1,70 @@
+import { randomUUID } from "crypto";
+import { EventEmitter } from "stream";
+
+import { PlayerInfoMessage } from "@edopro/messages/client-to-server/PlayerInfoMessage";
+import { Logger } from "@shared/logger/domain/Logger";
+
+import { generateUniqueId } from "src/utils/generateUniqueId";
+
+import { YGOProMessageRepository } from "../../room/infrastructure/YGOProMessageRepository";
+import { YGOProRoom } from "../../room/domain/YGOProRoom";
+import YGOProRoomList from "../../room/infrastructure/YGOProRoomList";
+
+export interface CreateMatchmakingRoomInput {
+	/** true → ranked (Verified) human pair; false → unrated (Casual) bot game. */
+	rankedOverride: boolean;
+	logger: Logger;
+	emitter: EventEmitter;
+}
+
+export interface MatchmakingRoomHandle {
+	room: YGOProRoom;
+	/**
+	 * The EXACT string a client must send in CTOS_JOIN_GAME { pass } to land in
+	 * this room: "<room-name>#<password>". Both paired players send this same
+	 * string; TicketJoinStrategy resolves it to this room by name + password.
+	 */
+	roomPassword: string;
+}
+
+/**
+ * Additive room-creation seam for matchmaking (RISK-1).
+ *
+ * The normal ticket path builds a room from a client's CTOS_JOIN_GAME wire bytes
+ * (a PlayerInfoMessage). Matchmaking pairs players BEFORE either connects, so no
+ * such wire message exists yet. This factory reuses the SAME YGOProRoom.create()
+ * path with a synthetic, empty PlayerInfoMessage — the host's name/PIN are never
+ * read for a matchmaking room (league is decided by rankedOverride, not the PIN,
+ * and the seat name comes from each player's own join later). The existing
+ * create() path is left untouched.
+ *
+ * Command token "to" → rule 1 + first TCG banlist (strict TCG). A unique
+ * "mm-<uuid>" token is appended purely to make the room name/join-string unique;
+ * it matches no rule mapping, so the parser ignores it.
+ */
+export function createMatchmakingRoom(input: CreateMatchmakingRoomInput): MatchmakingRoomHandle {
+	const unique = randomUUID().replace(/-/g, "").slice(0, 12);
+	const password = randomUUID().replace(/-/g, "").slice(0, 16);
+	const command = `to,mm-${unique}#${password}`;
+
+	// Empty buffer → name "", password null. Never surfaced to a client because
+	// nobody has joined this room yet; each real player supplies their own name.
+	const syntheticPlayerInfo = new PlayerInfoMessage(Buffer.alloc(0), 0);
+
+	const room = YGOProRoom.create(
+		generateUniqueId(),
+		command,
+		input.logger,
+		input.emitter,
+		syntheticPlayerInfo,
+		// No creating socket — the room exists independently of any connection.
+		`matchmaking-${unique}`,
+		new YGOProMessageRepository(),
+		input.rankedOverride,
+	);
+
+	YGOProRoomList.addRoom(room);
+	room.waiting();
+
+	return { room, roomPassword: `${room.name}#${room.password}` };
+}

--- a/src/ygopro/matchmaking/application/MatchmakingRoomFactory.ts
+++ b/src/ygopro/matchmaking/application/MatchmakingRoomFactory.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "crypto";
+import { randomInt } from "crypto";
 import { EventEmitter } from "stream";
 
 import { PlayerInfoMessage } from "@edopro/messages/client-to-server/PlayerInfoMessage";
@@ -46,13 +46,46 @@ export interface MatchmakingRoomHandle {
  * create() path is left untouched.
  *
  * Command token "to" → rule 1 + first TCG banlist (strict TCG). A unique
- * "mm-<uuid>" token is appended purely to make the room name/join-string unique;
- * it matches no rule mapping, so the parser ignores it.
+ * "mm<base36>" token is appended purely to make the room name/join-string
+ * unique; its "mm" prefix guarantees it never matches a rule mapping validator
+ * (all rule tokens are exact strings or anchored regexes that never start with
+ * "mm"), so the parser ignores it.
+ *
+ * CRITICAL — wire-field budget: the client encodes CTOS_JOIN_GAME { pass } as a
+ * FIXED utf16[20] field (ygopro-msg-encode: BinaryField("utf16", 8, 20)). Any
+ * join string longer than the field is silently truncated on encode, which
+ * destroys the "#password" segment and makes the human's join fail the password
+ * check. The full "<name>#<password>" string MUST therefore stay <= 19 chars
+ * (19 is the safe ceiling: it leaves one wchar of margin for a terminator; 20
+ * is the hard cap where the field is completely full with no terminator).
+ *
+ * Layout within the 19-char budget:
+ *   "to," (3) + "mm" + 5 base36 (7) + "#" (1) + 7 base36 (7) = 18 chars.
  */
+const NAME_ENTROPY_CHARS = 5;
+const PASSWORD_CHARS = 7;
+
+function randomBase36(length: number): string {
+	let out = "";
+	for (let i = 0; i < length; i++) {
+		out += randomInt(36).toString(36);
+	}
+
+	return out;
+}
+
 export function createMatchmakingRoom(input: CreateMatchmakingRoomInput): MatchmakingRoomHandle {
-	const unique = randomUUID().replace(/-/g, "").slice(0, 12);
-	const password = randomUUID().replace(/-/g, "").slice(0, 16);
-	const command = `to,mm-${unique}#${password}`;
+	// "mm"-prefixed base36 suffix: collision-proof against rule tokens and unique
+	// enough that a clash in YGOProRoomList is astronomically rare — but we still
+	// regenerate on the off chance a live room already owns the name so both
+	// matched players resolve to the SAME room via findByName.
+	let unique = `mm${randomBase36(NAME_ENTROPY_CHARS)}`;
+	while (YGOProRoomList.findByName(`to,${unique}`)) {
+		unique = `mm${randomBase36(NAME_ENTROPY_CHARS)}`;
+	}
+
+	const password = randomBase36(PASSWORD_CHARS);
+	const command = `to,${unique}#${password}`;
 
 	// Empty buffer → name "", password null. Never surfaced to a client because
 	// nobody has joined this room yet; each real player supplies their own name.

--- a/src/ygopro/matchmaking/application/MatchmakingRoomFactory.ts
+++ b/src/ygopro/matchmaking/application/MatchmakingRoomFactory.ts
@@ -15,6 +15,13 @@ export interface CreateMatchmakingRoomInput {
 	rankedOverride: boolean;
 	logger: Logger;
 	emitter: EventEmitter;
+	/**
+	 * Invoked with the freshly created room BEFORE it is returned. The composition
+	 * root uses this to register the room with the empty-room reaper so a room that
+	 * is never joined (rage-quit, ticket expiry, network drop) is torn down instead
+	 * of leaking forever. Optional so tests can create rooms without a reaper.
+	 */
+	onRoomCreated?: (room: YGOProRoom) => void;
 }
 
 export interface MatchmakingRoomHandle {
@@ -65,6 +72,10 @@ export function createMatchmakingRoom(input: CreateMatchmakingRoomInput): Matchm
 
 	YGOProRoomList.addRoom(room);
 	room.waiting();
+
+	// Register with the empty-room reaper (if wired) so an unjoined room does not
+	// leak: nothing else reaps a matchmaking room that never sees a real socket.
+	input.onRoomCreated?.(room);
 
 	return { room, roomPassword: `${room.name}#${room.password}` };
 }

--- a/src/ygopro/matchmaking/application/MatchmakingRoomReaper.test.ts
+++ b/src/ygopro/matchmaking/application/MatchmakingRoomReaper.test.ts
@@ -1,0 +1,91 @@
+import { YGOProRoom } from "../../room/domain/YGOProRoom";
+import {
+	MATCHMAKING_ROOM_JOIN_GRACE_MS,
+	MatchmakingRoomReaper,
+	MatchmakingRoomReaperDeps,
+} from "./MatchmakingRoomReaper";
+
+// A minimal room stand-in — the reaper only reads `id` and `playersCount`.
+const makeRoom = (id: number, playersCount = 0): YGOProRoom =>
+	({ id, playersCount }) as unknown as YGOProRoom;
+
+const makeReaper = (overrides: Partial<MatchmakingRoomReaperDeps> = {}) => {
+	const clock = { t: 0 };
+	const finalize = jest.fn();
+	const reaper = new MatchmakingRoomReaper({
+		now: () => clock.t,
+		finalize,
+		...overrides,
+	});
+	return { reaper, finalize, clock };
+};
+
+describe("MatchmakingRoomReaper", () => {
+	it("finalizes a tracked room that is still empty after the grace window", () => {
+		const { reaper, finalize, clock } = makeReaper();
+		const room = makeRoom(1, 0);
+
+		reaper.track(room);
+		clock.t = MATCHMAKING_ROOM_JOIN_GRACE_MS + 1;
+		reaper.sweep();
+
+		expect(finalize).toHaveBeenCalledTimes(1);
+		expect(finalize).toHaveBeenCalledWith(room);
+		expect(reaper.size).toBe(0);
+	});
+
+	it("does NOT finalize a room that has been joined (playersCount > 0)", () => {
+		const clock = { t: 0 };
+		const finalize = jest.fn();
+		const reaper = new MatchmakingRoomReaper({ now: () => clock.t, finalize });
+		// Room object whose playersCount flips to 1 after a client joins.
+		const room = { id: 2, playersCount: 0 } as unknown as YGOProRoom;
+
+		reaper.track(room);
+		(room as unknown as { playersCount: number }).playersCount = 1;
+		clock.t = MATCHMAKING_ROOM_JOIN_GRACE_MS + 1;
+		reaper.sweep();
+
+		expect(finalize).not.toHaveBeenCalled();
+		// Ownership handed back to the normal lifecycle: no longer tracked.
+		expect(reaper.size).toBe(0);
+	});
+
+	it("does NOT finalize an empty room before the grace window elapses", () => {
+		const { reaper, finalize, clock } = makeReaper();
+		reaper.track(makeRoom(3, 0));
+
+		clock.t = MATCHMAKING_ROOM_JOIN_GRACE_MS - 1;
+		reaper.sweep();
+
+		expect(finalize).not.toHaveBeenCalled();
+		expect(reaper.size).toBe(1);
+	});
+
+	it("reaps only expired rooms and leaves younger ones tracked", () => {
+		const { reaper, finalize, clock } = makeReaper();
+		const older = makeRoom(10, 0);
+		reaper.track(older);
+
+		clock.t = 30_000;
+		const younger = makeRoom(11, 0);
+		reaper.track(younger);
+
+		clock.t = MATCHMAKING_ROOM_JOIN_GRACE_MS + 1; // older expired, younger not
+		reaper.sweep();
+
+		expect(finalize).toHaveBeenCalledTimes(1);
+		expect(finalize).toHaveBeenCalledWith(older);
+		expect(reaper.size).toBe(1);
+	});
+
+	it("honours an injected grace window override", () => {
+		const { reaper, finalize, clock } = makeReaper({ graceMs: 100 });
+		reaper.track(makeRoom(4, 0));
+
+		clock.t = 101;
+		reaper.sweep();
+
+		expect(finalize).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/ygopro/matchmaking/application/MatchmakingRoomReaper.ts
+++ b/src/ygopro/matchmaking/application/MatchmakingRoomReaper.ts
@@ -1,0 +1,70 @@
+import { YGOProRoom } from "../../room/domain/YGOProRoom";
+
+/** Grace window a matchmaking-created room is allowed to stay empty before it is
+ * reaped. Covers the gap between "match decided" and the real WS handshake: a
+ * rage-quit before join, ticket expiry between match and join, or a network drop
+ * would otherwise leak the pre-created room forever (RoomFinder/DisconnectHandler
+ * only reap rooms that had a real socket). */
+export const MATCHMAKING_ROOM_JOIN_GRACE_MS = 45_000;
+
+interface TrackedRoom {
+	room: YGOProRoom;
+	registeredAt: number;
+}
+
+export interface MatchmakingRoomReaperDeps {
+	now: () => number;
+	/** Canonical room teardown. Injected so the reaper stays decoupled from the
+	 * concrete FinalizeYGOProRoom path and is deterministically testable. */
+	finalize: (room: YGOProRoom) => void;
+	/** Grace window before an unjoined room is reaped. Defaults to the constant. */
+	graceMs?: number;
+}
+
+/**
+ * Reaper for matchmaking pre-created rooms that never receive a real client.
+ *
+ * MatchmakingRoomFactory registers a YGOProRoom in the lobby BEFORE either paired
+ * player connects. If no real client ever joins (rage-quit, ticket expiry, network
+ * drop), nothing else reaps it — the normal reap paths key off a real socket.
+ *
+ * On each sweep, any tracked room still empty (playersCount === 0) past the grace
+ * window is torn down via the injected finalize (the existing FinalizeYGOProRoom
+ * path in production). A room that has since been joined is left alone and dropped
+ * from tracking — its own lifecycle now owns teardown.
+ */
+export class MatchmakingRoomReaper {
+	private readonly tracked = new Map<number, TrackedRoom>();
+	private readonly graceMs: number;
+
+	constructor(private readonly deps: MatchmakingRoomReaperDeps) {
+		this.graceMs = deps.graceMs ?? MATCHMAKING_ROOM_JOIN_GRACE_MS;
+	}
+
+	/** Track a matchmaking-created room from the moment it enters the lobby. */
+	track(room: YGOProRoom): void {
+		this.tracked.set(room.id, { room, registeredAt: this.deps.now() });
+	}
+
+	/** Reap every tracked room still empty past the grace window; stop tracking any
+	 * room that has been joined (its own lifecycle owns teardown from here). */
+	sweep(): void {
+		const now = this.deps.now();
+		for (const [id, tracked] of this.tracked) {
+			if (tracked.room.playersCount > 0) {
+				// A real client joined — hand ownership back to the normal lifecycle.
+				this.tracked.delete(id);
+				continue;
+			}
+			if (now - tracked.registeredAt <= this.graceMs) continue;
+
+			this.deps.finalize(tracked.room);
+			this.tracked.delete(id);
+		}
+	}
+
+	/** Test/inspection seam: how many rooms are currently tracked. */
+	get size(): number {
+		return this.tracked.size;
+	}
+}

--- a/src/ygopro/matchmaking/domain/MatchmakingQueue.test.ts
+++ b/src/ygopro/matchmaking/domain/MatchmakingQueue.test.ts
@@ -458,6 +458,46 @@ describe("MatchmakingQueue", () => {
 			expect(() => enqueue(queue, "t3", "user-1")).toThrow();
 		});
 
+		it("keeps a matched entry alive while it is still being polled (grace measured from last poll)", () => {
+			// W3: a slow-joining client that keeps polling its matched result must NOT
+			// be dropped mid-flow, even long after matchedAt + MATCHED_GRACE_MS. The
+			// grace is measured from lastPollAt, which poll() refreshes on every call.
+			const clock = { t: 0 };
+			const queue = MatchmakingQueue.createForTests(makeDeps({ now: () => clock.t }));
+			enqueue(queue, "t1", "user-1");
+			enqueue(queue, "t2", "user-2");
+			queue.tick(); // pairs both → matched at t=0
+
+			// Well past matchedAt + grace, but the client kept polling.
+			clock.t = MATCHED_GRACE_MS * 3;
+			expect(queue.poll("t1")).toMatchObject({ state: "matched" });
+			queue.tick();
+
+			// Still present: last poll was at clock.t, so grace has not elapsed since.
+			expect(queue.get("t1")?.state).toBe("matched");
+		});
+
+		it("expires a matched entry MATCHED_GRACE_MS after it STOPS polling (joined)", () => {
+			// W3: once the client stops polling (it joined the room), the entry is
+			// reaped a grace window after its LAST contact — not after matchedAt.
+			const clock = { t: 0 };
+			const queue = MatchmakingQueue.createForTests(makeDeps({ now: () => clock.t }));
+			enqueue(queue, "t1", "user-1");
+			enqueue(queue, "t2", "user-2");
+			queue.tick(); // pairs both → matched at t=0
+
+			// Client polls once, later, then stops (joined).
+			clock.t = 10_000;
+			expect(queue.poll("t1")).toMatchObject({ state: "matched" });
+
+			// Grace elapses from the LAST poll, then a tick reaps it.
+			clock.t = 10_000 + MATCHED_GRACE_MS + 1;
+			queue.tick();
+
+			expect(queue.get("t1")).toBeUndefined();
+			expect(() => enqueue(queue, "t3", "user-1")).not.toThrow();
+		});
+
 		it("frees a bot-matched user after the grace window too", () => {
 			const clock = { t: 0 };
 			const queue = MatchmakingQueue.createForTests(makeDeps({ now: () => clock.t }));

--- a/src/ygopro/matchmaking/domain/MatchmakingQueue.test.ts
+++ b/src/ygopro/matchmaking/domain/MatchmakingQueue.test.ts
@@ -75,6 +75,21 @@ describe("MatchmakingQueue", () => {
 			expect(queue.poll("nope")).toBeNull();
 		});
 
+		it("does NOT advance the whole-queue tick for an unknown ticketId", () => {
+			// A garbage/unknown ticket poll must short-circuit (404) WITHOUT driving an
+			// O(n) sweep or side-effecting room creation on behalf of nobody.
+			const queue = MatchmakingQueue.createForTests(makeDeps());
+			enqueue(queue, "t1", "user-1"); // a lone waiting entry
+			const tickSpy = jest.spyOn(queue, "tick");
+
+			expect(queue.poll("garbage")).toBeNull();
+
+			// The unknown poll short-circuited: the sweep was never run.
+			expect(tickSpy).not.toHaveBeenCalled();
+			expect(queue.get("t1")?.state).toBe("searching");
+			tickSpy.mockRestore();
+		});
+
 		it("returns the matched payload once paired", () => {
 			const clock = { t: 0 };
 			const queue = MatchmakingQueue.createForTests(makeDeps({ now: () => clock.t }));
@@ -240,6 +255,112 @@ describe("MatchmakingQueue", () => {
 			expect(createBotRoom).not.toHaveBeenCalled();
 			// graceful: entry keeps waiting rather than crashing
 			expect(queue.get("t1")?.state).toBe("searching");
+		});
+	});
+
+	describe("tick — room-creation port failures", () => {
+		it("does not bubble a throwing createRankedRoom out of the sweep", () => {
+			const createRankedRoom = jest.fn(() => {
+				throw new Error("room boom");
+			});
+			const onRoomCreationError = jest.fn();
+			const queue = MatchmakingQueue.createForTests(
+				makeDeps({ createRankedRoom, onRoomCreationError }),
+			);
+			enqueue(queue, "t1", "user-1");
+			enqueue(queue, "t2", "user-2");
+
+			// The opportunistic enqueue tick already hit the throwing port; an explicit
+			// tick must also stay contained rather than propagating a 500 to the caller.
+			expect(() => queue.tick()).not.toThrow();
+			expect(onRoomCreationError).toHaveBeenCalled();
+			// The failed pair is left searching for a later retry, not corrupted.
+			expect(queue.get("t1")?.state).toBe("searching");
+			expect(queue.get("t2")?.state).toBe("searching");
+		});
+
+		it("continues the sweep for other pairs when one createRankedRoom throws", () => {
+			// The first pair's room creation throws; the second pair must still match.
+			let call = 0;
+			const createRankedRoom = jest.fn(() => {
+				call += 1;
+				if (call === 1) throw new Error("first pair boom");
+				return { roomPassword: `to,mm-r${call}#pw${call}` };
+			});
+			const queue = MatchmakingQueue.createForTests(
+				makeDeps({ createRankedRoom, onRoomCreationError: jest.fn() }),
+			);
+			// Four same-format searching entries → two pairs in a single sweep. The
+			// opportunistic enqueue ticks fire the throwing port on the first pair each
+			// time (they stay searching); a final explicit sweep pairs a surviving pair.
+			enqueue(queue, "t1", "user-1");
+			enqueue(queue, "t2", "user-2");
+			enqueue(queue, "t3", "user-3");
+			enqueue(queue, "t4", "user-4");
+			queue.tick();
+
+			// The throwing port kept firing but never aborted a sweep; once it returns a
+			// room (any call after the first) a pair matches — so at least two entries
+			// end matched while the sweep never threw.
+			const matched = ["t1", "t2", "t3", "t4"]
+				.map((t) => queue.get(t)?.state)
+				.filter((s) => s === "matched").length;
+			expect(matched).toBeGreaterThanOrEqual(2);
+			expect(createRankedRoom.mock.calls.length).toBeGreaterThanOrEqual(2);
+		});
+
+		it("does not bubble a throwing createBotRoom out of the sweep", () => {
+			const clock = { t: 0 };
+			const createBotRoom = jest.fn(() => {
+				throw new Error("bot room boom");
+			});
+			const onRoomCreationError = jest.fn();
+			const spawnBot = jest.fn();
+			const queue = MatchmakingQueue.createForTests(
+				makeDeps({ now: () => clock.t, createBotRoom, spawnBot, onRoomCreationError }),
+			);
+			enqueue(queue, "t1", "user-1");
+
+			clock.t = QUEUE_TTL_MS - 1;
+			queue.poll("t1");
+			clock.t = BOT_FALLBACK_MS + 1;
+
+			expect(() => queue.tick()).not.toThrow();
+			expect(onRoomCreationError).toHaveBeenCalled();
+			expect(spawnBot).not.toHaveBeenCalled();
+			// Entry left searching (retried next tick / TTL-dropped), not corrupted.
+			expect(queue.get("t1")?.state).toBe("searching");
+		});
+
+		it("throwing createBotRoom for one entry does not stop the others (lone-entry retries survive)", () => {
+			// A single lone entry hits the throwing bot port past the fallback window;
+			// the sweep neither throws nor corrupts it, and the entry remains eligible
+			// for a later retry once the port recovers.
+			const clock = { t: 0 };
+			let call = 0;
+			const createBotRoom = jest.fn(() => {
+				call += 1;
+				if (call === 1) throw new Error("first bot boom");
+				return { roomPassword: `to,mm-b${call}#pw${call}`, roomId: 5000 + call };
+			});
+			const spawnBot = jest.fn();
+			const queue = MatchmakingQueue.createForTests(
+				makeDeps({ now: () => clock.t, createBotRoom, spawnBot, onRoomCreationError: jest.fn() }),
+			);
+			enqueue(queue, "t1", "user-1"); // lone → bot-fallback candidate
+
+			clock.t = QUEUE_TTL_MS - 1;
+			queue.poll("t1");
+			clock.t = BOT_FALLBACK_MS + 1;
+
+			// First tick: bot port throws, entry stays searching, no crash.
+			expect(() => queue.tick()).not.toThrow();
+			expect(queue.get("t1")?.state).toBe("searching");
+
+			// Second tick: port recovers, entry now matches to a bot.
+			expect(() => queue.tick()).not.toThrow();
+			expect(queue.get("t1")?.state).toBe("matched");
+			expect(spawnBot).toHaveBeenCalledWith(5000 + call);
 		});
 	});
 

--- a/src/ygopro/matchmaking/domain/MatchmakingQueue.test.ts
+++ b/src/ygopro/matchmaking/domain/MatchmakingQueue.test.ts
@@ -1,0 +1,313 @@
+import { BOT_FALLBACK_MS, QUEUE_TTL_MS, SUPPORTED_FORMAT } from "./QueueEntry";
+import { MatchmakingQueue, MatchmakingQueueDeps } from "./MatchmakingQueue";
+
+// ---- helpers ----
+
+const makeDeps = (overrides: Partial<MatchmakingQueueDeps> = {}): MatchmakingQueueDeps => {
+	let roomSeq = 0;
+	return {
+		now: () => 0,
+		createRankedRoom: () => {
+			roomSeq += 1;
+			return { roomPassword: `to,mm-r${roomSeq}#pw${roomSeq}` };
+		},
+		createBotRoom: () => {
+			roomSeq += 1;
+			return { roomPassword: `to,mm-b${roomSeq}#pw${roomSeq}`, roomId: 1000 + roomSeq };
+		},
+		spawnBot: jest.fn(),
+		...overrides,
+	};
+};
+
+const enqueue = (queue: MatchmakingQueue, ticketId: string, userId: string) =>
+	queue.enqueue({ ticketId, userId, format: SUPPORTED_FORMAT });
+
+describe("MatchmakingQueue", () => {
+	afterEach(() => {
+		MatchmakingQueue.resetForTests();
+	});
+
+	describe("enqueue", () => {
+		it("registers a searching entry keyed by ticketId", () => {
+			const clock = { t: 100 };
+			const queue = MatchmakingQueue.createForTests(makeDeps({ now: () => clock.t }));
+
+			enqueue(queue, "t1", "user-1");
+			const entry = queue.get("t1");
+
+			expect(entry).toMatchObject({
+				ticketId: "t1",
+				userId: "user-1",
+				state: "searching",
+				enteredAt: 100,
+				lastPollAt: 100,
+			});
+		});
+
+		it("rejects a second active entry for the same user (one entry per user)", () => {
+			const queue = MatchmakingQueue.createForTests(makeDeps());
+
+			enqueue(queue, "t1", "user-1");
+
+			expect(() => enqueue(queue, "t2", "user-1")).toThrow();
+			expect(queue.get("t2")).toBeUndefined();
+			// original entry stays intact
+			expect(queue.get("t1")).toBeDefined();
+		});
+	});
+
+	describe("poll", () => {
+		it("returns searching state with elapsed waitedMs and refreshes lastPollAt", () => {
+			const clock = { t: 0 };
+			const queue = MatchmakingQueue.createForTests(makeDeps({ now: () => clock.t }));
+			enqueue(queue, "t1", "user-1");
+
+			clock.t = 3_000;
+			const status = queue.poll("t1");
+
+			expect(status).toEqual({ state: "searching", waitedMs: 3_000 });
+			expect(queue.get("t1")?.lastPollAt).toBe(3_000);
+		});
+
+		it("returns null for an unknown ticketId", () => {
+			const queue = MatchmakingQueue.createForTests(makeDeps());
+			expect(queue.poll("nope")).toBeNull();
+		});
+
+		it("returns the matched payload once paired", () => {
+			const clock = { t: 0 };
+			const queue = MatchmakingQueue.createForTests(makeDeps({ now: () => clock.t }));
+			enqueue(queue, "t1", "user-1");
+			enqueue(queue, "t2", "user-2");
+
+			queue.tick();
+
+			const s1 = queue.poll("t1");
+			const s2 = queue.poll("t2");
+			expect(s1).toMatchObject({ state: "matched", opponentType: "human", rated: true });
+			expect(s2).toMatchObject({ state: "matched", opponentType: "human", rated: true });
+			// both land in the SAME room password (the exact join string)
+			expect((s1 as { roomPassword: string }).roomPassword).toBe(
+				(s2 as { roomPassword: string }).roomPassword,
+			);
+		});
+	});
+
+	describe("cancel", () => {
+		it("removes the entry and frees the user", () => {
+			const queue = MatchmakingQueue.createForTests(makeDeps());
+			enqueue(queue, "t1", "user-1");
+
+			expect(queue.cancel("t1")).toBe(true);
+			expect(queue.get("t1")).toBeUndefined();
+			// user can enqueue again with a new ticket
+			expect(() => enqueue(queue, "t2", "user-1")).not.toThrow();
+		});
+
+		it("returns false when cancelling an unknown ticket", () => {
+			const queue = MatchmakingQueue.createForTests(makeDeps());
+			expect(queue.cancel("nope")).toBe(false);
+		});
+	});
+
+	describe("tick — pairing", () => {
+		it("pairs two searching entries of the same format into one ranked room", () => {
+			const createRankedRoom = jest.fn().mockReturnValue({ roomPassword: "to,mm-r1#pw1" });
+			const queue = MatchmakingQueue.createForTests(makeDeps({ createRankedRoom }));
+			enqueue(queue, "t1", "user-1");
+			enqueue(queue, "t2", "user-2");
+
+			queue.tick();
+
+			expect(createRankedRoom).toHaveBeenCalledTimes(1);
+			const e1 = queue.get("t1");
+			const e2 = queue.get("t2");
+			expect(e1?.state).toBe("matched");
+			expect(e2?.state).toBe("matched");
+			expect(e1?.roomPassword).toBe("to,mm-r1#pw1");
+			expect(e2?.roomPassword).toBe("to,mm-r1#pw1");
+			expect(e1?.rated).toBe(true);
+			expect(e2?.rated).toBe(true);
+			expect(e1?.opponentType).toBe("human");
+		});
+
+		it("does not pair an already matched entry again", () => {
+			const createRankedRoom = jest.fn().mockReturnValue({ roomPassword: "to,mm-r1#pw1" });
+			const queue = MatchmakingQueue.createForTests(makeDeps({ createRankedRoom }));
+			enqueue(queue, "t1", "user-1");
+			enqueue(queue, "t2", "user-2");
+
+			queue.tick();
+			queue.tick();
+
+			expect(createRankedRoom).toHaveBeenCalledTimes(1);
+		});
+
+		it("leaves a lone searching entry unpaired", () => {
+			const createRankedRoom = jest.fn();
+			const queue = MatchmakingQueue.createForTests(makeDeps({ createRankedRoom }));
+			enqueue(queue, "t1", "user-1");
+
+			queue.tick();
+
+			expect(createRankedRoom).not.toHaveBeenCalled();
+			expect(queue.get("t1")?.state).toBe("searching");
+		});
+	});
+
+	describe("tick — bot fallback", () => {
+		it("matches a lone entry to a bot after the fallback window", () => {
+			const clock = { t: 0 };
+			const createBotRoom = jest
+				.fn()
+				.mockReturnValue({ roomPassword: "to,mm-b1#pw1", roomId: 4242 });
+			const spawnBot = jest.fn();
+			const queue = MatchmakingQueue.createForTests(
+				makeDeps({ now: () => clock.t, createBotRoom, spawnBot }),
+			);
+			enqueue(queue, "t1", "user-1");
+
+			// Keep polling within the TTL window, as a real client does, so the
+			// entry survives to the bot-fallback threshold instead of being swept.
+			clock.t = QUEUE_TTL_MS - 1;
+			queue.poll("t1");
+			clock.t = BOT_FALLBACK_MS + 1;
+			queue.tick();
+
+			const e1 = queue.get("t1");
+			expect(e1?.state).toBe("matched");
+			expect(e1?.opponentType).toBe("bot");
+			expect(e1?.rated).toBe(false);
+			expect(e1?.roomPassword).toBe("to,mm-b1#pw1");
+			expect(spawnBot).toHaveBeenCalledWith(4242);
+		});
+
+		it("does not trigger bot fallback before the window elapses", () => {
+			const clock = { t: 0 };
+			const createBotRoom = jest.fn();
+			const queue = MatchmakingQueue.createForTests(
+				makeDeps({ now: () => clock.t, createBotRoom }),
+			);
+			enqueue(queue, "t1", "user-1");
+
+			clock.t = QUEUE_TTL_MS - 1;
+			queue.poll("t1");
+			clock.t = BOT_FALLBACK_MS - 1;
+			queue.tick();
+
+			expect(createBotRoom).not.toHaveBeenCalled();
+			expect(queue.get("t1")?.state).toBe("searching");
+		});
+
+		it("prefers pairing two humans over a bot even past the fallback window", () => {
+			const clock = { t: 0 };
+			const createRankedRoom = jest.fn().mockReturnValue({ roomPassword: "to,mm-r1#pw1" });
+			const createBotRoom = jest.fn();
+			const queue = MatchmakingQueue.createForTests(
+				makeDeps({ now: () => clock.t, createRankedRoom, createBotRoom }),
+			);
+			enqueue(queue, "t1", "user-1");
+			enqueue(queue, "t2", "user-2");
+
+			clock.t = QUEUE_TTL_MS - 1;
+			queue.poll("t1");
+			queue.poll("t2");
+			clock.t = BOT_FALLBACK_MS + 1;
+			queue.tick();
+
+			expect(createRankedRoom).toHaveBeenCalledTimes(1);
+			expect(createBotRoom).not.toHaveBeenCalled();
+		});
+
+		it("keeps the entry searching when the bot spawner is unavailable", () => {
+			const clock = { t: 0 };
+			const createBotRoom = jest.fn();
+			const queue = MatchmakingQueue.createForTests(
+				makeDeps({
+					now: () => clock.t,
+					createBotRoom,
+					botAvailable: () => false,
+				}),
+			);
+			enqueue(queue, "t1", "user-1");
+
+			clock.t = QUEUE_TTL_MS - 1;
+			queue.poll("t1");
+			clock.t = BOT_FALLBACK_MS + 1;
+			queue.tick();
+
+			expect(createBotRoom).not.toHaveBeenCalled();
+			// graceful: entry keeps waiting rather than crashing
+			expect(queue.get("t1")?.state).toBe("searching");
+		});
+	});
+
+	describe("tick — TTL expiry", () => {
+		it("drops a searching entry that missed the poll window", () => {
+			const clock = { t: 0 };
+			const queue = MatchmakingQueue.createForTests(makeDeps({ now: () => clock.t }));
+			enqueue(queue, "t1", "user-1");
+
+			clock.t = QUEUE_TTL_MS + 1;
+			queue.tick();
+
+			expect(queue.get("t1")).toBeUndefined();
+			// user freed after drop
+			expect(() => enqueue(queue, "t2", "user-1")).not.toThrow();
+		});
+
+		it("does not drop an entry that polled within the window", () => {
+			const clock = { t: 0 };
+			const queue = MatchmakingQueue.createForTests(makeDeps({ now: () => clock.t }));
+			enqueue(queue, "t1", "user-1");
+
+			clock.t = QUEUE_TTL_MS - 1;
+			queue.poll("t1"); // refresh
+			clock.t = QUEUE_TTL_MS + 1; // now within TTL of the last poll
+			queue.tick();
+
+			expect(queue.get("t1")).toBeDefined();
+		});
+
+		it("does not drop a matched entry on TTL (it already found a game)", () => {
+			const clock = { t: 0 };
+			const queue = MatchmakingQueue.createForTests(makeDeps({ now: () => clock.t }));
+			enqueue(queue, "t1", "user-1");
+			enqueue(queue, "t2", "user-2");
+			queue.tick(); // pairs both
+
+			clock.t = QUEUE_TTL_MS + 1;
+			queue.tick();
+
+			expect(queue.get("t1")).toBeDefined();
+			expect(queue.get("t2")).toBeDefined();
+		});
+	});
+
+	describe("singleton", () => {
+		it("start() installs an unref'd interval and stop() clears it", () => {
+			const unref = jest.fn().mockReturnThis();
+			const setIntervalSpy = jest
+				.spyOn(global, "setInterval")
+				.mockReturnValue({ unref } as unknown as NodeJS.Timeout);
+			const clearIntervalSpy = jest
+				.spyOn(global, "clearInterval")
+				.mockImplementation(() => undefined);
+
+			MatchmakingQueue.init(makeDeps());
+			MatchmakingQueue.getInstance().start();
+			expect(unref).toHaveBeenCalled();
+
+			MatchmakingQueue.getInstance().stop();
+			expect(clearIntervalSpy).toHaveBeenCalled();
+
+			setIntervalSpy.mockRestore();
+			clearIntervalSpy.mockRestore();
+		});
+
+		it("getInstance throws before init", () => {
+			expect(() => MatchmakingQueue.getInstance()).toThrow();
+		});
+	});
+});

--- a/src/ygopro/matchmaking/domain/MatchmakingQueue.test.ts
+++ b/src/ygopro/matchmaking/domain/MatchmakingQueue.test.ts
@@ -1,4 +1,4 @@
-import { BOT_FALLBACK_MS, QUEUE_TTL_MS, SUPPORTED_FORMAT } from "./QueueEntry";
+import { BOT_FALLBACK_MS, MATCHED_GRACE_MS, QUEUE_TTL_MS, SUPPORTED_FORMAT } from "./QueueEntry";
 import { MatchmakingQueue, MatchmakingQueueDeps } from "./MatchmakingQueue";
 
 // ---- helpers ----
@@ -403,6 +403,77 @@ describe("MatchmakingQueue", () => {
 
 			expect(queue.get("t1")).toBeDefined();
 			expect(queue.get("t2")).toBeDefined();
+		});
+	});
+
+	describe("tick — matched grace-window cleanup", () => {
+		it("frees the user after MATCHED_GRACE_MS so the SAME userId can enqueue again", () => {
+			const clock = { t: 0 };
+			const queue = MatchmakingQueue.createForTests(makeDeps({ now: () => clock.t }));
+			enqueue(queue, "t1", "user-1");
+			enqueue(queue, "t2", "user-2");
+			queue.tick(); // pairs both → matched
+
+			// Grace window elapses, then a tick sweeps the matched entries.
+			clock.t = MATCHED_GRACE_MS + 1;
+			queue.tick();
+
+			// Entries and their user mappings are gone.
+			expect(queue.get("t1")).toBeUndefined();
+			expect(queue.get("t2")).toBeUndefined();
+			// The same users can enqueue again with fresh tickets (Quick Match works again).
+			expect(() => enqueue(queue, "t3", "user-1")).not.toThrow();
+			expect(() => enqueue(queue, "t4", "user-2")).not.toThrow();
+		});
+
+		it("keeps returning the matched result while re-polling within the grace window (idempotent)", () => {
+			const clock = { t: 0 };
+			const queue = MatchmakingQueue.createForTests(makeDeps({ now: () => clock.t }));
+			enqueue(queue, "t1", "user-1");
+			enqueue(queue, "t2", "user-2");
+			queue.tick(); // pairs both → matched
+
+			// Re-poll several times within the grace window: each still gets `matched`.
+			clock.t = 1_000;
+			expect(queue.poll("t1")).toMatchObject({ state: "matched", opponentType: "human" });
+			clock.t = MATCHED_GRACE_MS - 1;
+			expect(queue.poll("t1")).toMatchObject({ state: "matched", opponentType: "human" });
+			// Still present because we did not delete on first poll.
+			expect(queue.get("t1")?.state).toBe("matched");
+		});
+
+		it("does NOT drop a matched entry before the grace window elapses", () => {
+			const clock = { t: 0 };
+			const queue = MatchmakingQueue.createForTests(makeDeps({ now: () => clock.t }));
+			enqueue(queue, "t1", "user-1");
+			enqueue(queue, "t2", "user-2");
+			queue.tick(); // pairs both → matched
+
+			clock.t = MATCHED_GRACE_MS - 1;
+			queue.tick();
+
+			expect(queue.get("t1")).toBeDefined();
+			expect(queue.get("t2")).toBeDefined();
+			// User still held → cannot enqueue again yet.
+			expect(() => enqueue(queue, "t3", "user-1")).toThrow();
+		});
+
+		it("frees a bot-matched user after the grace window too", () => {
+			const clock = { t: 0 };
+			const queue = MatchmakingQueue.createForTests(makeDeps({ now: () => clock.t }));
+			enqueue(queue, "t1", "user-1");
+
+			clock.t = QUEUE_TTL_MS - 1;
+			queue.poll("t1");
+			clock.t = BOT_FALLBACK_MS + 1;
+			queue.tick(); // matched to a bot
+			expect(queue.get("t1")?.state).toBe("matched");
+
+			clock.t = BOT_FALLBACK_MS + 1 + MATCHED_GRACE_MS + 1;
+			queue.tick();
+
+			expect(queue.get("t1")).toBeUndefined();
+			expect(() => enqueue(queue, "t2", "user-1")).not.toThrow();
 		});
 	});
 

--- a/src/ygopro/matchmaking/domain/MatchmakingQueue.ts
+++ b/src/ygopro/matchmaking/domain/MatchmakingQueue.ts
@@ -29,6 +29,9 @@ export interface MatchmakingQueueDeps {
 	spawnBot: (roomId: number) => void;
 	/** Whether bot fallback is currently possible (windbot initialized + enabled). */
 	botAvailable?: () => boolean;
+	/** Optional sink for per-entry room-creation failures. Injected so the queue
+	 * domain stays free of a concrete logger; the composition root logs. */
+	onRoomCreationError?: (error: unknown) => void;
 }
 
 export interface EnqueueInput {
@@ -228,9 +231,17 @@ export class MatchmakingQueue {
 			for (let i = 0; i + 1 < bucket.length; i += 2) {
 				const a = bucket[i];
 				const b = bucket[i + 1];
-				const { roomPassword } = this.deps.createRankedRoom();
-				this.markMatched(a, roomPassword, "human", true, b.userId);
-				this.markMatched(b, roomPassword, "human", true, a.userId);
+				// A synchronous throw from the room-creation port must not abort the
+				// whole sweep or bubble a 500 to an unrelated enqueue/poll caller.
+				// On failure, leave BOTH entries searching (a retry next tick, or a
+				// bot fallback / TTL drop, will resolve them) and move on.
+				try {
+					const { roomPassword } = this.deps.createRankedRoom();
+					this.markMatched(a, roomPassword, "human", true, b.userId);
+					this.markMatched(b, roomPassword, "human", true, a.userId);
+				} catch (error) {
+					this.deps.onRoomCreationError?.(error);
+				}
 			}
 		}
 	}
@@ -247,9 +258,16 @@ export class MatchmakingQueue {
 			if (entry.state !== "searching") continue;
 			if (now - entry.enteredAt <= BOT_FALLBACK_MS) continue;
 
-			const { roomPassword, roomId } = this.deps.createBotRoom();
-			this.markMatched(entry, roomPassword, "bot", false);
-			this.deps.spawnBot(roomId);
+			// A synchronous throw from createBotRoom/spawnBot must not abort the sweep
+			// or 500 an unrelated caller. On failure, leave THIS entry searching (a
+			// later tick retries, or the TTL sweep drops it) and continue with the rest.
+			try {
+				const { roomPassword, roomId } = this.deps.createBotRoom();
+				this.markMatched(entry, roomPassword, "bot", false);
+				this.deps.spawnBot(roomId);
+			} catch (error) {
+				this.deps.onRoomCreationError?.(error);
+			}
 		}
 	}
 

--- a/src/ygopro/matchmaking/domain/MatchmakingQueue.ts
+++ b/src/ygopro/matchmaking/domain/MatchmakingQueue.ts
@@ -222,11 +222,12 @@ export class MatchmakingQueue {
 			// the `matched` result (idempotency), then reaped to free the user — even
 			// if the client never polled the final result. This only cleans up the
 			// QUEUE entry; the created room is reaped separately by MatchmakingRoomReaper.
-			if (
-				entry.state === "matched" &&
-				entry.matchedAt !== undefined &&
-				now - entry.matchedAt > MATCHED_GRACE_MS
-			) {
+			//
+			// The grace is measured from lastPollAt (refreshed on every poll, including
+			// polls of matched entries), NOT matchedAt: an actively-polling client (e.g.
+			// a slow join) is never dropped mid-flow, while a client that stopped polling
+			// (already joined) expires MATCHED_GRACE_MS after its last contact.
+			if (entry.state === "matched" && now - entry.lastPollAt > MATCHED_GRACE_MS) {
 				this.entries.delete(entry.ticketId);
 				this.usersInQueue.delete(entry.userId);
 			}

--- a/src/ygopro/matchmaking/domain/MatchmakingQueue.ts
+++ b/src/ygopro/matchmaking/domain/MatchmakingQueue.ts
@@ -1,0 +1,269 @@
+import {
+	BOT_FALLBACK_MS,
+	CLEANUP_INTERVAL_MS,
+	MatchmakingFormat,
+	QUEUE_TTL_MS,
+	QueueEntry,
+} from "./QueueEntry";
+
+export interface RankedRoomHandle {
+	/** The exact string a client sends in CTOS_JOIN_GAME { pass } to land in this room. */
+	roomPassword: string;
+}
+
+export interface BotRoomHandle extends RankedRoomHandle {
+	roomId: number;
+}
+
+/**
+ * Ports the queue depends on. Injected so the pairing/TTL logic stays pure and
+ * deterministically testable, decoupled from YGOProRoom, windbot, and the clock.
+ */
+export interface MatchmakingQueueDeps {
+	now: () => number;
+	/** Creates a ranked (Verified) room for a human pair. */
+	createRankedRoom: () => RankedRoomHandle;
+	/** Creates a casual (unrated) room for a bot game and returns its id for the spawn. */
+	createBotRoom: () => BotRoomHandle;
+	/** Fires the windbot join for the given room (fire-and-forget). */
+	spawnBot: (roomId: number) => void;
+	/** Whether bot fallback is currently possible (windbot initialized + enabled). */
+	botAvailable?: () => boolean;
+}
+
+export interface EnqueueInput {
+	ticketId: string;
+	userId: string;
+	format: MatchmakingFormat;
+}
+
+export type PollResult =
+	| { state: "searching"; waitedMs: number }
+	| {
+			state: "matched";
+			roomPassword: string;
+			opponentType: "human" | "bot";
+			opponentName?: string;
+			rated: boolean;
+	  };
+
+export class DuplicateQueueEntryError extends Error {
+	constructor(userId: string) {
+		super(`User ${userId} already has an active matchmaking entry`);
+		this.name = "DuplicateQueueEntryError";
+	}
+}
+
+/**
+ * MatchmakingQueue — in-memory auto-pairing queue for the duel server.
+ *
+ * Node's single thread means synchronous Map operations need no locking: enqueue,
+ * poll, cancel, and every tick run to completion without interleaving. All async
+ * work (room creation side effects, windbot HTTP) is delegated to injected ports
+ * and, for the bot spawn, fired-and-forgotten.
+ *
+ * The tick (run on an unref'd interval AND opportunistically on enqueue/poll):
+ *   1. TTL sweep: drop searching entries whose last poll fell outside QUEUE_TTL_MS.
+ *   2. Pair: two searching entries of the same format → one ranked room, both matched.
+ *   3. Bot fallback: a searching entry older than BOT_FALLBACK_MS with no human → bot room.
+ */
+export class MatchmakingQueue {
+	private readonly entries = new Map<string, QueueEntry>();
+	private readonly usersInQueue = new Map<string, string>(); // userId -> ticketId
+	private interval: NodeJS.Timeout | null = null;
+
+	private constructor(private readonly deps: MatchmakingQueueDeps) {}
+
+	// ---- singleton accessor (mirrors WindbotModule / YGOProRoomList pattern) ----
+
+	private static _instance: MatchmakingQueue | null = null;
+
+	static init(deps: MatchmakingQueueDeps): void {
+		MatchmakingQueue._instance = new MatchmakingQueue(deps);
+	}
+
+	static getInstance(): MatchmakingQueue {
+		if (!MatchmakingQueue._instance) {
+			throw new Error("MatchmakingQueue not initialized — call MatchmakingQueue.init() first");
+		}
+		return MatchmakingQueue._instance;
+	}
+
+	static isInitialized(): boolean {
+		return MatchmakingQueue._instance !== null;
+	}
+
+	/** Test seam: build an instance with injected deps without touching the singleton. */
+	static createForTests(deps: MatchmakingQueueDeps): MatchmakingQueue {
+		return new MatchmakingQueue(deps);
+	}
+
+	/** Test seam: reset the singleton so suites can call init() cleanly. */
+	static resetForTests(): void {
+		if (MatchmakingQueue._instance) {
+			MatchmakingQueue._instance.stop();
+		}
+		MatchmakingQueue._instance = null;
+	}
+
+	// ---- lifecycle ----
+
+	start(): void {
+		if (this.interval) return;
+		// unref() so the interval never keeps the process (or a test run) alive.
+		this.interval = setInterval(() => this.tick(), CLEANUP_INTERVAL_MS);
+		this.interval.unref();
+	}
+
+	stop(): void {
+		if (this.interval) {
+			clearInterval(this.interval);
+			this.interval = null;
+		}
+	}
+
+	// ---- public API ----
+
+	enqueue(input: EnqueueInput): QueueEntry {
+		const existingTicket = this.usersInQueue.get(input.userId);
+		if (existingTicket !== undefined) {
+			throw new DuplicateQueueEntryError(input.userId);
+		}
+
+		const now = this.deps.now();
+		const entry: QueueEntry = {
+			ticketId: input.ticketId,
+			userId: input.userId,
+			format: input.format,
+			enteredAt: now,
+			lastPollAt: now,
+			state: "searching",
+		};
+		this.entries.set(input.ticketId, entry);
+		this.usersInQueue.set(input.userId, input.ticketId);
+
+		// Opportunistic pairing so a waiting partner is matched without waiting a full tick.
+		this.tick();
+		return entry;
+	}
+
+	poll(ticketId: string): PollResult | null {
+		const entry = this.entries.get(ticketId);
+		if (!entry) {
+			return null;
+		}
+
+		entry.lastPollAt = this.deps.now();
+
+		if (entry.state === "matched") {
+			return {
+				state: "matched",
+				roomPassword: entry.roomPassword as string,
+				opponentType: entry.opponentType as "human" | "bot",
+				opponentName: entry.opponentName,
+				rated: entry.rated as boolean,
+			};
+		}
+
+		// Advance the queue on the poll too — the poll is the client's heartbeat.
+		this.tick();
+
+		const refreshed = this.entries.get(ticketId);
+		if (refreshed && refreshed.state === "matched") {
+			return {
+				state: "matched",
+				roomPassword: refreshed.roomPassword as string,
+				opponentType: refreshed.opponentType as "human" | "bot",
+				opponentName: refreshed.opponentName,
+				rated: refreshed.rated as boolean,
+			};
+		}
+
+		return { state: "searching", waitedMs: this.deps.now() - entry.enteredAt };
+	}
+
+	cancel(ticketId: string): boolean {
+		const entry = this.entries.get(ticketId);
+		if (!entry) {
+			return false;
+		}
+		this.entries.delete(ticketId);
+		this.usersInQueue.delete(entry.userId);
+		return true;
+	}
+
+	get(ticketId: string): QueueEntry | undefined {
+		return this.entries.get(ticketId);
+	}
+
+	// ---- the pairing/expiry engine ----
+
+	tick(): void {
+		const now = this.deps.now();
+		this.expireStale(now);
+		this.pairHumans();
+		this.botFallback(now);
+	}
+
+	private expireStale(now: number): void {
+		for (const entry of this.entries.values()) {
+			if (entry.state === "searching" && now - entry.lastPollAt > QUEUE_TTL_MS) {
+				this.entries.delete(entry.ticketId);
+				this.usersInQueue.delete(entry.userId);
+			}
+		}
+	}
+
+	private pairHumans(): void {
+		// Pair by format. Insertion order (Map iteration) gives FIFO fairness.
+		const byFormat = new Map<MatchmakingFormat, QueueEntry[]>();
+		for (const entry of this.entries.values()) {
+			if (entry.state !== "searching") continue;
+			const bucket = byFormat.get(entry.format) ?? [];
+			bucket.push(entry);
+			byFormat.set(entry.format, bucket);
+		}
+
+		for (const bucket of byFormat.values()) {
+			for (let i = 0; i + 1 < bucket.length; i += 2) {
+				const a = bucket[i];
+				const b = bucket[i + 1];
+				const { roomPassword } = this.deps.createRankedRoom();
+				this.markMatched(a, roomPassword, "human", true, b.userId);
+				this.markMatched(b, roomPassword, "human", true, a.userId);
+			}
+		}
+	}
+
+	private botFallback(now: number): void {
+		const botAvailable = this.deps.botAvailable?.() ?? true;
+		if (!botAvailable) {
+			// Graceful degradation: leave entries searching (a human may still arrive,
+			// or the TTL sweep drops them) rather than crashing or erroring the poll.
+			return;
+		}
+
+		for (const entry of this.entries.values()) {
+			if (entry.state !== "searching") continue;
+			if (now - entry.enteredAt <= BOT_FALLBACK_MS) continue;
+
+			const { roomPassword, roomId } = this.deps.createBotRoom();
+			this.markMatched(entry, roomPassword, "bot", false);
+			this.deps.spawnBot(roomId);
+		}
+	}
+
+	private markMatched(
+		entry: QueueEntry,
+		roomPassword: string,
+		opponentType: "human" | "bot",
+		rated: boolean,
+		opponentName?: string,
+	): void {
+		entry.state = "matched";
+		entry.roomPassword = roomPassword;
+		entry.opponentType = opponentType;
+		entry.rated = rated;
+		entry.opponentName = opponentName;
+	}
+}

--- a/src/ygopro/matchmaking/domain/MatchmakingQueue.ts
+++ b/src/ygopro/matchmaking/domain/MatchmakingQueue.ts
@@ -1,6 +1,7 @@
 import {
 	BOT_FALLBACK_MS,
 	CLEANUP_INTERVAL_MS,
+	MATCHED_GRACE_MS,
 	MatchmakingFormat,
 	QUEUE_TTL_MS,
 	QueueEntry,
@@ -210,7 +211,22 @@ export class MatchmakingQueue {
 
 	private expireStale(now: number): void {
 		for (const entry of this.entries.values()) {
+			// Searching entries that fell behind the poll heartbeat are dropped.
 			if (entry.state === "searching" && now - entry.lastPollAt > QUEUE_TTL_MS) {
+				this.entries.delete(entry.ticketId);
+				this.usersInQueue.delete(entry.userId);
+				continue;
+			}
+
+			// Matched entries are retained for a grace window so a re-poll still gets
+			// the `matched` result (idempotency), then reaped to free the user — even
+			// if the client never polled the final result. This only cleans up the
+			// QUEUE entry; the created room is reaped separately by MatchmakingRoomReaper.
+			if (
+				entry.state === "matched" &&
+				entry.matchedAt !== undefined &&
+				now - entry.matchedAt > MATCHED_GRACE_MS
+			) {
 				this.entries.delete(entry.ticketId);
 				this.usersInQueue.delete(entry.userId);
 			}
@@ -279,6 +295,7 @@ export class MatchmakingQueue {
 		opponentName?: string,
 	): void {
 		entry.state = "matched";
+		entry.matchedAt = this.deps.now();
 		entry.roomPassword = roomPassword;
 		entry.opponentType = opponentType;
 		entry.rated = rated;

--- a/src/ygopro/matchmaking/domain/MatchmakingTcgBotDecks.test.ts
+++ b/src/ygopro/matchmaking/domain/MatchmakingTcgBotDecks.test.ts
@@ -31,4 +31,11 @@ describe("pickRandomTcgBotDeck", () => {
 			MATCHMAKING_TCG_BOT_DECKS[MATCHMAKING_TCG_BOT_DECKS.length - 1],
 		);
 	});
+
+	it("clamps to the last deck when random() returns exactly 1.0", () => {
+		// Math.floor(1.0 * len) === len → out-of-range/undefined without the clamp.
+		const deck = pickRandomTcgBotDeck(() => 1);
+		expect(deck).toBe(MATCHMAKING_TCG_BOT_DECKS[MATCHMAKING_TCG_BOT_DECKS.length - 1]);
+		expect(MATCHMAKING_TCG_BOT_DECKS).toContain(deck);
+	});
 });

--- a/src/ygopro/matchmaking/domain/MatchmakingTcgBotDecks.test.ts
+++ b/src/ygopro/matchmaking/domain/MatchmakingTcgBotDecks.test.ts
@@ -1,0 +1,34 @@
+import { MATCHMAKING_TCG_BOT_DECKS, pickRandomTcgBotDeck } from "./MatchmakingTcgBotDecks";
+
+describe("MATCHMAKING_TCG_BOT_DECKS", () => {
+	it("is a non-empty pool of deck names", () => {
+		expect(Array.isArray(MATCHMAKING_TCG_BOT_DECKS)).toBe(true);
+		expect(MATCHMAKING_TCG_BOT_DECKS.length).toBeGreaterThan(0);
+	});
+
+	it("contains only non-empty, unique deck strings", () => {
+		const seen = new Set<string>();
+		for (const deck of MATCHMAKING_TCG_BOT_DECKS) {
+			expect(typeof deck).toBe("string");
+			expect(deck.length).toBeGreaterThan(0);
+			expect(seen.has(deck)).toBe(false);
+			seen.add(deck);
+		}
+	});
+});
+
+describe("pickRandomTcgBotDeck", () => {
+	it("always returns a member of the TCG pool", () => {
+		for (const r of [0, 0.25, 0.5, 0.75, 0.999]) {
+			const deck = pickRandomTcgBotDeck(() => r);
+			expect(MATCHMAKING_TCG_BOT_DECKS).toContain(deck);
+		}
+	});
+
+	it("selects by index using the injected random source", () => {
+		expect(pickRandomTcgBotDeck(() => 0)).toBe(MATCHMAKING_TCG_BOT_DECKS[0]);
+		expect(pickRandomTcgBotDeck(() => 0.999)).toBe(
+			MATCHMAKING_TCG_BOT_DECKS[MATCHMAKING_TCG_BOT_DECKS.length - 1],
+		);
+	});
+});

--- a/src/ygopro/matchmaking/domain/MatchmakingTcgBotDecks.ts
+++ b/src/ygopro/matchmaking/domain/MatchmakingTcgBotDecks.ts
@@ -30,6 +30,9 @@ export const MATCHMAKING_TCG_BOT_DECKS: readonly string[] = [
  * bootstrap wiring stays declarative and the selection is unit-testable.
  */
 export function pickRandomTcgBotDeck(random: () => number = Math.random): string {
-	const index = Math.floor(random() * MATCHMAKING_TCG_BOT_DECKS.length);
+	const len = MATCHMAKING_TCG_BOT_DECKS.length;
+	// Clamp to the last valid index: Math.floor(random() * len) would yield `len`
+	// (an out-of-range, undefined element) if random() ever returns exactly 1.0.
+	const index = Math.min(Math.floor(random() * len), len - 1);
 	return MATCHMAKING_TCG_BOT_DECKS[index];
 }

--- a/src/ygopro/matchmaking/domain/MatchmakingTcgBotDecks.ts
+++ b/src/ygopro/matchmaking/domain/MatchmakingTcgBotDecks.ts
@@ -1,0 +1,35 @@
+/**
+ * Curated pool of TCG-legal deck names for matchmaking bot fallback.
+ *
+ * Matchmaking v1 rooms are created as TCG (rule 1 + TCG banlist), so a bot
+ * dropped into one MUST play a deck that passes the active TCG deck-check —
+ * otherwise the duel cannot start and the human is ejected. The server-side
+ * botlist (config/botlist.example.json) is format-blind, so the format-correct
+ * deck is chosen HERE and passed as a deckOverride when spawning the bot.
+ *
+ * Each string maps to an existing windbot deck file: windbot normalizes the
+ * deck string by stripping spaces and wrapping it as `AI_<DeckNoSpaces>.ydk`
+ * (e.g. "Toadally Awesome" -> AI_ToadallyAwesome.ydk). Every entry below was
+ * verified against windbot/Decks/AI_*.ydk and windbot/bots.json.
+ *
+ * IMPORTANT: These must be legal for the active TCG banlist (2026.05); adjust
+ * if the deck-check rejects any.
+ */
+export const MATCHMAKING_TCG_BOT_DECKS: readonly string[] = [
+	"Salamangreat", // AI_Salamangreat.ydk
+	"SkyStriker", // AI_SkyStriker.ydk
+	"Labrynth", // AI_Labrynth.ydk
+	"Yubel", // AI_Yubel.ydk
+	"Swordsoul", // AI_Swordsoul.ydk
+	"Ryzeal", // AI_Ryzeal.ydk
+	"Maliss", // AI_Maliss.ydk
+];
+
+/**
+ * Picks a random deck from the TCG pool. Kept as a tiny helper so the
+ * bootstrap wiring stays declarative and the selection is unit-testable.
+ */
+export function pickRandomTcgBotDeck(random: () => number = Math.random): string {
+	const index = Math.floor(random() * MATCHMAKING_TCG_BOT_DECKS.length);
+	return MATCHMAKING_TCG_BOT_DECKS[index];
+}

--- a/src/ygopro/matchmaking/domain/QueueEntry.ts
+++ b/src/ygopro/matchmaking/domain/QueueEntry.ts
@@ -8,6 +8,14 @@
 export const QUEUE_TTL_MS = 8_000;
 export const BOT_FALLBACK_MS = 15_000;
 export const CLEANUP_INTERVAL_MS = 2_000;
+/**
+ * Grace window a matched entry is retained after pairing. Within it, a client
+ * that re-polls still gets its `matched` result (idempotency); once it elapses
+ * the sweep drops the entry and frees the user so they can queue again — even if
+ * the client never polled the final result. This only reaps the QUEUE bookkeeping;
+ * the created room is owned/reaped separately by MatchmakingRoomReaper.
+ */
+export const MATCHED_GRACE_MS = 30_000;
 
 /** v1 supports a single format/queue combination. Kept as constants so the
  * pairing predicate (same format) is explicit rather than magic strings. */
@@ -33,6 +41,9 @@ export interface QueueEntry {
 	/** Refreshed on every status poll; the TTL sweep drops entries that fall behind. */
 	lastPollAt: number;
 	state: QueueEntryState;
+	/** Set when the entry transitions to `matched`; drives the grace-window sweep
+	 * that frees the user (MATCHED_GRACE_MS) regardless of client polling. */
+	matchedAt?: number;
 	/** Set once matched — the exact string the client sends in CTOS_JOIN_GAME { pass }. */
 	roomPassword?: string;
 	opponentType?: OpponentType;

--- a/src/ygopro/matchmaking/domain/QueueEntry.ts
+++ b/src/ygopro/matchmaking/domain/QueueEntry.ts
@@ -1,0 +1,41 @@
+/**
+ * Matchmaking queue tunables. Mirrors the values in the shared contract
+ * (evolution-card-game/docs/architecture/matchmaking-contract.md):
+ *  - the client short-polls status every ~2s; that poll doubles as the heartbeat.
+ *  - a ticket that misses the poll window is dropped (TTL).
+ *  - a ticket with no human match within the bot-fallback window gets a bot game.
+ */
+export const QUEUE_TTL_MS = 8_000;
+export const BOT_FALLBACK_MS = 15_000;
+export const CLEANUP_INTERVAL_MS = 2_000;
+
+/** v1 supports a single format/queue combination. Kept as constants so the
+ * pairing predicate (same format) is explicit rather than magic strings. */
+export const SUPPORTED_FORMAT = "tcg" as const;
+export const SUPPORTED_QUEUE = "ranked" as const;
+
+export type MatchmakingFormat = typeof SUPPORTED_FORMAT;
+
+export type OpponentType = "human" | "bot";
+
+/**
+ * A ticket's lifecycle state. `searching` entries are candidates for pairing
+ * and bot fallback; `matched` entries carry the join password the client needs.
+ */
+export type QueueEntryState = "searching" | "matched";
+
+export interface QueueEntry {
+	readonly ticketId: string;
+	/** Identity resolved from the auth ticket. Enforces one active entry per user. */
+	readonly userId: string;
+	readonly format: MatchmakingFormat;
+	readonly enteredAt: number;
+	/** Refreshed on every status poll; the TTL sweep drops entries that fall behind. */
+	lastPollAt: number;
+	state: QueueEntryState;
+	/** Set once matched — the exact string the client sends in CTOS_JOIN_GAME { pass }. */
+	roomPassword?: string;
+	opponentType?: OpponentType;
+	opponentName?: string;
+	rated?: boolean;
+}

--- a/src/ygopro/room/application/join-strategies/AIJoinTokenStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/AIJoinTokenStrategy.test.ts
@@ -217,6 +217,26 @@ describe("AIJoinTokenStrategy", () => {
 				expect(roomEmitSpy).toHaveBeenCalledWith("JOIN", expect.anything(), ctx.socket);
 			});
 
+			it("marks the room as an AI room (noHost + noReconnect) so it tears down when the human leaves", async () => {
+				const { room, emitter } = createRoomInList();
+				const token = tokenStore.register(room.id, "Anna", "Anna.ydk");
+
+				jest.spyOn(room, "emit").mockImplementation(() => undefined);
+
+				const mod = makeModule(tokenStore);
+				const strategy = new AIJoinTokenStrategy(mod);
+
+				const ctx = makeCtx(`AIJOIN#${token}`, {
+					eventEmitter: emitter,
+					messageRepository: makeMessageRepository() as never,
+				});
+
+				expect(room.noHost).toBe(false);
+				await strategy.handle(ctx);
+				expect(room.noHost).toBe(true);
+				expect(room.noReconnect).toBe(true);
+			});
+
 			it("finds the room by roomId from the token payload", async () => {
 				const { room, emitter } = createRoomInList();
 				const token = tokenStore.register(room.id, "Anna", "Anna.ydk");

--- a/src/ygopro/room/application/join-strategies/AIJoinTokenStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/AIJoinTokenStrategy.ts
@@ -60,6 +60,15 @@ export class AIJoinTokenStrategy implements JoinStrategy {
 			return;
 		}
 
+		// A bot has joined — this room is now an AI room. Mark it noHost so the
+		// DisconnectHandler tears it down when the (only) human leaves, and
+		// noReconnect since a bot practice game is not reconnectable. Mirrors
+		// WindBotJoinStrategy: the classic vs-AI path sets these at creation, but
+		// matchmaking bot rooms are created generically and only become AI rooms
+		// when the windbot connects here.
+		room.noHost = true;
+		room.noReconnect = true;
+
 		// Emit JOIN for the bot client — the waiting state will call createPlayerUnsafe + addPlayerUnsafe
 		// (or createSpectatorUnsafe if slots are full, but for a windbot room there should be a free slot).
 		// handleJoin queues the player creation on room.mutex.

--- a/src/ygopro/windbot/application/RequestWindBotJoin.test.ts
+++ b/src/ygopro/windbot/application/RequestWindBotJoin.test.ts
@@ -76,6 +76,32 @@ describe("RequestWindBotJoin", () => {
 			const payload = tokenStore.consume(token);
 			expect(payload.deck).toBe("CustomDeck.ydk");
 		});
+
+		it("clears deckcode on override so windbot cannot ignore the override deck", () => {
+			// windbot honors `deckcode` over `deck`. If the source bot carries a
+			// deckcode, the returned bot MUST drop it so the override actually applies
+			// (otherwise the bot plays its original, possibly non-TCG deck → deck-check
+			// ejection). See RequestWindBotJoin W1 fix.
+			const bot = makeBot({ deck: "Anna.ydk", deckcode: "SomeBase64OriginalDeck" });
+			const repo = makeRepo({ findByName: jest.fn().mockReturnValue(bot) });
+			const useCase = new RequestWindBotJoin(repo, tokenStore);
+
+			const result = useCase.execute(1, "Anna", "CustomDeck.ydk");
+
+			expect(result.bot.deck).toBe("CustomDeck.ydk");
+			expect(result.bot.deckcode).toBeUndefined();
+		});
+
+		it("preserves deckcode when no override is provided", () => {
+			// The no-override path must NOT mutate the source bot's deckcode.
+			const bot = makeBot({ deck: "Anna.ydk", deckcode: "SomeBase64OriginalDeck" });
+			const repo = makeRepo({ findByName: jest.fn().mockReturnValue(bot) });
+			const useCase = new RequestWindBotJoin(repo, tokenStore);
+
+			const result = useCase.execute(1, "Anna");
+
+			expect(result.bot.deckcode).toBe("SomeBase64OriginalDeck");
+		});
 	});
 
 	describe("random bot selection", () => {

--- a/src/ygopro/windbot/application/RequestWindBotJoin.ts
+++ b/src/ygopro/windbot/application/RequestWindBotJoin.ts
@@ -24,7 +24,12 @@ export class RequestWindBotJoin {
 		// The override must reach BOTH the token store AND the bot the provider
 		// fires to windbot (buildUrl reads bot.deck for the `deck=` query param),
 		// otherwise the bot would still play its original, possibly non-TCG deck.
-		const bot: WindbotData = deckOverride ? { ...resolved, deck: deckOverride } : resolved;
+		// We MUST also clear deckcode: windbot honors `deckcode` over `deck`, so a
+		// source bot carrying a deckcode would ignore the override and play its
+		// original (possibly non-TCG) deck, failing the room's deck-check.
+		const bot: WindbotData = deckOverride
+			? { ...resolved, deck: deckOverride, deckcode: undefined }
+			: resolved;
 		const token = this.tokenStore.register(roomId, bot.name, deck);
 		return { token, bot };
 	}

--- a/src/ygopro/windbot/application/RequestWindBotJoin.ts
+++ b/src/ygopro/windbot/application/RequestWindBotJoin.ts
@@ -19,8 +19,12 @@ export class RequestWindBotJoin {
 		botNameOrNull: string | null,
 		deckOverride?: string,
 	): RequestWindBotJoinResult {
-		const bot = this._resolveBot(botNameOrNull);
-		const deck = deckOverride ?? bot.deck;
+		const resolved = this._resolveBot(botNameOrNull);
+		const deck = deckOverride ?? resolved.deck;
+		// The override must reach BOTH the token store AND the bot the provider
+		// fires to windbot (buildUrl reads bot.deck for the `deck=` query param),
+		// otherwise the bot would still play its original, possibly non-TCG deck.
+		const bot: WindbotData = deckOverride ? { ...resolved, deck: deckOverride } : resolved;
 		const token = this.tokenStore.register(roomId, bot.name, deck);
 		return { token, bot };
 	}

--- a/src/ygopro/windbot/application/WindbotModule.test.ts
+++ b/src/ygopro/windbot/application/WindbotModule.test.ts
@@ -108,6 +108,41 @@ describe("WindbotModule", () => {
 			await expect(mod.requestBot(42, "Anna", () => false)).rejects.toBe(unreachable);
 		});
 
+		it("forwards deckOverride to the provider so the bot plays the requested deck", async () => {
+			const provider = makeProvider();
+			// pickRandom returns a non-TCG bot; the override must replace its deck.
+			const repo = makeRepo({
+				pickRandom: jest.fn().mockReturnValue(makeBot({ name: "Joey", deck: "JTP" })),
+			});
+			const mod = WindbotModule.createForTests(
+				makeDeps({ provider: provider as unknown as WindbotModuleDeps["provider"], repo }),
+			);
+
+			const result = await mod.requestBot(7, null, () => false, "Salamangreat");
+
+			const call = provider.requestJoin.mock.calls[0][0];
+			expect(call.bot.deck).toBe("Salamangreat");
+			expect(result.bot.deck).toBe("Salamangreat");
+			// The bot identity (name) is preserved; only the deck is overridden.
+			expect(result.bot.name).toBe("Joey");
+		});
+
+		it("uses the bot's own deck when no deckOverride is given", async () => {
+			const provider = makeProvider();
+			const repo = makeRepo({
+				pickRandom: jest.fn().mockReturnValue(makeBot({ name: "Joey", deck: "JTP" })),
+			});
+			const mod = WindbotModule.createForTests(
+				makeDeps({ provider: provider as unknown as WindbotModuleDeps["provider"], repo }),
+			);
+
+			const result = await mod.requestBot(7, null, () => false);
+
+			const call = provider.requestJoin.mock.calls[0][0];
+			expect(call.bot.deck).toBe("JTP");
+			expect(result.bot.deck).toBe("JTP");
+		});
+
 		it("selects random bot when botNameOrNull is null", async () => {
 			const provider = makeProvider();
 			const randomBot = makeBot({ name: "Gear", deck: "Gear.ydk" });

--- a/src/ygopro/windbot/application/WindbotModule.ts
+++ b/src/ygopro/windbot/application/WindbotModule.ts
@@ -123,8 +123,9 @@ export class WindbotModule {
 		roomId: number,
 		botNameOrNull: string | null,
 		isFinalizing: () => boolean,
+		deckOverride?: string,
 	): Promise<{ token: string; bot: WindbotData }> {
-		const { token, bot } = this.requestJoinUseCase.execute(roomId, botNameOrNull);
+		const { token, bot } = this.requestJoinUseCase.execute(roomId, botNameOrNull, deckOverride);
 
 		try {
 			await this.deps.provider.requestJoin({ token, bot, isFinalizing });


### PR DESCRIPTION
## Description / Descripción

Server-side matchmaking: an auto-pairing queue that matches players by format over HTTP (colocated with the rooms API). **v1 scope: TCG · ranked · single.** Two searching players of the same format are paired into a ranked room; a player waiting >15s with no human is matched against a **windbot** in an **unrated** practice room.

Endpoints:
- `POST /api/matchmaking/queue` `{ format, queue, ticket }` → `{ ticketId }`
- `GET /api/matchmaking/status?ticketId=…` → `searching | matched { roomPassword, opponentType, rated }`
- `DELETE /api/matchmaking/queue?ticketId`

Pairs with the frontend Quick Match PR in `evolution-card-game`. Full contract: `docs/architecture/matchmaking-contract.md` (frontend PR).

## Related Issue(s) / Issue(s) relacionado(s)

Tracked in Fibery — matchmaking (TCG ranked v1).

## Checklist

- [x] My code follows the project style and guidelines
- [x] I have added tests (queue pairing/TTL/bot-fallback, room factory, controllers, AI-room teardown, deckcode override)
- [x] Documentation updated (contract reference in the paired frontend PR)
- [x] The PR title is descriptive

## Additional Notes / Notas adicionales

- **Queue**: in-memory singleton, synchronous tick, `unref()`'d timers. Matched entries freed after a grace window (poll-based) so users can re-queue; orphaned/empty rooms reaped after a join grace.
- **Bot fallback**: reuses the existing windbot spawn; serves a **TCG-legal** deck via `deckOverride` (clears any stale `deckcode`); bot rooms are Casual/unrated and marked AI (`noHost`) so they tear down when the human leaves.
- **Join string** fits the 20-char `CTOS_JOIN_GAME` pass field (`to,mm<5>#<7>`).
- **Verified end-to-end** (curl + browser): human pairing (same roomPassword), 15s bot fallback, windbot join, leave-teardown.
- **Deferred v1**: full auth on status/cancel (rate-limited today); operator must confirm the 7 TCG bot decks are legal for the active 2026.05 banlist.
- Tests: full suite green; `tsc --noEmit` clean.