### PR TITLE
fix(matchmaking): abort incomplete room reservations

### DIFF
--- a/src/bootstrap/bootstrapMatchmaking.ts
+++ b/src/bootstrap/bootstrapMatchmaking.ts
@@ -4,10 +4,10 @@ import { Logger } from "@shared/logger/domain/Logger";
 
 import { createMatchmakingRoom } from "@ygopro/matchmaking/application/MatchmakingRoomFactory";
 import { MatchmakingRoomReaper } from "@ygopro/matchmaking/application/MatchmakingRoomReaper";
+import { AbortMatchmakingRoom } from "@ygopro/matchmaking/application/AbortMatchmakingRoom";
 import { pickBotFromRoster } from "@ygopro/matchmaking/domain/MatchmakingBotRoster";
 import { CLEANUP_INTERVAL_MS, MatchmakingFormat } from "@ygopro/matchmaking/domain/QueueEntry";
 import { MatchmakingQueue } from "@ygopro/matchmaking/domain/MatchmakingQueue";
-import { FinalizeYGOProRoom } from "@ygopro/room/application/FinalizeYGOProRoom";
 import YGOProRoomList from "@ygopro/room/infrastructure/YGOProRoomList";
 import { WindbotModule } from "@ygopro/windbot/application/WindbotModule";
 
@@ -29,21 +29,21 @@ export function bootstrapMatchmaking(logger: Logger): void {
 	// canonical teardown as every other reap path.
 	const reaper = new MatchmakingRoomReaper({
 		now: () => Date.now(),
-		finalize: (room) => FinalizeYGOProRoom.run(room),
+		finalize: (room) => AbortMatchmakingRoom.run(room),
 	});
 
 	MatchmakingQueue.init({
 		now: () => Date.now(),
 
 		createRankedRoom: (format: MatchmakingFormat) => {
-			const { roomPassword } = createMatchmakingRoom({
+			const { room, roomPassword } = createMatchmakingRoom({
 				format,
 				rankedOverride: true,
 				logger: mmLogger,
 				emitter: new EventEmitter(),
 				onRoomCreated: (room) => reaper.track(room),
 			});
-			return { roomPassword };
+			return { roomId: room.id, roomPassword };
 		},
 
 		createBotRoom: (format: MatchmakingFormat) => {
@@ -84,7 +84,7 @@ export function bootstrapMatchmaking(logger: Logger): void {
 							error instanceof Error ? error.message : String(error)
 						}`,
 					);
-					YGOProRoomList.deleteRoom(room);
+					AbortMatchmakingRoom.run(room);
 				});
 		},
 

--- a/src/http-server/controllers/CancelMatchmakingController.test.ts
+++ b/src/http-server/controllers/CancelMatchmakingController.test.ts
@@ -22,7 +22,7 @@ function fakeResponse(): { res: Response; body: () => unknown; status: () => num
 
 const makeDeps = () => ({
 	now: () => 0,
-	createRankedRoom: () => ({ roomPassword: "to,mm-r#pw" }),
+	createRankedRoom: () => ({ roomId: 1, roomPassword: "to,mm-r#pw" }),
 	createBotRoom: () => ({ roomPassword: "to,mm-b#pw", roomId: 1 }),
 	spawnBot: jest.fn(),
 });

--- a/src/http-server/controllers/EnqueueMatchmakingController.test.ts
+++ b/src/http-server/controllers/EnqueueMatchmakingController.test.ts
@@ -37,7 +37,7 @@ function fakeResponse(): { res: Response; body: () => unknown; status: () => num
 
 const makeDeps = () => ({
 	now: () => 0,
-	createRankedRoom: () => ({ roomPassword: "to,mm-r#pw" }),
+	createRankedRoom: () => ({ roomId: 1, roomPassword: "to,mm-r#pw" }),
 	createBotRoom: () => ({ roomPassword: "to,mm-b#pw", roomId: 1 }),
 	spawnBot: jest.fn(),
 });

--- a/src/http-server/controllers/MatchmakingStatusController.test.ts
+++ b/src/http-server/controllers/MatchmakingStatusController.test.ts
@@ -22,7 +22,7 @@ function fakeResponse(): { res: Response; body: () => unknown; status: () => num
 
 const makeDeps = () => ({
 	now: () => 0,
-	createRankedRoom: () => ({ roomPassword: "to,mm-r#pw" }),
+	createRankedRoom: () => ({ roomId: 1, roomPassword: "to,mm-r#pw" }),
 	createBotRoom: () => ({ roomPassword: "to,mm-b#pw", roomId: 1 }),
 	spawnBot: jest.fn(),
 });

--- a/src/shared/room/application/DisconnectHandler.ts
+++ b/src/shared/room/application/DisconnectHandler.ts
@@ -13,6 +13,7 @@ import { ISocket } from "../../socket/domain/ISocket";
 import { DuelState } from "../domain/YgoRoom";
 import { RoomFinder } from "./RoomFinder";
 import { FinalizeYGOProRoom } from "@ygopro/room/application/FinalizeYGOProRoom";
+import { AbortMatchmakingRoom } from "@ygopro/matchmaking/application/AbortMatchmakingRoom";
 
 export class DisconnectHandler {
 	constructor(
@@ -108,6 +109,14 @@ export class DisconnectHandler {
 	}
 
 	private handleYGOPro(room: YGOProRoom): void {
+		// A matchmaking reservation owns the whole two-player WAITING lobby. If
+		// either socket leaves, close the room and release both queue identities;
+		// the connected survivor will immediately re-enter the pool client-side.
+		if (room.isMatchmaking && room.duelState === DuelState.WAITING) {
+			AbortMatchmakingRoom.run(room);
+			return;
+		}
+
 		// On `close` the leaver's socket is already closed, so this also catches
 		// the last WAITING player leaving — finalize instead of leaking a zombie.
 		if (room.hasNoConnectedPlayers) {

--- a/src/shared/room/application/DisconnectHandlerAIRoomTeardown.test.ts
+++ b/src/shared/room/application/DisconnectHandlerAIRoomTeardown.test.ts
@@ -28,6 +28,7 @@ import { YGOProClient } from "@ygopro/client/domain/YGOProClient";
 import { YGOProRoom } from "@ygopro/room/domain/YGOProRoom";
 import MercuryRoomList from "@ygopro/room/infrastructure/YGOProRoomList";
 import WebSocketSingleton from "../../../web-socket-server/WebSocketSingleton";
+import { MatchmakingQueue } from "@ygopro/matchmaking/domain/MatchmakingQueue";
 
 // ---------- helpers ----------
 
@@ -110,6 +111,7 @@ describe("DisconnectHandler.handleYGOPro() — AI room teardown", () => {
 	});
 
 	afterEach(() => {
+		MatchmakingQueue.resetForTests();
 		jest.restoreAllMocks();
 		const rooms = MercuryRoomList.getRooms();
 		while (rooms.length) {
@@ -163,6 +165,37 @@ describe("DisconnectHandler.handleYGOPro() — AI room teardown", () => {
 			expect(mockInstance.broadcast).not.toHaveBeenCalledWith(
 				expect.objectContaining({ action: "REMOVE-ROOM" }),
 			);
+		});
+
+		it("aborts a matchmaking lobby, closes the survivor, and frees both queue users", () => {
+			const leaverId = "sock-matchmaking-leaver";
+			const leaver = makeClient(leaverId, true);
+			const survivor = makeClient("sock-matchmaking-survivor", false);
+			const room = createAIRoom(leaverId, DuelState.WAITING, false, [leaver, survivor]);
+			room.isMatchmaking = true;
+
+			MatchmakingQueue.init({
+				now: () => 0,
+				createRankedRoom: () => ({
+					roomId: room.id,
+					roomPassword: `${room.name}#${room.password}`,
+				}),
+				createBotRoom: () => ({
+					roomId: 9999,
+					roomPassword: "to,bot#pw",
+				}),
+				spawnBot: jest.fn(),
+			});
+			const queue = MatchmakingQueue.getInstance();
+			queue.enqueue({ ticketId: "ticket-a", userId: "user-a", format: "tcg" });
+			queue.enqueue({ ticketId: "ticket-b", userId: "user-b", format: "tcg" });
+
+			runDisconnect(room, leaverId);
+
+			expect(queue.get("ticket-a")).toBeUndefined();
+			expect(queue.get("ticket-b")).toBeUndefined();
+			expect((survivor as unknown as { destroy: jest.Mock }).destroy).toHaveBeenCalledTimes(1);
+			expect(MercuryRoomList.findById(room.id)).toBeNull();
 		});
 	});
 });

--- a/src/ygopro/matchmaking/application/AbortMatchmakingRoom.ts
+++ b/src/ygopro/matchmaking/application/AbortMatchmakingRoom.ts
@@ -1,0 +1,19 @@
+import { MatchmakingQueue } from "@ygopro/matchmaking/domain/MatchmakingQueue";
+import { FinalizeYGOProRoom } from "@ygopro/room/application/FinalizeYGOProRoom";
+import { YGOProRoom } from "@ygopro/room/domain/YGOProRoom";
+
+/**
+ * Atomically abort an incomplete matchmaking lobby.
+ *
+ * Queue reservations must be released before sockets are closed: the surviving
+ * client reacts to that close by immediately re-entering matchmaking, and would
+ * otherwise collide with its old matched entry (`409 Already in queue`).
+ */
+export class AbortMatchmakingRoom {
+	static run(room: YGOProRoom): void {
+		if (MatchmakingQueue.isInitialized()) {
+			MatchmakingQueue.getInstance().abortRoom(room.id);
+		}
+		FinalizeYGOProRoom.run(room);
+	}
+}

--- a/src/ygopro/matchmaking/application/MatchmakingRoomFactory.test.ts
+++ b/src/ygopro/matchmaking/application/MatchmakingRoomFactory.test.ts
@@ -37,6 +37,7 @@ describe("createMatchmakingRoom", () => {
 		expect(room.ranked).toBe(true);
 		// rule 1 = strict TCG (from the "to" token)
 		expect(room.hostInfo.rule).toBe(1);
+		expect(room.isMatchmaking).toBe(true);
 		expect(YGOProRoomList.findById(room.id)).toBe(room);
 	});
 

--- a/src/ygopro/matchmaking/application/MatchmakingRoomFactory.ts
+++ b/src/ygopro/matchmaking/application/MatchmakingRoomFactory.ts
@@ -129,6 +129,7 @@ export function createMatchmakingRoom(input: CreateMatchmakingRoomInput): Matchm
 	);
 
 	YGOProRoomList.addRoom(room);
+	room.isMatchmaking = true;
 	room.waiting();
 
 	// Register with the empty-room reaper (if wired) so an unjoined room does not

--- a/src/ygopro/matchmaking/application/MatchmakingRoomReaper.test.ts
+++ b/src/ygopro/matchmaking/application/MatchmakingRoomReaper.test.ts
@@ -7,7 +7,7 @@ import {
 
 // A minimal room stand-in — the reaper only reads `id` and `playersCount`.
 const makeRoom = (id: number, playersCount = 0): YGOProRoom =>
-	({ id, playersCount }) as unknown as YGOProRoom;
+	({ id, playersCount, finalizing: false }) as unknown as YGOProRoom;
 
 const makeReaper = (overrides: Partial<MatchmakingRoomReaperDeps> = {}) => {
 	const clock = { t: 0 };
@@ -34,20 +34,55 @@ describe("MatchmakingRoomReaper", () => {
 		expect(reaper.size).toBe(0);
 	});
 
-	it("does NOT finalize a room that has been joined (playersCount > 0)", () => {
+	it("keeps tracking a partially joined room before the grace window", () => {
 		const clock = { t: 0 };
 		const finalize = jest.fn();
 		const reaper = new MatchmakingRoomReaper({ now: () => clock.t, finalize });
-		// Room object whose playersCount flips to 1 after a client joins.
 		const room = { id: 2, playersCount: 0 } as unknown as YGOProRoom;
 
 		reaper.track(room);
 		(room as unknown as { playersCount: number }).playersCount = 1;
+		clock.t = MATCHMAKING_ROOM_JOIN_GRACE_MS - 1;
+		reaper.sweep();
+
+		expect(finalize).not.toHaveBeenCalled();
+		expect(reaper.size).toBe(1);
+	});
+
+	it("finalizes a partially joined room after the grace window", () => {
+		const { reaper, finalize, clock } = makeReaper();
+		const room = makeRoom(5, 1);
+
+		reaper.track(room);
+		clock.t = MATCHMAKING_ROOM_JOIN_GRACE_MS + 1;
+		reaper.sweep();
+
+		expect(finalize).toHaveBeenCalledTimes(1);
+		expect(finalize).toHaveBeenCalledWith(room);
+		expect(reaper.size).toBe(0);
+	});
+
+	it("stops tracking a room only after both players join", () => {
+		const { reaper, finalize, clock } = makeReaper();
+		const room = makeRoom(6, 2);
+
+		reaper.track(room);
 		clock.t = MATCHMAKING_ROOM_JOIN_GRACE_MS + 1;
 		reaper.sweep();
 
 		expect(finalize).not.toHaveBeenCalled();
-		// Ownership handed back to the normal lifecycle: no longer tracked.
+		expect(reaper.size).toBe(0);
+	});
+
+	it("drops an already finalized room without finalizing it twice", () => {
+		const { reaper, finalize } = makeReaper();
+		const room = makeRoom(7, 1);
+		room.finalizing = true;
+
+		reaper.track(room);
+		reaper.sweep();
+
+		expect(finalize).not.toHaveBeenCalled();
 		expect(reaper.size).toBe(0);
 	});
 

--- a/src/ygopro/matchmaking/application/MatchmakingRoomReaper.ts
+++ b/src/ygopro/matchmaking/application/MatchmakingRoomReaper.ts
@@ -28,10 +28,9 @@ export interface MatchmakingRoomReaperDeps {
  * player connects. If no real client ever joins (rage-quit, ticket expiry, network
  * drop), nothing else reaps it — the normal reap paths key off a real socket.
  *
- * On each sweep, any tracked room still empty (playersCount === 0) past the grace
- * window is torn down via the injected finalize (the existing FinalizeYGOProRoom
- * path in production). A room that has since been joined is left alone and dropped
- * from tracking — its own lifecycle now owns teardown.
+ * On each sweep, any room that still lacks one of its two participants past the
+ * grace window is torn down via the injected finalize callback. Ownership is
+ * handed to the normal room lifecycle only after both participants have joined.
  */
 export class MatchmakingRoomReaper {
 	private readonly tracked = new Map<number, TrackedRoom>();
@@ -46,13 +45,17 @@ export class MatchmakingRoomReaper {
 		this.tracked.set(room.id, { room, registeredAt: this.deps.now() });
 	}
 
-	/** Reap every tracked room still empty past the grace window; stop tracking any
-	 * room that has been joined (its own lifecycle owns teardown from here). */
+	/** Reap every incomplete room past the grace window; stop tracking only once
+	 * both matchmaking participants have joined. */
 	sweep(): void {
 		const now = this.deps.now();
 		for (const [id, tracked] of this.tracked) {
-			if (tracked.room.playersCount > 0) {
-				// A real client joined — hand ownership back to the normal lifecycle.
+			if (tracked.room.finalizing) {
+				this.tracked.delete(id);
+				continue;
+			}
+			if (tracked.room.playersCount >= 2) {
+				// Both clients joined — hand ownership back to the normal lifecycle.
 				this.tracked.delete(id);
 				continue;
 			}

--- a/src/ygopro/matchmaking/domain/MatchmakingQueue.test.ts
+++ b/src/ygopro/matchmaking/domain/MatchmakingQueue.test.ts
@@ -9,7 +9,7 @@ const makeDeps = (overrides: Partial<MatchmakingQueueDeps> = {}): MatchmakingQue
 		now: () => 0,
 		createRankedRoom: () => {
 			roomSeq += 1;
-			return { roomPassword: `to,mm-r${roomSeq}#pw${roomSeq}` };
+			return { roomId: roomSeq, roomPassword: `to,mm-r${roomSeq}#pw${roomSeq}` };
 		},
 		createBotRoom: () => {
 			roomSeq += 1;
@@ -126,9 +126,34 @@ describe("MatchmakingQueue", () => {
 		});
 	});
 
+	describe("abortRoom", () => {
+		it("releases both users from an aborted matched room so they can queue again", () => {
+			const queue = MatchmakingQueue.createForTests(
+				makeDeps({
+					createRankedRoom: () => ({
+						roomId: 4242,
+						roomPassword: "to,mm-r1#pw1",
+					}),
+				}),
+			);
+			enqueue(queue, "t1", "user-1");
+			enqueue(queue, "t2", "user-2");
+
+			expect(queue.get("t1")?.state).toBe("matched");
+			expect(queue.get("t2")?.state).toBe("matched");
+
+			expect(queue.abortRoom(4242)).toBe(2);
+			expect(queue.get("t1")).toBeUndefined();
+			expect(queue.get("t2")).toBeUndefined();
+			expect(() => enqueue(queue, "t3", "user-1")).not.toThrow();
+		});
+	});
+
 	describe("tick — pairing", () => {
 		it("pairs two searching entries of the same format into one ranked room", () => {
-			const createRankedRoom = jest.fn().mockReturnValue({ roomPassword: "to,mm-r1#pw1" });
+			const createRankedRoom = jest
+				.fn()
+				.mockReturnValue({ roomId: 1, roomPassword: "to,mm-r1#pw1" });
 			const queue = MatchmakingQueue.createForTests(makeDeps({ createRankedRoom }));
 			enqueue(queue, "t1", "user-1");
 			enqueue(queue, "t2", "user-2");
@@ -148,7 +173,9 @@ describe("MatchmakingQueue", () => {
 		});
 
 		it("does not pair an already matched entry again", () => {
-			const createRankedRoom = jest.fn().mockReturnValue({ roomPassword: "to,mm-r1#pw1" });
+			const createRankedRoom = jest
+				.fn()
+				.mockReturnValue({ roomId: 1, roomPassword: "to,mm-r1#pw1" });
 			const queue = MatchmakingQueue.createForTests(makeDeps({ createRankedRoom }));
 			enqueue(queue, "t1", "user-1");
 			enqueue(queue, "t2", "user-2");
@@ -233,7 +260,9 @@ describe("MatchmakingQueue", () => {
 
 		it("prefers pairing two humans over a bot even past the fallback window", () => {
 			const clock = { t: 0 };
-			const createRankedRoom = jest.fn().mockReturnValue({ roomPassword: "to,mm-r1#pw1" });
+			const createRankedRoom = jest
+				.fn()
+				.mockReturnValue({ roomId: 1, roomPassword: "to,mm-r1#pw1" });
 			const createBotRoom = jest.fn();
 			const queue = MatchmakingQueue.createForTests(
 				makeDeps({ now: () => clock.t, createRankedRoom, createBotRoom }),
@@ -301,7 +330,7 @@ describe("MatchmakingQueue", () => {
 			const createRankedRoom = jest.fn(() => {
 				call += 1;
 				if (call === 1) throw new Error("first pair boom");
-				return { roomPassword: `to,mm-r${call}#pw${call}` };
+				return { roomId: call, roomPassword: `to,mm-r${call}#pw${call}` };
 			});
 			const queue = MatchmakingQueue.createForTests(
 				makeDeps({ createRankedRoom, onRoomCreationError: jest.fn() }),

--- a/src/ygopro/matchmaking/domain/MatchmakingQueue.ts
+++ b/src/ygopro/matchmaking/domain/MatchmakingQueue.ts
@@ -10,6 +10,8 @@ import {
 export interface RankedRoomHandle {
 	/** The exact string a client sends in CTOS_JOIN_GAME { pass } to land in this room. */
 	roomPassword: string;
+	/** Concrete room id used to invalidate both reservations if the lobby aborts. */
+	roomId: number;
 }
 
 export interface BotRoomHandle extends RankedRoomHandle {
@@ -191,9 +193,25 @@ export class MatchmakingQueue {
 		if (!entry) {
 			return false;
 		}
-		this.entries.delete(ticketId);
-		this.usersInQueue.delete(entry.userId);
+		this.removeEntry(entry);
 		return true;
+	}
+
+	/**
+	 * Release every matched reservation owned by an incomplete room.
+	 *
+	 * The room lifecycle calls this before finalizing a matchmaking lobby. Both
+	 * users are freed together so the connected survivor can immediately obtain
+	 * a fresh ticket and re-enter the pool instead of receiving HTTP 409.
+	 */
+	abortRoom(roomId: number): number {
+		let removed = 0;
+		for (const entry of [...this.entries.values()]) {
+			if (entry.roomId !== roomId) continue;
+			this.removeEntry(entry);
+			removed += 1;
+		}
+		return removed;
 	}
 
 	get(ticketId: string): QueueEntry | undefined {
@@ -253,9 +271,9 @@ export class MatchmakingQueue {
 				// On failure, leave BOTH entries searching (a retry next tick, or a
 				// bot fallback / TTL drop, will resolve them) and move on.
 				try {
-					const { roomPassword } = this.deps.createRankedRoom(a.format);
-					this.markMatched(a, roomPassword, "human", true, b.userId);
-					this.markMatched(b, roomPassword, "human", true, a.userId);
+					const { roomPassword, roomId } = this.deps.createRankedRoom(a.format);
+					this.markMatched(a, roomPassword, "human", true, b.userId, roomId);
+					this.markMatched(b, roomPassword, "human", true, a.userId, roomId);
 				} catch (error) {
 					this.deps.onRoomCreationError?.(error);
 				}
@@ -280,7 +298,7 @@ export class MatchmakingQueue {
 			// later tick retries, or the TTL sweep drops it) and continue with the rest.
 			try {
 				const { roomPassword, roomId } = this.deps.createBotRoom(entry.format);
-				this.markMatched(entry, roomPassword, "bot", false);
+				this.markMatched(entry, roomPassword, "bot", false, undefined, roomId);
 				this.deps.spawnBot(roomId, entry.format);
 			} catch (error) {
 				this.deps.onRoomCreationError?.(error);
@@ -294,12 +312,19 @@ export class MatchmakingQueue {
 		opponentType: "human" | "bot",
 		rated: boolean,
 		opponentName?: string,
+		roomId?: number,
 	): void {
 		entry.state = "matched";
 		entry.matchedAt = this.deps.now();
 		entry.roomPassword = roomPassword;
+		entry.roomId = roomId;
 		entry.opponentType = opponentType;
 		entry.rated = rated;
 		entry.opponentName = opponentName;
+	}
+
+	private removeEntry(entry: QueueEntry): void {
+		this.entries.delete(entry.ticketId);
+		this.usersInQueue.delete(entry.userId);
 	}
 }

--- a/src/ygopro/matchmaking/domain/QueueEntry.ts
+++ b/src/ygopro/matchmaking/domain/QueueEntry.ts
@@ -46,6 +46,9 @@ export interface QueueEntry {
 	matchedAt?: number;
 	/** Set once matched — the exact string the client sends in CTOS_JOIN_GAME { pass }. */
 	roomPassword?: string;
+	/** Server room owning this reservation. Used to release both users atomically
+	 * when an incomplete matchmaking lobby is aborted. */
+	roomId?: number;
 	opponentType?: OpponentType;
 	opponentName?: string;
 	rated?: boolean;

--- a/src/ygopro/room/application/FinalizeYGOProRoom.test.ts
+++ b/src/ygopro/room/application/FinalizeYGOProRoom.test.ts
@@ -175,6 +175,17 @@ describe("FinalizeYGOProRoom.run()", () => {
 		);
 	});
 
+	it("is idempotent when overlapping lifecycle owners finalize the same room", () => {
+		const openClient = makeClient(makeSocket(false));
+		const room = createRoomInList([openClient]);
+
+		FinalizeYGOProRoom.run(room);
+		FinalizeYGOProRoom.run(room);
+
+		expect(openClient.destroy).toHaveBeenCalledTimes(1);
+		expect(mockInstance.broadcast).toHaveBeenCalledTimes(1);
+	});
+
 	it("does not throw when windbot is not initialized", () => {
 		const room = createRoomInList();
 		expect(() => FinalizeYGOProRoom.run(room)).not.toThrow();

--- a/src/ygopro/room/application/FinalizeYGOProRoom.ts
+++ b/src/ygopro/room/application/FinalizeYGOProRoom.ts
@@ -21,6 +21,9 @@ import { ReconnectionTokenIssuer } from "@shared/room/application/reconnect/Reco
  */
 export class FinalizeYGOProRoom {
 	static run(room: YGOProRoom): void {
+		// Matchmaking's join reaper and socket disconnect handler can observe the
+		// same abort on adjacent turns. Teardown is a single terminal transition.
+		if (room.finalizing) return;
 		room.finalizing = true;
 
 		WindbotModule.cleanupRoomIfEnabled(room.id);

--- a/src/ygopro/room/domain/YGOProRoom.ts
+++ b/src/ygopro/room/domain/YGOProRoom.ts
@@ -82,6 +82,9 @@ export class YGOProRoom extends YgoRoom {
 	windbot?: { name: string; deck: string };
 	noHost: boolean = false;
 	noReconnect: boolean = false;
+	/** True only for rooms pre-created by the matchmaking queue. Their WAITING
+	 * lifecycle is atomic: if either participant leaves, the reservation aborts. */
+	isMatchmaking: boolean = false;
 
 	// Set to true when the room begins teardown (removeRoom entry point in YGOProDuelingState).
 	// The WindBotJoinStrategy retry-abort callback reads this to stop retrying when the room


### PR DESCRIPTION
## Summary

- Associates both matched queue entries with the reserved room.
- Adds an atomic room abort path that releases both users and finalizes the room idempotently.
- Aborts incomplete matchmaking rooms when a player disconnects while the room is waiting.
- Keeps the room reaper active through the two-player join window and cleans up expired incomplete rooms.
- Routes bot spawn failures through the same abort lifecycle.

## Root cause

A match reservation was considered complete before both clients had joined the YGOPro room. Queue entries did not retain the room identity, so disconnect and timeout cleanup could not release the reservation or return the surviving player to matchmaking.

## Impact

Incomplete matchmaking rooms are destroyed consistently, stale reservations no longer strand users, and the client can safely requeue the remaining player.

## Validation

- `npm test`: 110 suites, 937 tests passed
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`
