### PR TITLE
feat(matchmaking): ranked human pairs play best-of-3 matches

### DIFF
--- a/src/bootstrap/bootstrapMatchmaking.ts
+++ b/src/bootstrap/bootstrapMatchmaking.ts
@@ -38,6 +38,8 @@ export function bootstrapMatchmaking(logger: Logger): void {
 		createRankedRoom: (format: MatchmakingFormat) => {
 			const { room, roomPassword } = createMatchmakingRoom({
 				format,
+				// Ranked human pairs play best-of-3 (MATCH room with side-decking).
+				matchMode: true,
 				rankedOverride: true,
 				logger: mmLogger,
 				emitter: new EventEmitter(),
@@ -49,6 +51,9 @@ export function bootstrapMatchmaking(logger: Logger): void {
 		createBotRoom: (format: MatchmakingFormat) => {
 			const { room, roomPassword } = createMatchmakingRoom({
 				format,
+				// Bot fallback stays best-of-1: windbot has no side-deck support,
+				// so a MATCH room would stall in side-decking until the timeout.
+				matchMode: false,
 				rankedOverride: false,
 				logger: mmLogger,
 				emitter: new EventEmitter(),

--- a/src/ygopro/matchmaking/application/MatchmakingRoomFactory.test.ts
+++ b/src/ygopro/matchmaking/application/MatchmakingRoomFactory.test.ts
@@ -4,7 +4,11 @@ import { RoomLeague } from "@shared/room/admission/domain/RoomLeague";
 
 import { MATCHMAKING_FORMATS } from "../domain/QueueEntry";
 import YGOProRoomList from "../../room/infrastructure/YGOProRoomList";
-import { createMatchmakingRoom, FORMAT_ROOM_TOKEN } from "./MatchmakingRoomFactory";
+import {
+	createMatchmakingRoom,
+	FORMAT_ROOM_TOKEN,
+	FORMAT_ROOM_TOKEN_MATCH,
+} from "./MatchmakingRoomFactory";
 
 const makeLogger = () =>
 	({
@@ -53,6 +57,48 @@ describe("createMatchmakingRoom", () => {
 		expect(room.ranked).toBe(false);
 	});
 
+	it("creates a best-of-3 MATCH room for ranked human pairs (matchMode)", () => {
+		const { room } = createMatchmakingRoom({
+			rankedOverride: true,
+			matchMode: true,
+			logger: makeLogger(),
+			emitter: new EventEmitter(),
+		});
+
+		expect(room.bestOf).toBe(3);
+		expect(room.isMatch).toBe(true);
+		// "tmr" = same rule set as "tt" (rule 5 + first TCG lflist) + best-of-3 MATCH.
+		expect(room.name.startsWith("tmr,")).toBe(true);
+		expect(room.hostInfo.rule).toBe(5);
+	});
+
+	it('uses the "jm" token for jtp MATCH rooms (jtp rules + best-of-3)', () => {
+		const { room } = createMatchmakingRoom({
+			format: "jtp",
+			rankedOverride: true,
+			matchMode: true,
+			logger: makeLogger(),
+			emitter: new EventEmitter(),
+		});
+
+		expect(room.bestOf).toBe(3);
+		expect(room.isMatch).toBe(true);
+		expect(room.name.startsWith("jm,")).toBe(true);
+		expect(room.hostInfo.rule).toBe(5);
+	});
+
+	it("keeps rooms best-of-1 when matchMode is omitted (bot fallback — windbot cannot side-deck)", () => {
+		const { room } = createMatchmakingRoom({
+			rankedOverride: false,
+			logger: makeLogger(),
+			emitter: new EventEmitter(),
+		});
+
+		expect(room.bestOf).toBe(1);
+		expect(room.isMatch).toBe(false);
+		expect(room.name.startsWith("tt,")).toBe(true);
+	});
+
 	it("returns roomPassword as the exact command#password join string", () => {
 		const { room, roomPassword } = createMatchmakingRoom({
 			rankedOverride: true,
@@ -85,6 +131,24 @@ describe("createMatchmakingRoom", () => {
 			const { roomPassword } = createMatchmakingRoom({
 				format,
 				rankedOverride: true,
+				logger: makeLogger(),
+				emitter: new EventEmitter(),
+			});
+
+			expect(roomPassword.length).toBeLessThanOrEqual(19);
+		}
+	});
+
+	// Same guard over the MATCH tokens. "tmr" (3 chars) fills the budget to the
+	// 19-char total (token + 16-char "mm<5>#<7>" suffix), exactly like "jtp".
+	it.each(
+		MATCHMAKING_FORMATS,
+	)("produces a join string that fits the pass field (<= 19 chars) for MATCH rooms, format %s", (format) => {
+		for (let i = 0; i < 500; i++) {
+			const { roomPassword } = createMatchmakingRoom({
+				format,
+				rankedOverride: true,
+				matchMode: true,
 				logger: makeLogger(),
 				emitter: new EventEmitter(),
 			});
@@ -171,5 +235,22 @@ describe("FORMAT_ROOM_TOKEN", () => {
 	it('maps tcg to the "tt" token (toot alias: rule 5 + TCG lflist) and jtp to "jtp"', () => {
 		expect(FORMAT_ROOM_TOKEN.tcg).toBe("tt");
 		expect(FORMAT_ROOM_TOKEN.jtp).toBe("jtp");
+	});
+});
+
+describe("FORMAT_ROOM_TOKEN_MATCH", () => {
+	it("has a MATCH token for every format in MATCHMAKING_FORMATS", () => {
+		for (const fmt of MATCHMAKING_FORMATS) {
+			const token = FORMAT_ROOM_TOKEN_MATCH[fmt];
+			expect(typeof token).toBe("string");
+			expect(token.length).toBeGreaterThan(0);
+			// Wire budget: token.length + 16 <= 19 (see the factory doc comment).
+			expect(token.length).toBeLessThanOrEqual(3);
+		}
+	});
+
+	it('maps tcg to "tmr" (tt rules + best-of-3) and jtp to "jm"', () => {
+		expect(FORMAT_ROOM_TOKEN_MATCH.tcg).toBe("tmr");
+		expect(FORMAT_ROOM_TOKEN_MATCH.jtp).toBe("jm");
 	});
 });

--- a/src/ygopro/matchmaking/application/MatchmakingRoomFactory.ts
+++ b/src/ygopro/matchmaking/application/MatchmakingRoomFactory.ts
@@ -28,10 +28,28 @@ export const FORMAT_ROOM_TOKEN: Record<MatchmakingFormat, string> = {
 	jtp: "jtp",
 };
 
+/**
+ * Per-format MATCH (best-of-3) token, used for human pairs. Same banlist/rule
+ * set as FORMAT_ROOM_TOKEN plus mode=MATCH + best_of=3 (RuleMappings: "tmr",
+ * "jm"). "tmr" (3) sits at the 19-char wire ceiling like "jtp"; "jm" (2) has
+ * one char of slack.
+ */
+export const FORMAT_ROOM_TOKEN_MATCH: Record<MatchmakingFormat, string> = {
+	tcg: "tmr",
+	jtp: "jm",
+};
+
 export interface CreateMatchmakingRoomInput {
 	/** Format determines the room command token (banlist/rule set). Defaults to "tcg"
 	 * for backwards compatibility when callers do not supply it. */
 	format?: MatchmakingFormat;
+	/**
+	 * true → best-of-3 MATCH room (human pairs). Defaults to false (single duel)
+	 * because bot fallback rooms MUST stay best-of-1: windbot never submits a
+	 * side deck, so a MATCH room would stall in side-decking until the timeout
+	 * kicks the bot mid-match.
+	 */
+	matchMode?: boolean;
 	/** true → ranked (Verified) human pair; false → unrated (Casual) bot game. */
 	rankedOverride: boolean;
 	logger: Logger;
@@ -102,7 +120,8 @@ function randomBase36(length: number): string {
 }
 
 export function createMatchmakingRoom(input: CreateMatchmakingRoomInput): MatchmakingRoomHandle {
-	const token = FORMAT_ROOM_TOKEN[input.format ?? "tcg"];
+	const tokens = input.matchMode ? FORMAT_ROOM_TOKEN_MATCH : FORMAT_ROOM_TOKEN;
+	const token = tokens[input.format ?? "tcg"];
 
 	// "mm"-prefixed base36 suffix: collision-proof against rule tokens and unique
 	// enough that a clash in YGOProRoomList is astronomically rare — but we still

--- a/src/ygopro/room/domain/RuleMappings.test.ts
+++ b/src/ygopro/room/domain/RuleMappings.test.ts
@@ -1,0 +1,30 @@
+import { GameMode } from "ygopro-msg-encode";
+
+import { formatRuleMappings, priorityRuleMappings } from "./RuleMappings";
+
+describe("match-mode shortcut mappings", () => {
+	// A MATCH shortcut without best_of leaves hostInfo.best_of at the SINGLE
+	// default (1), which makes Match.needWins = 1 — functionally a single duel
+	// despite mode=MATCH. Every match shortcut must therefore pin best_of.
+	it.each(["oomr", "omr", "tomr", "tmr"])('"%s" sets mode MATCH and best_of 3', (key) => {
+		const rule = priorityRuleMappings[key].get(key);
+		expect(rule.mode).toBe(GameMode.MATCH);
+		expect(rule.best_of).toBe(3);
+	});
+});
+
+describe("jm mapping (jtp best-of-3, used by matchmaking)", () => {
+	it("maps the jtp rule set to a best-of-3 match", () => {
+		const rule = formatRuleMappings.jm.get("jm");
+		expect(rule.mode).toBe(GameMode.MATCH);
+		expect(rule.best_of).toBe(3);
+		expect(rule.rule).toBe(5);
+		expect(rule.duel_rule).toBe(2);
+	});
+
+	it("validates only the exact token", () => {
+		expect(formatRuleMappings.jm.validate("jm")).toBe(true);
+		expect(formatRuleMappings.jm.validate("jmx")).toBe(false);
+		expect(formatRuleMappings.jm.validate("jtp")).toBe(false);
+	});
+});

--- a/src/ygopro/room/domain/RuleMappings.ts
+++ b/src/ygopro/room/domain/RuleMappings.ts
@@ -350,6 +350,7 @@ export const priorityRuleMappings: RuleMappings = {
 				rule: 0,
 				lflist: 0,
 				mode: GameMode.MATCH,
+				best_of: 3,
 			};
 		},
 		validate: (value) => {
@@ -363,6 +364,7 @@ export const priorityRuleMappings: RuleMappings = {
 				rule: 5,
 				lflist: 0,
 				mode: GameMode.MATCH,
+				best_of: 3,
 			};
 		},
 		validate: (value) => {
@@ -376,6 +378,7 @@ export const priorityRuleMappings: RuleMappings = {
 				rule: 1,
 				lflist: MercuryBanListMemoryRepository.getFirstTCGIndex(),
 				mode: GameMode.MATCH,
+				best_of: 3,
 			};
 		},
 		validate: (value) => {
@@ -389,6 +392,7 @@ export const priorityRuleMappings: RuleMappings = {
 				rule: 5,
 				lflist: MercuryBanListMemoryRepository.getFirstTCGIndex(),
 				mode: GameMode.MATCH,
+				best_of: 3,
 			};
 		},
 		validate: (value) => {
@@ -461,6 +465,23 @@ export const formatRuleMappings: RuleMappings = {
 		},
 		validate: (value) => {
 			return value === "jtp";
+		},
+	},
+	// "jtp" + best-of-3 match. Kept to 2 chars because it is the matchmaking
+	// MATCH token for the jtp queue, whose join string must fit the utf16[20]
+	// wire field (token <= 3 chars — see MatchmakingRoomFactory).
+	jm: {
+		get: () => {
+			return {
+				rule: 5,
+				lflist: Math.max(0, MercuryBanListMemoryRepository.findIndexByAlias("jtp")),
+				duel_rule: 2,
+				mode: GameMode.MATCH,
+				best_of: 3,
+			};
+		},
+		validate: (value) => {
+			return value === "jm";
 		},
 	},
 	gx: {


### PR DESCRIPTION
## Summary

Ranked matchmaking rooms were single-duel: the `FORMAT_ROOM_TOKEN` tokens (`tt`, `jtp`) set no `mode`, so `hostInfo` fell to the `GameMode.SINGLE` default. Product call: ranked human pairs now play **best-of-3** (with side-decking between games); the bot fallback **stays best-of-1** — windbot never submits a side deck, so a MATCH room would stall in side-decking until the timeout kicks the bot mid-match.

- **RuleMappings** — fixes a latent bug in the four match shortcuts (`oomr`/`omr`/`tomr`/`tmr`): they set `mode: MATCH` but left `best_of` at the SINGLE default of 1, making `Match.needWins = ceil(1/2) = 1` — functionally a single duel. All four now pin `best_of: 3`. New `jm` mapping = jtp rules (`rule 5`, jtp lflist, `duel_rule: 2`) + MATCH + `best_of: 3`, kept to 2 chars for the wire budget.
- **MatchmakingRoomFactory** — new `FORMAT_ROOM_TOKEN_MATCH` (`tcg → "tmr"`, `jtp → "jm"`) selected by a new `matchMode` input (defaults to false, the safe direction: a caller that omits it degrades to a single duel, never to a stalled bot match). `"tmr"` sits at the 19-char `utf16[20]` ceiling exactly like `"jtp"`.
- **bootstrapMatchmaking** — `createRankedRoom` passes `matchMode: true`; `createBotRoom` passes an explicit `matchMode: false` with the windbot rationale.

Ranked reporting is unaffected: `GameOverDomainEvent` already fires **once per match** (only when `isMatchFinished()`), so ELO/stats never multi-count a Bo3. The reaper is also safe — it stops tracking a room once both players join, so side-decking can never be reaped. Client needs zero changes: the join string is opaque, and the client already ships the side-deck screen + match score HUD.

## Test plan

- [x] `RuleMappings.test.ts` (new): the four match shortcuts return `best_of: 3`; `jm` maps jtp rules + MATCH + `best_of: 3` and validates only the exact token
- [x] `MatchmakingRoomFactory.test.ts`: human match rooms come out `bestOf 3` / `isMatch` with `tmr,`/`jm,` prefixes; bot rooms stay `bestOf 1` on `tt,`; wire-budget guard (≤19 chars × 500 iterations per format) extended over the MATCH tokens
- [x] Full suite: 951 tests, 111 suites · biome and tsc clean
- [ ] Staging smoke test: two human clients through game 1 → side deck → game 2 before deploy