### PR TITLE
fix(ranking): key rank by banlist name to unify formats across paths

### DIFF
--- a/src/edopro/room/application/FinishDuelHandler.ts
+++ b/src/edopro/room/application/FinishDuelHandler.ts
@@ -105,6 +105,7 @@ export class FinishDuelHandler {
 					players: this.room.matchPlayersHistory,
 					date: new Date(),
 					banListHash: this.room.banListHash,
+					banListName: this.room.banListName ?? "N/A",
 					ranked: this.room.ranked,
 				}),
 			);

--- a/src/edopro/room/domain/Room.ts
+++ b/src/edopro/room/domain/Room.ts
@@ -1,3 +1,4 @@
+import BanListMemoryRepository from "@edopro/ban-list/infrastructure/BanListMemoryRepository";
 import { PlayerChangeClientMessage } from "@edopro/messages/server-to-client/PlayerChangeClientMessage";
 import { ChildProcessWithoutNullStreams } from "child_process";
 import shuffle from "shuffle-array";
@@ -507,6 +508,10 @@ export class Room extends YgoRoom {
 
 	get replay(): Replay {
 		return this._replay;
+	}
+
+	get banListName(): string | null {
+		return BanListMemoryRepository.findByHash(this.banListHash)?.name ?? null;
 	}
 
 	setDecksToPlayer(position: number, deck: Deck): void {

--- a/src/shared/room/domain/match/domain/domain-events/GameOverDomainEvent.ts
+++ b/src/shared/room/domain/match/domain/domain-events/GameOverDomainEvent.ts
@@ -5,6 +5,7 @@ export type GameOverData = {
 	date: Date;
 	players: PlayerMatchSummary[];
 	banListHash: number;
+	banListName: string;
 	ranked: boolean;
 };
 

--- a/src/shared/stats/basic/application/BasicStatsCalculator.test.ts
+++ b/src/shared/stats/basic/application/BasicStatsCalculator.test.ts
@@ -114,6 +114,7 @@ describe("BasicStatsCalculator", () => {
 		const event = GameOverDomainEventMother.create({
 			players: players.map((player) => player.toPresentation()),
 			ranked: true,
+			banListName: "N/A",
 		});
 
 		await basicStatsCalculator.handle(event);
@@ -133,5 +134,49 @@ describe("BasicStatsCalculator", () => {
 		);
 		expect(playerStatsRepository.save).toHaveBeenNthCalledWith(1, PlayerStats.from(playerStats));
 		expect(playerStatsRepository.save).toHaveBeenNthCalledWith(2, PlayerStats.from(opponentStats));
+	});
+
+	it("Should use banListName from event data (not from hash lookup) for per-format rank", async () => {
+		const edisonBanListName = "2010.03 Edison";
+		playerStatsRepository.findByUserIdAndBanListName
+			.mockResolvedValueOnce(playerStats) // per-format lookup for player
+			.mockResolvedValueOnce(playerStats) // Global lookup for player
+			.mockResolvedValueOnce(opponentStats) // per-format lookup for opponent
+			.mockResolvedValueOnce(opponentStats); // Global lookup for opponent
+
+		const players = [player, opponent];
+		const event = GameOverDomainEventMother.create({
+			players: players.map((p) => p.toPresentation()),
+			ranked: true,
+			banListName: edisonBanListName,
+		});
+
+		await basicStatsCalculator.handle(event);
+
+		// Per-format lookup must use the name from event.data.banListName
+		expect(playerStatsRepository.findByUserIdAndBanListName).toHaveBeenCalledWith(
+			playerUserProfile.id,
+			edisonBanListName,
+		);
+		expect(playerStatsRepository.findByUserIdAndBanListName).toHaveBeenCalledWith(
+			opponentUserProfile.id,
+			edisonBanListName,
+		);
+	});
+
+	it("Should NOT write per-format row when banListName is N/A", async () => {
+		const players = [player, opponent];
+		const event = GameOverDomainEventMother.create({
+			players: players.map((p) => p.toPresentation()),
+			ranked: true,
+			banListName: "N/A",
+		});
+
+		await basicStatsCalculator.handle(event);
+
+		// Only Global calls — no per-format call with "N/A"
+		const calls = playerStatsRepository.findByUserIdAndBanListName.mock.calls;
+		const perFormatCalls = calls.filter(([, name]) => name !== "Global");
+		expect(perFormatCalls).toHaveLength(0);
 	});
 });

--- a/src/shared/stats/basic/application/BasicStatsCalculator.ts
+++ b/src/shared/stats/basic/application/BasicStatsCalculator.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import BanListMemoryRepository from "@edopro/ban-list/infrastructure/BanListMemoryRepository";
 import { Logger } from "src/shared/logger/domain/Logger";
 import { Player } from "src/shared/player/domain/Player";
 import { UserProfileRepository } from "src/shared/user-profile/domain/UserProfileRepository";
@@ -35,7 +34,7 @@ export class BasicStatsCalculator implements DomainEventSubscriber<GameOverDomai
 			return;
 		}
 
-		const banList = BanListMemoryRepository.findByHash(event.data.banListHash);
+		const banListName = event.data.banListName;
 		const players = event.data.players.map((item) => new Player(item));
 
 		const gameId = randomUUID();
@@ -59,10 +58,10 @@ export class BasicStatsCalculator implements DomainEventSubscriber<GameOverDomai
 				.map((element) => element.id);
 			const points = player.calculateMatchPoints();
 			this.logger.info(`Player ${player.name} and id: ${userProfile.id} gain ${points} points`);
-			if (banList?.name) {
+			if (banListName && banListName !== "N/A") {
 				const playerStats = await this.playerStatsRepository.findByUserIdAndBanListName(
 					userProfile.id,
-					banList.name,
+					banListName,
 				);
 				playerStats.addPoints(points);
 				player.winner ? playerStats.increaseWins() : playerStats.increaseLosses();
@@ -86,7 +85,7 @@ export class BasicStatsCalculator implements DomainEventSubscriber<GameOverDomai
 				playerIds: playerIds.filter((id): id is string => id !== null),
 				opponentIds: opponentIds.filter((id): id is string => id !== null),
 				date: event.data.date,
-				banListName: banList?.name ?? "N/A",
+				banListName: banListName,
 				banListHash: event.data.banListHash.toString(),
 				playerScore: player.wins,
 				opponentScore: player.losses,
@@ -106,7 +105,7 @@ export class BasicStatsCalculator implements DomainEventSubscriber<GameOverDomai
 					playerNames,
 					opponentNames,
 					date: event.data.date,
-					banListName: banList?.name ?? "N/A",
+					banListName: banListName,
 					banListHash: event.data.banListHash.toString(),
 					result: game.result,
 					turns: game.turns,

--- a/src/shared/stats/unranked-match/application/UnrankedMatchSaver.test.ts
+++ b/src/shared/stats/unranked-match/application/UnrankedMatchSaver.test.ts
@@ -25,6 +25,7 @@ describe("UnrankedMatchSaver", () => {
 			bestOf: 1,
 			date: new Date(),
 			banListHash: 123,
+			banListName: "N/A",
 		});
 
 		await unrankedMatchSaver.handle(event);
@@ -70,6 +71,7 @@ describe("UnrankedMatchSaver", () => {
 			bestOf: 1,
 			date: new Date(),
 			banListHash: 123,
+			banListName: "2010.03 Edison",
 		});
 
 		await unrankedMatchSaver.handle(event);
@@ -83,12 +85,13 @@ describe("UnrankedMatchSaver", () => {
 		expect(capturedMatch.winnerTeam).toBe(0);
 		expect(capturedMatch.playerNames).toContain("Player0");
 		expect(capturedMatch.opponentNames).toContain("Player1");
+		expect(capturedMatch.banListName).toBe("2010.03 Edison");
 
 		const capturedDuel = unrankedMatchRepository.saveDuel.mock.calls[0][0];
 		expect(capturedDuel.team0Score).toBe(1);
 		expect(capturedDuel.team1Score).toBe(0);
 		expect(capturedDuel.winnerTeam).toBe(0);
-		expect(capturedDuel.banListName).toBe("N/A");
+		expect(capturedDuel.banListName).toBe("2010.03 Edison");
 	});
 
 	it("should NOT save if players are missing from one team", async () => {
@@ -107,6 +110,7 @@ describe("UnrankedMatchSaver", () => {
 			bestOf: 1,
 			date: new Date(),
 			banListHash: 123,
+			banListName: "N/A",
 		});
 
 		await unrankedMatchSaver.handle(event);

--- a/src/shared/stats/unranked-match/application/UnrankedMatchSaver.ts
+++ b/src/shared/stats/unranked-match/application/UnrankedMatchSaver.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import BanListMemoryRepository from "@edopro/ban-list/infrastructure/BanListMemoryRepository";
 import { DomainEventSubscriber } from "src/shared/event-bus/EventBus";
 import { Logger } from "src/shared/logger/domain/Logger";
 import { GameOverDomainEvent } from "src/shared/room/domain/match/domain/domain-events/GameOverDomainEvent";
@@ -36,8 +35,7 @@ export class UnrankedMatchSaver implements DomainEventSubscriber<GameOverDomainE
 		);
 
 		const gameId = randomUUID();
-		const banList = BanListMemoryRepository.findByHash(event.data.banListHash);
-		const banListName = banList?.name ?? "N/A";
+		const banListName = event.data.banListName;
 		const banListHash = event.data.banListHash.toString();
 
 		// Use the first player of Team 0 as reference for scores and result

--- a/src/test-support/mothers/player/GameOverDomainEventMother.ts
+++ b/src/test-support/mothers/player/GameOverDomainEventMother.ts
@@ -13,6 +13,7 @@ export class GameOverDomainEventMother {
 			date: faker.date.past(),
 			players: [PlayerMother.create().toPresentation(), PlayerMother.create().toPresentation()],
 			banListHash: faker.number.int(),
+			banListName: faker.helpers.arrayElement(["2010.03 Edison", "TCG", "Global"]),
 			ranked: faker.datatype.boolean(),
 			...params,
 		});

--- a/src/ygopro/room/domain/YGOProRoom.ts
+++ b/src/ygopro/room/domain/YGOProRoom.ts
@@ -340,6 +340,10 @@ export class YGOProRoom extends YgoRoom {
 		return this._edoBanListHash;
 	}
 
+	get banListName(): string | null {
+		return MercuryBanListMemoryRepository.findByHash(this.banListHash)?.name ?? null;
+	}
+
 	waiting(): void {
 		this._roomState?.removeAllListener();
 		const userProfileRepo = new UserProfilePostgresRepository();

--- a/src/ygopro/room/domain/states/YGOProDuelingState.ts
+++ b/src/ygopro/room/domain/states/YGOProDuelingState.ts
@@ -640,7 +640,8 @@ export class YGOProDuelingState extends RoomState {
 				bestOf: this.room.bestOf,
 				players: this.room.matchPlayersHistory,
 				date: new Date(),
-				banListHash: this.room.edoBanListHash, //TODO: Fallback to syncronized banlist hash rank for different hash for the same banlist
+				banListHash: this.room.edoBanListHash,
+				banListName: this.room.banListName ?? "N/A",
 				ranked: this.room.ranked,
 			}),
 		);


### PR DESCRIPTION
## Description / Descripción

El ranking se indexa por el **nombre normalizado** de la banlist (`player_stats`, único por `(userId, banListName, season)`), pero el nombre se re-derivaba haciendo un round-trip de un hash a través de `findByHash(...).name`. En el path YGOPro eso usaba el `edoBanListHash` cross-referenciado, que podía resolver a `null` en silencio y **perder la fila del rank por-formato** (solo se escribía `"Global"`).

El mismo formato jugado en ambos paths (p. ej. Edison) comparte un único nombre normalizado (`2010.03 Edison`) pero tiene hashes de lflist distintos, así que la unificación dependía de una coincidencia frágil de strings de header entre dos repos de recursos.

**Fix:** `GameOverDomainEvent` ahora transporta `banListName` directo, resuelto en el origen desde el repositorio propio de cada room (EDOPro vía `BanListMemoryRepository`, YGOPro vía `MercuryBanListMemoryRepository` — no `edoBanListHash`). Ambos consumidores de stats leen el nombre del evento. `banListHash` se conserva **solo como metadato de auditoría** en los registros de match/duel resume (es más granular: distingue pool con errata vs pre-errata).

## Related Issue(s) / Issue(s) relacionado(s)

_N/A_

## Checklist

- [x] My code follows the project style and guidelines
- [x] I have added tests or examples if needed
- [ ] I have updated documentation if needed
- [x] The PR title is descriptive

## Additional Notes / Notas adicionales

- Sin cambios de esquema; sin migración. Las filas existentes de `player_stats` ya están keyeadas por nombre.
- Cada room resuelve su nombre desde su propio repo, así que aunque el cross-ref `edoBanListHash` falle, el rank ya no se rompe en silencio. Elimina el `//TODO` de `YGOProDuelingState`.
- Tests: 1007/1007 verde, `tsc --noEmit` limpio, `biome check` limpio.

**Archivos:**

| File | Change |
|------|--------|
| `src/shared/room/domain/match/domain/domain-events/GameOverDomainEvent.ts` | `GameOverData` ahora incluye `banListName` |
| `src/edopro/room/domain/Room.ts` | getter `banListName` (repo EDOPro) |
| `src/ygopro/room/domain/YGOProRoom.ts` | getter `banListName` (repo mercury propio) |
| `src/edopro/room/application/FinishDuelHandler.ts` | despacha `banListName` |
| `src/ygopro/room/domain/states/YGOProDuelingState.ts` | despacha `banListName`, elimina TODO obsoleto |
| `src/shared/stats/basic/application/BasicStatsCalculator.ts` | usa `event.data.banListName` para el rank; conserva hash como auditoría |
| `src/shared/stats/unranked-match/application/UnrankedMatchSaver.ts` | idem para el path no-rankeado |
| `src/test-support/mothers/player/GameOverDomainEventMother.ts` | default `banListName` |
| `*.test.ts` (2) | cobertura del nuevo origen del nombre |