### PR TITLE
chore(edison): post-merge cleanup of #316 (redact framing, fix comment)

### DIFF
--- a/resources.manifest.json
+++ b/resources.manifest.json
@@ -120,7 +120,7 @@
 			"file": "lflist/edison.lflist.conf"
 		},
 		{
-			"comment": "ocgcore fork WASM — placed at ygopro/core/ocgcore-worker; read once at boot by YGOProResourceLoader",
+			"comment": "ocgcore fork WASM — placed at ygopro/core/ocgcore-worker; read by the card-load worker when (re)building card storage",
 			"target": "ygopro/core/ocgcore-worker",
 			"from": "edison-core",
 			"file": "ocgcore-worker"

--- a/scripts/resources-lib.sh
+++ b/scripts/resources-lib.sh
@@ -34,7 +34,7 @@ _check_jq
 
 # ---------------------------------------------------------------------------
 # Private override merge — keeps PRIVATE git sources (private repos, e.g. the
-# pre-errata scripts moat) OUT of the public base manifest. When the caller uses
+# pre-errata scripts) OUT of the public base manifest. When the caller uses
 # the default base manifest AND a private override file exists, merge base +
 # override (append sources + assembly) into an effective manifest and use it.
 # Prod/CI provide resources.manifest.private.json (gitignored) + a read-only


### PR DESCRIPTION
Post-merge follow-up to #316 (squash-merged) — two small items that landed after the squash:

- **Redact strategic framing**: drop the "moat" wording from `scripts/resources-lib.sh`. This is a public repo; the comment stays factual (private sources are kept out of the base manifest).
- **Fix manifest comment**: the `edison-core` fork WASM is read by the card-load worker on each (re)load, not "once at boot".
