### PR TITLE
fix(emotes): reject spectator emotes server-side

### DIFF
--- a/src/edopro/room/domain/RoomState.test.ts
+++ b/src/edopro/room/domain/RoomState.test.ts
@@ -5,9 +5,9 @@ import { Commands } from "../../../shared/messages/Commands";
 import { RoomType } from "src/shared/room/domain/RoomType";
 
 // RoomState is abstract but declares no abstract members — a bare concrete
-// subclass is enough to exercise the inherited CHAT handler (registered in the
-// constructor). handleChat/handleMercuryChat are private, so we drive them
-// through the "CHAT" event, exactly as the runtime does.
+// subclass is enough to exercise the inherited CHAT and EMOTE handlers
+// (registered in the constructor). The handlers are private, so we drive them
+// through the "CHAT" / "EMOTE" events, exactly as the runtime does.
 class TestRoomState extends RoomState {}
 
 const makeSocket = () => ({
@@ -18,6 +18,12 @@ const makeSocket = () => ({
 
 const makeChatMessage = (text: string) => ({
 	data: Buffer.from(text, "utf16le"),
+	previousMessage: Buffer.alloc(0),
+});
+
+// Emote ids travel as raw utf-8 in the frame body (not utf16le like chat).
+const makeEmoteMessage = (id: string) => ({
+	data: Buffer.from(id, "utf8"),
 	previousMessage: Buffer.alloc(0),
 });
 
@@ -70,5 +76,51 @@ describe("RoomState — Mercury spectator chat (Option A: server prefixes name)"
 		const sent = socket.send.mock.calls[0][0] as Buffer;
 		expect(sent.includes(Buffer.from("Jugador A: hola", "utf16le"))).toBe(false);
 		expect(sent.includes(Buffer.from("hola", "utf16le"))).toBe(true);
+	});
+});
+
+describe("RoomState — Mercury emote gate (only seated duelists send)", () => {
+	let eventEmitter: EventEmitter;
+
+	beforeEach(() => {
+		eventEmitter = new EventEmitter();
+		new TestRoomState(eventEmitter);
+	});
+
+	it("broadcasts a duelist's valid emote to the room", () => {
+		const socket = makeSocket();
+		const room = makeMercuryRoom(socket);
+		const duelist = {
+			isSpectator: false,
+			position: 0,
+			tryEmote: () => true,
+		} as unknown as never;
+
+		eventEmitter.emit(Commands.EMOTE as unknown as string, makeEmoteMessage("wave"), room, duelist);
+
+		expect(socket.send).toHaveBeenCalledTimes(1);
+	});
+
+	it("does NOT broadcast a spectator's emote (rejected before rate-limit)", () => {
+		const socket = makeSocket();
+		const room = makeMercuryRoom(socket);
+		const spectator = {
+			isSpectator: true,
+			position: 7,
+			// The gate must short-circuit BEFORE the rate-limiter — if tryEmote is
+			// reached the spectator slipped through, so make that a hard failure.
+			tryEmote: () => {
+				throw new Error("tryEmote must not be reached for a spectator");
+			},
+		} as unknown as never;
+
+		eventEmitter.emit(
+			Commands.EMOTE as unknown as string,
+			makeEmoteMessage("wave"),
+			room,
+			spectator,
+		);
+
+		expect(socket.send).not.toHaveBeenCalled();
 	});
 });

--- a/src/edopro/room/domain/RoomState.ts
+++ b/src/edopro/room/domain/RoomState.ts
@@ -184,6 +184,11 @@ export abstract class RoomState {
 	private handleEmote(message: ClientMessage, room: YgoRoom, client: YgoClient): void {
 		if (room.roomType !== RoomType.MERCURY) return;
 
+		// Only seated duelists may emote. Spectators watch and receive emotes but
+		// cannot send them — reject here (the authoritative gate; the client also
+		// hides the picker for spectators).
+		if (client.isSpectator) return;
+
 		// Byte-length pre-check before the utf-8 conversion, so a garbage frame
 		// (megabytes of body) can't force a large string allocation just to fail.
 		if (message.data.length === 0 || message.data.length > MAX_ID_LENGTH) return;
@@ -195,11 +200,7 @@ export abstract class RoomState {
 		// Seat resolution mirrors handleMercuryChat so the client maps the sender
 		// to the correct HUD side (accounting for a swapped board).
 		const ygoproRoom = room as YGOProRoom;
-		const playerType = client.isSpectator
-			? NetPlayerType.OBSERVER
-			: ygoproRoom.isPositionSwapped
-				? client.position ^ 1
-				: client.position;
+		const playerType = ygoproRoom.isPositionSwapped ? client.position ^ 1 : client.position;
 
 		const frame = buildStocEmoteFrame(playerType, emoteId);
 		room.clients.forEach((c: YgoClient) => {


### PR DESCRIPTION
## Problem

`handleEmote` let spectators through: it resolved them to `NetPlayerType.OBSERVER` and broadcast the frame. On the client, `sideForSeat(OBSERVER, …)` maps to the **opponent's** HUD side — so a spectator (or a modified spectator client) could make an emote appear **as if a duelist sent it**.

The client hides the picker for spectators, but that's cosmetic — the server is the authoritative gate.

## Fix

Reject spectators early in `handleEmote`, before any parsing/allocation or the rate-limiter:

```ts
if (client.isSpectator) return;
```

Only seated duelists may send. Spectators still **receive and see** emotes. The now-unreachable `OBSERVER` branch in the `playerType` resolution is removed (the surviving path is just the swap-aware seat position). `NetPlayerType` stays imported — still used by `handleMercuryChat`.

> Asymmetry note: spectators **can** chat (with a server-prefixed name, "Option A") but **cannot** emote. Intended — emotes are seat-anchored to a HUD side and a spectator has no seat.

## Tests

- A duelist's valid emote broadcasts once.
- A spectator's emote is dropped **before** the rate-limiter (the mock's `tryEmote` throws if reached, proving short-circuit order).
- typecheck ✓ · biome lint ✓ · suite green.

Fresh-context review: mergeable as-is. Pairs with the client PR (`evolution-card-game#125`).