### PR TITLE
feat(windbot): shorten TCG botlist names to fit the join wire budget

### DIFF
--- a/config/botlist.example.json
+++ b/config/botlist.example.json
@@ -8,31 +8,31 @@
 		"deck": "Yugi"
 	},
 	{
-		"name": "Salamangreat Bot",
+		"name": "Salamangreat",
 		"deck": "Salamangreat"
 	},
 	{
-		"name": "Sky Striker Bot",
+		"name": "Sky Striker",
 		"deck": "SkyStriker"
 	},
 	{
-		"name": "Labrynth Bot",
+		"name": "Labrynth",
 		"deck": "Labrynth"
 	},
 	{
-		"name": "Yubel Bot",
+		"name": "Yubel",
 		"deck": "Yubel"
 	},
 	{
-		"name": "Swordsoul Bot",
+		"name": "Swordsoul",
 		"deck": "Swordsoul"
 	},
 	{
-		"name": "Ryzeal Bot",
+		"name": "Ryzeal",
 		"deck": "Ryzeal"
 	},
 	{
-		"name": "Maliss Bot",
+		"name": "Maliss",
 		"deck": "Maliss"
 	}
 ]

--- a/src/bootstrap/bootstrapMatchmaking.test.ts
+++ b/src/bootstrap/bootstrapMatchmaking.test.ts
@@ -64,7 +64,7 @@ describe("bootstrapMatchmaking — spawnBot roster identity-pair wiring", () => 
 	it("requests a TCG bot with explicit name and deckOverride from the TCG roster", () => {
 		const requestBot = jest
 			.fn()
-			.mockResolvedValue({ bot: { name: "Salamangreat Bot", deck: "Salamangreat" } });
+			.mockResolvedValue({ bot: { name: "Salamangreat", deck: "Salamangreat" } });
 		jest.spyOn(WindbotModule, "isInitialized").mockReturnValue(true);
 		jest.spyOn(WindbotModule, "getInstance").mockReturnValue({
 			isEnabled: () => true,

--- a/src/ygopro/matchmaking/domain/MatchmakingBotRoster.ts
+++ b/src/ygopro/matchmaking/domain/MatchmakingBotRoster.ts
@@ -14,13 +14,13 @@ export interface BotIdentity {
  * could mix identities (e.g. "Yugi" playing a Salamangreat deck).
  *
  * TCG names and decks are verified against config/botlist.example.json:
- *   - "Salamangreat Bot" ↔ AI_Salamangreat.ydk
- *   - "Sky Striker Bot"  ↔ AI_SkyStriker.ydk
- *   - "Labrynth Bot"     ↔ AI_Labrynth.ydk
- *   - "Yubel Bot"        ↔ AI_Yubel.ydk
- *   - "Swordsoul Bot"    ↔ AI_Swordsoul.ydk
- *   - "Ryzeal Bot"       ↔ AI_Ryzeal.ydk
- *   - "Maliss Bot"       ↔ AI_Maliss.ydk
+ *   - "Salamangreat" ↔ AI_Salamangreat.ydk
+ *   - "Sky Striker"  ↔ AI_SkyStriker.ydk
+ *   - "Labrynth"     ↔ AI_Labrynth.ydk
+ *   - "Yubel"        ↔ AI_Yubel.ydk
+ *   - "Swordsoul"    ↔ AI_Swordsoul.ydk
+ *   - "Ryzeal"       ↔ AI_Ryzeal.ydk
+ *   - "Maliss"       ↔ AI_Maliss.ydk
  *
  * JTP roster: Joey plays JTP, Yugi plays Yugi. Both are in the server botlist
  * (config/botlist.example.json) so requestBot will find them by name.
@@ -30,13 +30,13 @@ export interface BotIdentity {
  */
 export const MATCHMAKING_BOT_ROSTER: Record<MatchmakingFormat, readonly BotIdentity[]> = {
 	tcg: [
-		{ name: "Salamangreat Bot", deck: "Salamangreat" },
-		{ name: "Sky Striker Bot", deck: "SkyStriker" },
-		{ name: "Labrynth Bot", deck: "Labrynth" },
-		{ name: "Yubel Bot", deck: "Yubel" },
-		{ name: "Swordsoul Bot", deck: "Swordsoul" },
-		{ name: "Ryzeal Bot", deck: "Ryzeal" },
-		{ name: "Maliss Bot", deck: "Maliss" },
+		{ name: "Salamangreat", deck: "Salamangreat" },
+		{ name: "Sky Striker", deck: "SkyStriker" },
+		{ name: "Labrynth", deck: "Labrynth" },
+		{ name: "Yubel", deck: "Yubel" },
+		{ name: "Swordsoul", deck: "Swordsoul" },
+		{ name: "Ryzeal", deck: "Ryzeal" },
+		{ name: "Maliss", deck: "Maliss" },
 	],
 	jtp: [
 		{ name: "Joey", deck: "JTP" },

--- a/src/ygopro/matchmaking/domain/deckOverrideBoundary.test.ts
+++ b/src/ygopro/matchmaking/domain/deckOverrideBoundary.test.ts
@@ -29,7 +29,7 @@ function makeTokenStore(): WindbotTokenStore {
 
 describe("deckOverride boundary — roster pair clears deckcode in RequestWindBotJoin", () => {
 	it("deckOverride set to pair.deck clears deckcode (TCG pair)", () => {
-		const pair = pickBotFromRoster("tcg", () => 0); // Salamangreat Bot
+		const pair = pickBotFromRoster("tcg", () => 0); // Salamangreat
 		// Simulate a source bot that has a deckcode field (e.g. from botlist.json)
 		const sourceBot: WindbotData = { name: pair.name, deck: pair.deck, deckcode: "some-code-123" };
 


### PR DESCRIPTION
## Summary

Fixes the vs-AI room failing to create for the longer TCG bots. The client embeds the bot name in its own `CTOS_JOIN_GAME` `pass` field — a fixed `utf16[20]` that silently truncates. `<token>,ai#Salamangreat Bot` (24 chars) arrived as `...ai#Salamangreat`, and `FileBotlistRepository.findByName` (exact, case-insensitive) never matched the truncated name → room fails, player bounced to the room list. "Salamangreat Bot" (16) / "Sky Striker Bot" (15) never fit under any token.

- Drop the redundant " Bot" suffix from the 7 TCG botlist entries (`config/botlist.example.json`): "Salamangreat Bot" → "Salamangreat", etc. So `tt,ai#Salamangreat` (18) fits.
- `MatchmakingBotRoster` names updated to match (findByName coherence for the ranked/casual fallback bots).
- **No deck/launch impact**: the windbot deck comes from `bot.deck` (unchanged AI_*.ydk); only the lookup/display name changes.

Pairs with the client PR (evolution-card-game) that references these short names via the `tt` alias. **Deploy this first** — the client vs-AI commands won't resolve until the botlist is renamed.

## Test plan

- [x] Full suite: 938 tests, 110 suites · biome check clean
- [x] Matchmaking roster + bootstrap tests updated to the short names