### PR TITLE
feat(emotes): relay a dedicated emote opcode (CTOS/STOC 0xfc)

### DIFF
--- a/src/edopro/room/domain/RoomState.ts
+++ b/src/edopro/room/domain/RoomState.ts
@@ -25,6 +25,12 @@ import { VersionErrorClientMessage } from "../../messages/server-to-client/Versi
 import { RoomType } from "src/shared/room/domain/RoomType";
 import { YGOProRoom } from "@ygopro/room/domain/YGOProRoom";
 import { NetPlayerType, YGOProStocChat, YGOProStocSelectHand } from "ygopro-msg-encode";
+import {
+	EMOTE_COOLDOWN_MS,
+	MAX_ID_LENGTH,
+	buildStocEmoteFrame,
+	isValidEmoteId,
+} from "@ygopro/emote/emote-protocol";
 
 export abstract class RoomState {
 	protected readonly eventEmitter: EventEmitter;
@@ -36,6 +42,12 @@ export abstract class RoomState {
 			Commands.CHAT as unknown as string,
 			(message: ClientMessage, room: YgoRoom, client: Client) =>
 				this.handleChat(message, room, client),
+		);
+
+		this.eventEmitter.on(
+			Commands.EMOTE as unknown as string,
+			(message: ClientMessage, room: YgoRoom, client: Client) =>
+				this.handleEmote(message, room, client),
 		);
 	}
 
@@ -160,6 +172,38 @@ export abstract class RoomState {
 
 		room.clients.forEach((_client: YgoClient) => {
 			_client.socket.send(chatMessage);
+		});
+	}
+
+	/**
+	 * Relay an emote (custom CTOS 0xfc) to the whole room as STOC 0xfc. Mercury
+	 * rooms only — the opcode is understood solely by this project's client, and
+	 * a standard ygopro client would neither send nor decode it. Validates the
+	 * id against the catalog and rate-limits per client before broadcasting.
+	 */
+	private handleEmote(message: ClientMessage, room: YgoRoom, client: YgoClient): void {
+		if (room.roomType !== RoomType.MERCURY) return;
+
+		// Byte-length pre-check before the utf-8 conversion, so a garbage frame
+		// (megabytes of body) can't force a large string allocation just to fail.
+		if (message.data.length === 0 || message.data.length > MAX_ID_LENGTH) return;
+
+		const emoteId = message.data.toString("utf8");
+		if (!isValidEmoteId(emoteId)) return;
+		if (!client.tryEmote(Date.now(), EMOTE_COOLDOWN_MS)) return;
+
+		// Seat resolution mirrors handleMercuryChat so the client maps the sender
+		// to the correct HUD side (accounting for a swapped board).
+		const ygoproRoom = room as YGOProRoom;
+		const playerType = client.isSpectator
+			? NetPlayerType.OBSERVER
+			: ygoproRoom.isPositionSwapped
+				? client.position ^ 1
+				: client.position;
+
+		const frame = buildStocEmoteFrame(playerType, emoteId);
+		room.clients.forEach((c: YgoClient) => {
+			c.socket.send(frame);
 		});
 	}
 

--- a/src/shared/client/domain/YgoClient.emote.test.ts
+++ b/src/shared/client/domain/YgoClient.emote.test.ts
@@ -1,0 +1,39 @@
+import { ISocket } from "../../socket/domain/ISocket";
+import { YgoClient } from "./YgoClient";
+
+// YgoClient has no abstract members — a trivial concrete subclass is enough to
+// exercise the emote rate-limit gate.
+class TestClient extends YgoClient {}
+
+function makeClient(): TestClient {
+	const socket = { remoteAddress: "::1" } as unknown as ISocket;
+	return new TestClient({ name: "P", position: 0, team: 0, socket, host: true, id: null });
+}
+
+describe("YgoClient.tryEmote — rate limit", () => {
+	const COOLDOWN = 2500;
+
+	it("allows the first emote", () => {
+		expect(makeClient().tryEmote(1000, COOLDOWN)).toBe(true);
+	});
+
+	it("blocks a second emote inside the cooldown window", () => {
+		const client = makeClient();
+		expect(client.tryEmote(1000, COOLDOWN)).toBe(true);
+		expect(client.tryEmote(1000 + COOLDOWN - 1, COOLDOWN)).toBe(false);
+	});
+
+	it("allows again once the cooldown has elapsed", () => {
+		const client = makeClient();
+		expect(client.tryEmote(1000, COOLDOWN)).toBe(true);
+		expect(client.tryEmote(1000 + COOLDOWN, COOLDOWN)).toBe(true);
+	});
+
+	it("does not advance the window on a blocked attempt", () => {
+		const client = makeClient();
+		expect(client.tryEmote(1000, COOLDOWN)).toBe(true);
+		// Blocked at t=2000 must NOT reset the clock; t=3500 is still >= 1000+2500.
+		expect(client.tryEmote(2000, COOLDOWN)).toBe(false);
+		expect(client.tryEmote(3500, COOLDOWN)).toBe(true);
+	});
+});

--- a/src/shared/client/domain/YgoClient.ts
+++ b/src/shared/client/domain/YgoClient.ts
@@ -44,6 +44,21 @@ export abstract class YgoClient {
 		this._ipAddress = socket.remoteAddress ?? null;
 	}
 
+	// -Infinity so the FIRST emote is always allowed, whatever `now` is (a 0
+	// seed would block emotes sent within `cooldownMs` of the epoch).
+	private _lastEmoteAt = Number.NEGATIVE_INFINITY;
+
+	/**
+	 * Emote rate-limit gate: returns true (and records `now`) when the cooldown
+	 * has elapsed since the last accepted emote, false otherwise. Kept on the
+	 * client so the window survives room state transitions.
+	 */
+	tryEmote(now: number, cooldownMs: number): boolean {
+		if (now - this._lastEmoteAt < cooldownMs) return false;
+		this._lastEmoteAt = now;
+		return true;
+	}
+
 	get position(): number {
 		return this._position;
 	}

--- a/src/shared/messages/Commands.ts
+++ b/src/shared/messages/Commands.ts
@@ -17,4 +17,5 @@ export enum Commands {
 	TO_DUEL = 32,
 	PING = 0xff,
 	RECONNECT = 0xfd,
+	EMOTE = 0xfc,
 }

--- a/src/ygopro/emote/emote-protocol.test.ts
+++ b/src/ygopro/emote/emote-protocol.test.ts
@@ -1,0 +1,28 @@
+import { EMOTE_OPCODE, buildStocEmoteFrame, isValidEmoteId } from "./emote-protocol";
+
+describe("isValidEmoteId", () => {
+	it("accepts catalog ids", () => {
+		expect(isValidEmoteId("wave")).toBe(true);
+		expect(isValidEmoteId("mindblown")).toBe(true);
+	});
+
+	it("rejects unknown, empty, and over-long ids (no arbitrary-string injection)", () => {
+		expect(isValidEmoteId("evil")).toBe(false);
+		expect(isValidEmoteId("")).toBe(false);
+		expect(isValidEmoteId("x".repeat(25))).toBe(false);
+	});
+});
+
+describe("buildStocEmoteFrame", () => {
+	it("lays out [size LE][0xfc][playerType][id] with size = 2 + id bytes", () => {
+		const frame = buildStocEmoteFrame(1, "fire");
+		expect(frame.readUInt16LE(0)).toBe(6); // opcode + playerType + 4 id bytes
+		expect(frame.readUInt8(2)).toBe(EMOTE_OPCODE);
+		expect(frame.readUInt8(3)).toBe(1);
+		expect(frame.subarray(4).toString("utf8")).toBe("fire");
+	});
+
+	it("masks the player type into a byte", () => {
+		expect(buildStocEmoteFrame(7, "cry").readUInt8(3)).toBe(7);
+	});
+});

--- a/src/ygopro/emote/emote-protocol.ts
+++ b/src/ygopro/emote/emote-protocol.ts
@@ -1,0 +1,50 @@
+/**
+ * Emote wire protocol (server side) — the custom CTOS/STOC 0xfc opcode, in the
+ * same family as PING/PONG and RECONNECT. The client sends CTOS 0xfc with a
+ * catalog id; the server validates + rate-limits, then broadcasts STOC 0xfc
+ * carrying the sender's seat so every viewer maps it to the right HUD side.
+ *
+ * Frame layout (ygopro framing: [size:u16 LE][opcode:u8][body...], size counts
+ * the opcode but not the 2-byte prefix):
+ *   CTOS: body = [emoteId: utf-8]
+ *   STOC: body = [playerType: u8][emoteId: utf-8]
+ */
+
+export const EMOTE_OPCODE = 0xfc;
+
+/** Cooldown between accepted emotes, per client. */
+export const EMOTE_COOLDOWN_MS = 2500;
+
+/** Longest id the wire accepts — bounds a malformed/oversized frame. */
+export const MAX_ID_LENGTH = 24;
+
+/**
+ * Ids the server accepts, mirroring the client emote catalog. An unknown id is
+ * dropped (never broadcast), so a client cannot inject arbitrary strings.
+ */
+export const EMOTE_IDS: ReadonlySet<string> = new Set([
+	"wave",
+	"thumbsup",
+	"fire",
+	"thinking",
+	"cool",
+	"mindblown",
+	"sweat",
+	"cry",
+]);
+
+export function isValidEmoteId(id: string): boolean {
+	return id.length > 0 && id.length <= MAX_ID_LENGTH && EMOTE_IDS.has(id);
+}
+
+/** Build the STOC emote frame broadcast to the room. */
+export function buildStocEmoteFrame(playerType: number, emoteId: string): Buffer {
+	const idBytes = Buffer.from(emoteId, "utf8");
+	const size = 1 /* opcode */ + 1 /* playerType */ + idBytes.length;
+	const frame = Buffer.alloc(2 + size);
+	frame.writeUInt16LE(size, 0);
+	frame.writeUInt8(EMOTE_OPCODE, 2);
+	frame.writeUInt8(playerType & 0xff, 3);
+	idBytes.copy(frame, 4);
+	return frame;
+}


### PR DESCRIPTION
## Summary

Server half of in-duel emotes (client PR in evolution-card-game). A new custom **CTOS/STOC 0xfc** opcode, in the same family as PING/PONG (0xff/0xfe) and RECONNECT (0xfd): the client sends an emote id, the server validates + rate-limits + broadcasts to the room.

- `ygopro/emote/emote-protocol.ts`: opcode, id allowlist (`isValidEmoteId`), STOC frame builder.
- `Commands.EMOTE = 0xfc`.
- `RoomState.handleEmote` — subscribed in the base constructor, so **every ygopro/Mercury state inherits it exactly like CHAT**. Mercury rooms only (the opcode is understood solely by this project's client). Seat resolution mirrors `handleMercuryChat` (spectator → OBSERVER, position-swap aware) so each viewer maps the sender to the right HUD side.
- `YgoClient.tryEmote`: per-client cooldown, seeded to `-Infinity` so the first emote always passes; a blocked attempt does not advance the window. Kept on the client so the window survives room state transitions.
- Hardening (from review): validate id **before** consuming the rate-limit budget; byte-length pre-check before the utf-8 conversion so a garbage frame can't force a large string allocation. Unknown ids are dropped — no arbitrary-string injection.

Flow confirmed: PING (0xff) is intercepted at the socket layer and never reaches the room; EMOTE (0xfc) is not intercepted, so it flows `SimpleRoomMessageEmitter → emitRoomEvent → handleEmote` like CHAT.

## Test plan

- [x] `emote-protocol.test.ts`: id allowlist (unknown/empty/over-long rejected), STOC frame layout
- [x] `YgoClient.emote.test.ts`: cooldown gate — first allowed, blocked inside window, allowed after, blocked attempt doesn't reset the clock
- [x] Full suite: 946 tests, 112 suites · biome clean