### PR TITLE
feat(matchmaking): open the ranked TCG room pool via the tt token

### DIFF
--- a/src/ygopro/matchmaking/application/MatchmakingRoomFactory.test.ts
+++ b/src/ygopro/matchmaking/application/MatchmakingRoomFactory.test.ts
@@ -35,8 +35,9 @@ describe("createMatchmakingRoom", () => {
 
 		expect(room.league).toBe(RoomLeague.Verified);
 		expect(room.ranked).toBe(true);
-		// rule 1 = strict TCG (from the "to" token)
-		expect(room.hostInfo.rule).toBe(1);
+		// rule 5 = open pool, TCG banlist (from the "tt" token — toot alias):
+		// the TCG format is banlist-defined, so OCG-only printings stay playable.
+		expect(room.hostInfo.rule).toBe(5);
 		expect(room.isMatchmaking).toBe(true);
 		expect(YGOProRoomList.findById(room.id)).toBe(room);
 	});
@@ -100,9 +101,9 @@ describe("createMatchmakingRoom", () => {
 		});
 
 		const [name, password] = roomPassword.split("#");
-		// The name must still start with the shortest TCG-only token so the room
-		// resolves to rule 1 + TCG banlist.
-		expect(name.startsWith("to,")).toBe(true);
+		// The name must still start with the short toot alias so the room
+		// resolves to rule 5 (open pool) + TCG banlist.
+		expect(name.startsWith("tt,")).toBe(true);
 		// A non-empty password keeps the room private (needpass: true) so random
 		// players in the open list cannot join a matchmaking room.
 		expect(password.length).toBeGreaterThan(0);
@@ -167,8 +168,8 @@ describe("FORMAT_ROOM_TOKEN", () => {
 		}
 	});
 
-	it('maps tcg to the "to" token and jtp to the "jtp" token', () => {
-		expect(FORMAT_ROOM_TOKEN.tcg).toBe("to");
+	it('maps tcg to the "tt" token (toot alias: rule 5 + TCG lflist) and jtp to "jtp"', () => {
+		expect(FORMAT_ROOM_TOKEN.tcg).toBe("tt");
 		expect(FORMAT_ROOM_TOKEN.jtp).toBe("jtp");
 	});
 });

--- a/src/ygopro/matchmaking/application/MatchmakingRoomFactory.ts
+++ b/src/ygopro/matchmaking/application/MatchmakingRoomFactory.ts
@@ -16,11 +16,15 @@ import YGOProRoomList from "../../room/infrastructure/YGOProRoomList";
  *
  * WIRE-BUDGET CONSTRAINT: the full join string "<token>,mm<5>#{7}" must be ≤ 19
  * UTF-16 chars. Any token here must satisfy: token.length + 16 ≤ 19, i.e. ≤ 3 chars.
- * "to" (2) and "jtp" (3) both satisfy this; "jtp" is the 19-char boundary with
+ * "tt" (2) and "jtp" (3) both satisfy this; "jtp" is the 19-char boundary with
  * zero slack. See MatchmakingRoomFactory.test.ts.
+ *
+ * "tt" is the short alias of "toot" (RuleMappings): rule 5 + first TCG lflist —
+ * TCG banlist over an OPEN pool. The old "to" (rule 1, scoped pool) bounced
+ * cards without a TCG release (recent OCG printings, ot=0x9) at join.
  */
 export const FORMAT_ROOM_TOKEN: Record<MatchmakingFormat, string> = {
-	tcg: "to",
+	tcg: "tt",
 	jtp: "jtp",
 };
 

--- a/src/ygopro/room/domain/RuleMappings.ts
+++ b/src/ygopro/room/domain/RuleMappings.ts
@@ -155,7 +155,9 @@ export const priorityRuleMappings: RuleMappings = {
 			return value === "otto";
 		},
 	},
-	// TCG with TCG and OCG cards allowed
+	// TCG with TCG and OCG cards allowed. "tt" is the short alias used by the
+	// matchmaking room factory, whose join string must fit the utf16[20] wire
+	// field (token <= 3 chars — see MatchmakingRoomFactory).
 	toot: {
 		get: () => {
 			return {
@@ -164,7 +166,7 @@ export const priorityRuleMappings: RuleMappings = {
 			};
 		},
 		validate: (value) => {
-			return value === "toot";
+			return value === "toot" || value === "tt";
 		},
 	},
 

--- a/src/ygopro/room/domain/YGOProRoom.test.ts
+++ b/src/ygopro/room/domain/YGOProRoom.test.ts
@@ -107,6 +107,14 @@ describe("YGOProRoom", () => {
 		expect(room.useExtendedCardPool).toBe(false);
 	});
 
+	it("Should treat tt as the toot alias (rule 5, TCG banlist) — matchmaking's wire-budget token", () => {
+		const toot = YGOProRoomMother.create({ command: "toot#123" });
+		const tt = YGOProRoomMother.create({ command: "tt#123" });
+		expect(tt.hostInfo.rule).toBe(5);
+		expect(tt.hostInfo.rule).toBe(toot.hostInfo.rule);
+		expect(tt.hostInfo.lflist).toBe(toot.hostInfo.lflist);
+	});
+
 	it("Should create room with timelimit of 300 segs (for values between 1 and 60 should be covert to seconds) if the command is tm5#123", () => {
 		const room = YGOProRoomMother.create({ command: "tm5#123" });
 		expect(room.hostInfo.time_limit).toBe(300);


### PR DESCRIPTION
## Summary

Ranked TCG matchmaking rooms were created with the `to` token — rule 1, whose scope check (`CardAvailabilityValidationHandler`, srvpro2 `checkAvail`) bounces cards without a TCG release (recent OCG printings, `ot=0x9`) with a cryptic `CARD_OCG_ONLY` at join. Product call: the TCG format is defined by its **banlist**, not by release scope — the same shape srvpro2-family communities run TCG rooms with (their `TCG`/`OT` prefix is also rule 5).

- `FORMAT_ROOM_TOKEN.tcg`: `to` → `tt`
- `tt` is a NEW short alias on the **existing** `toot` mapping (rule 5 + first TCG lflist): same handler, second name. It exists because the matchmaking join string must fit the `utf16[20]` wire field — tokens are capped at 3 chars and `toot` has four.
- No validator/handler behavior changes anywhere else.

Client counterpart: evolution-card-game switches casual + vs-AI TCG commands to `toot` and turns its deck-builder scope gate off (rooms no longer scope-check).

## Test plan

- [x] `YGOProRoom.test.ts`: `tt` resolves identically to `toot` (rule 5, same lflist)
- [x] `MatchmakingRoomFactory.test.ts`: ranked TCG rooms now rule 5; name prefix `tt,`; wire-budget guard (≤19 chars over 500 iterations per format) still green
- [x] Full suite: 938 tests, 110 suites · biome check clean