### PR TITLE
feat(room): join-command overhaul — pairing joins, room identity, edison bots

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,11 @@ COPY --from=server-builder /server/node_modules ./node_modules
 # tsc only emits dist/, so config/ must be copied explicitly or the server crashes
 # at boot with ENOENT when windbot is enabled. Replace botlist.example.json with a
 # curated botlist whose deck names match the WindBot image's bots.json.
+# IMPORTANT: every entry MUST also carry a "format" tag ("tcg" / "jtp" / "edison")
+# matching resolveBotPool's pools. Format-scoped random join commands (e.g.
+# "pre,ai", "ed,ai", "jtp,ai") call pickRandom(format) — a curated botlist without
+# "format" tags makes that lookup return null for every user of those commands
+# (JOINERROR). See config/botlist.example.json for the reference shape.
 COPY --from=server-builder /server/config ./config
 
 # CoreIntegrator binaries

--- a/config/botlist.example.json
+++ b/config/botlist.example.json
@@ -1,38 +1,65 @@
 [
 	{
 		"name": "Joey",
-		"deck": "JTP"
+		"deck": "JTP",
+		"format": "jtp"
 	},
 	{
 		"name": "Yugi",
-		"deck": "Yugi"
+		"deck": "Yugi",
+		"format": "jtp"
 	},
 	{
 		"name": "Salamangreat",
-		"deck": "Salamangreat"
+		"deck": "Salamangreat",
+		"format": "tcg"
 	},
 	{
 		"name": "Sky Striker",
-		"deck": "SkyStriker"
+		"deck": "SkyStriker",
+		"format": "tcg"
 	},
 	{
 		"name": "Labrynth",
-		"deck": "Labrynth"
+		"deck": "Labrynth",
+		"format": "tcg"
 	},
 	{
 		"name": "Yubel",
-		"deck": "Yubel"
+		"deck": "Yubel",
+		"format": "tcg"
 	},
 	{
 		"name": "Swordsoul",
-		"deck": "Swordsoul"
+		"deck": "Swordsoul",
+		"format": "tcg"
 	},
 	{
 		"name": "Ryzeal",
-		"deck": "Ryzeal"
+		"deck": "Ryzeal",
+		"format": "tcg"
 	},
 	{
 		"name": "Maliss",
-		"deck": "Maliss"
+		"deck": "Maliss",
+		"format": "tcg"
+	},
+	{
+		"name": "Blackwing",
+		"deck": "EdisonBlackwing",
+		"hidden": true,
+		"format": "edison"
+	},
+	{
+		"name": "Lightsworn",
+		"deck": "EdisonLightsworn",
+		"hidden": true,
+		"format": "edison"
+	},
+	{
+		"name": "Machina",
+		"deck": "EdisonMachina",
+		"hidden": true,
+		"format": "edison"
 	}
 ]

--- a/docs/join-commands.md
+++ b/docs/join-commands.md
@@ -1,0 +1,287 @@
+# YGOPro Join Commands — Structure and Handling
+
+How the server interprets the `CTOS_JOIN_GAME` password ("join command"), how rooms
+are matched and created from it, and where player/spectator decisions happen.
+Evidence references point at the current source; update them if files move.
+
+## 1. Command wire format
+
+```
+<config-tokens>[#<room-password>]
+```
+
+- The whole string rides the `CTOS_JOIN_GAME` `pass` field: **UTF-16LE, fixed
+  `utf16[20]` — silently truncated past 20 characters**. Exactly-20 round-trips
+  (no NUL terminator required by `ygopro-msg-encode`).
+- `YGOProJoinHandler` splits on `#` and keeps only the first two segments
+  (`src/ygopro/room/application/YGOProJoinHandler.ts:51`):
+  - `command` = raw segment before the first `#` (case preserved).
+  - `password` = segment after the first `#`, or `""`.
+- Config tokens are comma-separated inside `command`. For rule resolution they
+  are trimmed and lowercased; for room identity they are **not** (see §4).
+
+Examples: `tcg`, `edison#myroom`, `nc,ns,ai#Blackwing`, `m,tt#duel1`.
+
+## 2. Join pipeline
+
+```
+socket → MessageEmitter (Commands.JOIN_GAME = 18) → YGOProJoinHandler
+       → JoinStrategyRegistry.resolve(ctx) → strategy.handle(ctx)
+```
+
+Strategy chain, first `matches()` wins
+(`src/ygopro/room/application/join-strategies/composeJoinStrategies.ts`):
+
+| # | Strategy | Matches when | Behavior |
+|---|----------|--------------|----------|
+| 1 | `AIJoinTokenStrategy` | windbot enabled AND `rawPass` starts with `AIJOIN#` | The bot itself connecting back: consumes a one-shot token, finds the room **by id**, marks the client internal. |
+| 2 | `WindBotJoinStrategy` | windbot enabled AND `ai` among config tokens | Creates an AI room, resolves the bot (by name after `#`, or format-scoped random via `resolveBotPool`), fires the bot request. Rejects tag mode. |
+| 3 | `TicketJoinStrategy` | socket authenticated via WS ticket (`resolvedUserId`) | Shared `findOrCreateRoom` helper (`rankedOverride=true`) — see §5 for the pairing-vs-non-pairing lookup it performs. |
+| 4 | `DefaultJoinStrategy` | always | Shared `findOrCreateRoom` helper (`rankedOverride=undefined`) — see §5 for the pairing-vs-non-pairing lookup it performs. Admission is delegated to the room state (§6). |
+
+On strategy error: `JOINERROR` frame + `socket.close()`.
+
+`TicketJoinStrategy` and `DefaultJoinStrategy` share one function,
+`findOrCreateRoom` (`src/ygopro/room/application/join-strategies/findOrCreateRoom.ts`),
+parameterized by `{ rankedOverride }`. The two strategies differ ONLY in that
+parameter — the find-or-create logic itself, including the pairing-join
+branch described in §5, is identical for both.
+
+## 3. Rule resolution (token catalog)
+
+`YGOProRoom.create` (`src/ygopro/room/domain/YGOProRoom.ts:198-233`) lowercases
+each token and applies three tiers from
+`src/ygopro/room/domain/RuleMappings.ts`, in order — later tiers overwrite
+earlier ones for the same option; **two matches inside one tier throw**:
+
+1. **`ruleMappings`** (mode): `m`/`match`, `t`/`tag`.
+2. **`formatRuleMappings`** (format presets): `edison`/`ed`, `hat`, `tengu`,
+   `md`, `jtp`, `jtp-2007-03`, `jm`, `gx`, `mdc`, `goat`,
+   `genesys`/`g`/`g<N>`/`genesys<N>`, `rush`, `rushpre`, `speed`, `world`,
+   `pre`, `ocg`, `tcgpre`, `ocgpre`, `tcgart`, `ocgart`.
+3. **`priorityRuleMappings`** (modifiers, win over format tokens): `bo<N>`,
+   `lp<N>`, `tm<N>`/`time<N>`, `mr<N>`/`duelrule<N>`, `ot`/`tcg`, `otto`,
+   `toot`/`tt`, `ns`, `nc`, `dr<N>`, `st<N>`, `to`/`tcgonly`/`tor`,
+   `lf*`/`lflist*`, `nf`/`nolflist`, `oor`/`oo`/`ocgonly`, `or`, `tr`, `oomr`,
+   `omr`, `tomr`, `tmr`.
+
+Notes worth knowing:
+
+- **`tcg` is an alias of `ot`** (priority tier): payload is `{ rule: 5 }` only —
+  banlist and duel rule stay at the host defaults (first TCG banlist,
+  duel_rule 5).
+- `ocg` → `{ rule: 0, lflist: 0, time_limit: 450 }`;
+  `md` → `{ rule: 5, lflist: alias("md"), duel_rule: 5, time_limit: 450 }`;
+  `tcgpre` → `{ rule: 5, duel_rule: 5, time_limit: 450 }` (default TCG lflist);
+  `ocgpre` → `{ rule: 5, duel_rule: 5, lflist: 0, time_limit: 450 }`;
+  `tcgart`/`ocgart` are byte-identical to `tcgpre`/`ocgpre` in ruleset, but
+  kept as separate tokens on purpose — token = room identity (§4/§5), so
+  merging them would silently merge two distinct pairing pools.
+- `g` resolves genesys (`rule: 1`, genesys banlist, `max_deck_points`
+  default 100) and **throws if the genesys banlist is not loaded**.
+- `pre`, `tcgpre`, `ocgpre`, `tcgart`, `ocgart`, `rushpre` additionally enable
+  the **extended card pool** (`extendedCardPoolFormats`,
+  `RuleMappings.ts:707`) — an effect separate from the tier payloads.
+- Banlist aliases resolve by **normalized substring inclusion**
+  (`MercuryBanListMemoryRepository.findIndexByAlias`), not exact match.
+- Unrecognized tokens are silently ignored (host defaults apply:
+  `rule: 1`, `mode: SINGLE`, `duel_rule: 5`, first TCG banlist).
+- AI-pool resolution for random windbots mirrors the tier precedence
+  (`src/ygopro/windbot/domain/resolveBotPool.ts`): priority TCG tokens win
+  over format tokens regardless of position.
+
+## 4. Room identity and matching
+
+- `room.name` = the **raw, case-preserved** config segment of whichever string
+  created the room. `room.password` = the raw segment after `#`.
+- For **non-pairing** joins, room identity is the exact **(name, password)
+  pair**: `YGOProRoomList.findByNameAndPassword`
+  (`src/ygopro/room/infrastructure/YGOProRoomList.ts`) does plain `===` on
+  both `room.name` and `room.password` against the joiner's `command` and
+  `password`, and returns the **first** room matching both. A miss creates a
+  new room under that exact pair — it never rejects the join. Two rooms
+  sharing a name but differing in password are therefore always
+  distinguishable and independently reachable.
+- `YGOProRoomList.findByName` (name-only match) remains available for callers
+  that need a name-only lookup (e.g. `MatchmakingRoomFactory`'s
+  name-collision check when minting a fresh matchmaking room name); the join
+  pipeline's non-pairing lookup uses `findByNameAndPassword` instead.
+- Consequences:
+  - **Case-sensitive identity**: `tcg` and `TCG` are two different rooms that
+    resolve to the same ruleset.
+  - **A bare token is both config AND room identity**: two strangers sending
+    exactly `tcg` land in the same room and get seated as the two players.
+    This started as an emergent side effect of `findByName`'s first-match
+    lookup; §5 formalizes it into the designed pairing feature (still keyed
+    on the exact command string, now state- and seat-aware).
+  - `findByNameAndPassword` returns the **first** room matching the pair and
+    **ignores room state** — a room stays in the list (and stays matchable)
+    through `waiting → rps → choosingOrder → dueling → sideDecking` until
+    `FinalizeYGOProRoom.run` removes it at match end. A joiner who supplies
+    the correct password for a room mid-duel still resolves to that room
+    (spectating decided downstream — see §6); a joiner who mistypes the
+    password resolves to no existing room and gets a fresh, empty one of
+    their own instead of a rejection.
+
+## 5. Pairing joins
+
+Any client can pair players by having them send the same bare token command
+(e.g. `TCG`, `edison`) with no password — the server matches them into the
+same room or gives each side a fresh one.
+
+Added on top of the pipeline in §2 — `findOrCreateRoom`
+(`src/ygopro/room/application/join-strategies/findOrCreateRoom.ts`) branches
+into a **pairing lookup** instead of the non-pairing `findByNameAndPassword`
+lookup when the join qualifies as a pairing join.
+
+**Placement in the pipeline:** this branch lives entirely inside step 4 of §2
+(`JoinStrategyRegistry.resolve(ctx) → strategy.handle(ctx)`), specifically
+inside the shared `findOrCreateRoom` helper called by both `TicketJoinStrategy`
+and `DefaultJoinStrategy`. It runs AFTER strategy resolution (so `AIJoinTokenStrategy`
+and `WindBotJoinStrategy` are never affected) and BEFORE room admission (§6) —
+it only decides WHICH room object the join is routed to, never who gets
+seated once there.
+
+**Predicate** (`isPairingJoin`,
+`src/ygopro/room/application/join-strategies/isPairingJoin.ts`): a join is a
+pairing join when ALL of the following hold:
+
+- the password segment is empty (no `#` in the command, or nothing after it);
+- the command is non-empty;
+- every comma-separated token, trimmed and lowercased, is **recognized**:
+  `isRecognizedToken(token)` (exported from `RuleMappings.ts` — true when the
+  token matches at least one tier's `validate()`, per §3) **or** the literal
+  token `"casual"`.
+
+Concretely NOT pairing joins: `ai` (intercepted earlier by
+`WindBotJoinStrategy` when windbot is enabled; when disabled it falls through
+here and is simply unrecognized — conservative, not a special case),
+`mm<...>` (the matchmaking queue's generated marker token), any arbitrary
+unrecognized room name, and the blank command.
+
+**Pairing key is the exact raw command string** — case and token order
+matter. `edison,ns` and `ns,edison` are two different pairing pools and will
+NOT pair with each other; `TCG` and `tcg` are likewise two different pools
+(consistent with the case-sensitive room identity already described in §4).
+This is a deliberate product decision: players expect to pair only with
+someone who typed the exact same command.
+
+**Lookup, inside `findOrCreateRoom`:**
+
+- Pairing join → `YGOProRoomList.findJoinableByName(command, options)`. Every
+  candidate with a matching name is scanned (not just the first), and ALL of
+  the following are evaluated **per candidate, inside the same scan** — a
+  candidate that fails any one of them is simply skipped, it can never
+  shadow a later qualifying candidate:
+  - `duelState === WAITING` and has a free seat (state- and seat-aware —
+    see §4);
+  - `password === ""` (`requireEmptyPassword`) — a passworded same-named
+    room (e.g. `tcg#secret`) is skipped, not treated as a match-then-reject;
+  - league compatibility for **guest** joiners only (`excludeRankedForGuest`):
+    a joiner with no resolved ticket identity and no PIN skips any candidate
+    whose league is ranked (Verified/External), because `RoomAdmission`
+    hard-rejects a guest in a ranked room (JOINERROR + close, no spectator
+    fallback) rather than seating or spectating it. Non-guest joiners
+    (ticket or PIN) are not filtered by league — they keep the pre-existing
+    behavior.
+  - Found → join it.
+  - Not found (no same-named room at all, or every same-named room is
+    dueling/full/passworded/league-incompatible for this guest) → **create a
+    new room** with the same name (`rankedOverride` per the calling
+    strategy, same as any other creation).
+- Non-pairing join → `findByNameAndPassword(command, password)` (first-match
+  on the exact pair, state-blind), exactly as in §4 — a match joins whatever
+  state that room is in (spectating included); no match **creates a new
+  room** under that name and password rather than rejecting. See §8 for the
+  trade-off this implies for a mistyped password.
+
+**Never-spectate guarantee (mostly — see the seat-race caveat):** because a
+pairing join either lands in a room that `findJoinableByName` just confirmed
+is `WAITING` with a free seat, or creates a brand-new `WAITING` room, a
+pairing join can **never** be routed into a dueling/mid-match room. The
+unconditional-spectator path in `YGOProDuelingState.handleJoin` (§6) is
+therefore unreachable for pairing joins — it only ever fires for non-pairing
+joins (passworded rooms, or an unrecognized/arbitrary room name), where the
+behavior is unchanged from before this feature.
+
+Caveat: `hasFreeSeat()` (used by `findJoinableByName`) is an explicitly
+**lock-free routing hint** — it does not hold the room's mutex. Two pairing
+joiners can both observe the same last free seat as available and both get
+routed to the same room; real admission (`RoomAdmission.decide`, inside
+`room.mutex.runExclusive`) is the actual arbiter, and the loser of that race
+degrades to **spectator** (no free seat left → `RoomAdmission` returns
+`spectator`, per §6), not a rejection. This is the one gap in the
+"never-spectate" guarantee: it holds for the routing decision, not for the
+sub-mutex admission race on the very last seat.
+
+## 6. Player vs spectator
+
+Admission depends on the room state active when `JOIN` fires:
+
+- **WAITING** (`YGOProWaitingState.handleJoin`): duplicate name → reject;
+  otherwise `RoomAdmission.decide`
+  (`src/shared/room/admission/domain/RoomAdmission.ts:32`):
+  ranked + guest → reject; league doesn't admit → spectator;
+  **no free seat → spectator**; else seated as player. A spectator can later be
+  promoted via `TO_DUEL` (waiting state only).
+- **RPS / ChoosingOrder / SideDecking / Dueling**: joiners are matched against
+  existing players by `findReconnectingPlayer` (name, and for unranked rooms
+  also remote address + original socket closed). Reconnect on match; otherwise
+  **unconditionally a spectator** — mid-match joins never create players, and
+  there is no "room is busy → go elsewhere" path.
+
+## 7. What join does NOT use
+
+- The HTTP room listings (`GET /api/getrooms`, `GET /api/rooms`) are read-only
+  browse endpoints; the join pipeline never consults them.
+- The HTTP matchmaking queue (`MatchmakingQueue`, `MatchmakingRoomFactory`) is
+  a separate engine: it pairs players per format, creates a room with a
+  generated `"<token>,mm<id>#<pass>"` string, and hands both players that exact
+  string to send through the normal socket join pipeline. The only room-side
+  marker is `room.isMatchmaking = true`. That generated string always carries
+  an `mm<id>` token, which `isRecognizedToken` does not recognize — so
+  matchmaking joins are never pairing joins (§5); they always go through the
+  `findByNameAndPassword` lookup (§4/§5), resolving to their room by the exact
+  generated `(name, password)` pair.
+
+## 8. Known caveats (current behavior)
+
+1. ~~Bare-token pairing works for the first two players, but a **third**
+   sender of the same token while the duel is running silently becomes a
+   spectator of two strangers.~~ **Fixed by the pairing feature (§5)** for any
+   command where every token is recognized (or `casual`): a third sender gets
+   a brand-new room instead of spectating, and a fourth sender pairs with the
+   third's room rather than the still-dueling first one. The caveat still
+   applies verbatim to commands with an unrecognized token or a password
+   segment — those keep using `findByNameAndPassword` (state-blind,
+   first-match on the pair) and can still land a joiner as a spectator of a
+   dueling room when the pair matches.
+2. Room identity is case-sensitive while rule resolution is not; clients that
+   uppercase their commands partition themselves from clients that lowercase.
+   The pairing feature (§5) inherits this exactly — `TCG` and `tcg` are two
+   distinct pairing pools, not one.
+3. `YGOProRoomList.findByName` (name-only, ignoring password) returns the
+   first name match regardless of state; a caller routing through it alone
+   can only ever reach the first same-named room. The join pipeline does not
+   have this problem: non-pairing joins resolve by the full `(name,
+   password)` pair via `findByNameAndPassword`, so a second, third, etc.
+   same-named room under a different password is always independently
+   reachable; pairing joins (§5) scan every same-named room via
+   `findJoinableByName` and skip dueling/full/passworded ones. The caveat
+   still applies to any other caller that uses plain `findByName` directly
+   (e.g. `MatchmakingRoomFactory`'s name-collision check when minting a new
+   matchmaking room name).
+4. Because room identity for a non-pairing join is the exact `(name,
+   password)` pair, there is no "wrong password" rejection on this path: a
+   joiner who mistypes the password of an existing room does not get an
+   error — they get a brand-new, empty room under that name and their typo'd
+   password, indistinguishable in kind from any other room. This is a
+   deliberate trade-off (see §4/§5): treating the full command string as the
+   identity avoids `findByName`'s first-match collision with same-named
+   pairing/other rooms, at the cost of silent typo-driven room creation
+   instead of an explicit reject. Because there is no reject on this path, a
+   mismatched password also no longer terminates the connection: the socket
+   is never destroyed, and the joiner instead lands in the newly created room.
+5. The 20-char `pass` ceiling applies to the entire command string; bot names
+   are boot-validated against a 13-char budget that assumes short (≤3 chars +
+   comma) format tokens.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1246,9 +1246,9 @@
 			}
 		},
 		"node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-			"version": "3.15.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-			"integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+			"version": "3.15.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+			"integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3142,9 +3142,9 @@
 			}
 		},
 		"node_modules/ansis": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
-			"integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
+			"integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
 			"license": "ISC",
 			"engines": {
 				"node": ">=14"
@@ -3512,21 +3512,34 @@
 			}
 		},
 		"node_modules/body-parser": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+			"integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
 			"license": "MIT",
 			"dependencies": {
 				"bytes": "^3.1.2",
-				"content-type": "^1.0.5",
+				"content-type": "^2.0.0",
 				"debug": "^4.4.3",
-				"http-errors": "^2.0.0",
-				"iconv-lite": "^0.7.0",
+				"http-errors": "^2.0.1",
+				"iconv-lite": "^0.7.2",
 				"on-finished": "^2.4.1",
-				"qs": "^6.14.1",
-				"raw-body": "^3.0.1",
-				"type-is": "^2.0.1"
+				"qs": "^6.15.2",
+				"raw-body": "^3.0.2",
+				"type-is": "^2.1.0"
 			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/body-parser/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
@@ -3558,9 +3571,9 @@
 			"license": "ISC"
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4333,9 +4346,9 @@
 			}
 		},
 		"node_modules/dayjs": {
-			"version": "1.11.20",
-			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
-			"integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+			"version": "1.11.21",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+			"integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
 			"license": "MIT"
 		},
 		"node_modules/debug": {
@@ -5015,9 +5028,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
 			"dev": true,
 			"funding": [
 				{
@@ -5347,9 +5360,9 @@
 			"peer": true
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-			"integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+			"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
@@ -6675,9 +6688,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -10042,17 +10055,34 @@
 			}
 		},
 		"node_modules/type-is": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-			"integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+			"integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
 			"license": "MIT",
 			"dependencies": {
-				"content-type": "^1.0.5",
+				"content-type": "^2.0.0",
 				"media-typer": "^1.1.0",
 				"mime-types": "^3.0.0"
 			},
 			"engines": {
-				"node": ">= 0.6"
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/type-is/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/typed-array-buffer": {
@@ -10102,16 +10132,16 @@
 			}
 		},
 		"node_modules/typeorm": {
-			"version": "0.3.30",
-			"resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.30.tgz",
-			"integrity": "sha512-8T35PzjefOdqc2ZR9mwLQj0pUGp6lQhMbK2EvVMwJVJWlaoHm0v/Q6dThNOZkFchD+0yMg8gwjKM28ePiLSXSQ==",
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.31.tgz",
+			"integrity": "sha512-6u9EFtdLBgHjnPm78NStVeM+I/1MolTzKykDDcydzKUkh6E++YS6XViU/fePJbvDvEGU4Xq34KOM/CLeer9I2A==",
 			"license": "MIT",
 			"dependencies": {
 				"@sqltools/formatter": "^1.2.5",
-				"ansis": "^4.2.0",
+				"ansis": "^4.3.1",
 				"app-root-path": "^3.1.0",
 				"buffer": "^6.0.3",
-				"dayjs": "^1.11.20",
+				"dayjs": "^1.11.21",
 				"debug": "^4.4.3",
 				"dedent": "^1.7.2",
 				"dotenv": "^16.6.1",
@@ -10121,7 +10151,7 @@
 				"sql-highlight": "^6.1.0",
 				"tslib": "^2.8.1",
 				"uuid": "^11.1.1",
-				"yargs": "^17.7.2"
+				"yargs": "^17.7.3"
 			},
 			"bin": {
 				"typeorm": "cli.js",
@@ -10142,13 +10172,13 @@
 				"mongodb": "^5.8.0 || ^6.0.0",
 				"mssql": "^9.1.1 || ^10.0.0 || ^11.0.0 || ^12.0.0",
 				"mysql2": "^2.2.5 || ^3.0.1",
-				"oracledb": "^6.3.0",
+				"oracledb": "^6.3.0 || ^7.0.0",
 				"pg": "^8.5.1",
 				"pg-native": "^3.0.0",
 				"pg-query-stream": "^4.0.0",
 				"redis": "^3.1.1 || ^4.0.0 || ^5.0.14",
 				"sql.js": "^1.4.0",
-				"sqlite3": "^5.0.3",
+				"sqlite3": "^5.0.3 || ^6.0.0",
 				"ts-node": "^10.7.0",
 				"typeorm-aurora-data-api-driver": "^2.0.0 || ^3.0.0"
 			},
@@ -10244,9 +10274,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+			"integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.1"
@@ -10829,9 +10859,9 @@
 			}
 		},
 		"node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"version": "17.7.3",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+			"integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
 			"license": "MIT",
 			"dependencies": {
 				"cliui": "^8.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,12 +45,11 @@ async function start(): Promise<void> {
 	// when the on-disk .conf files change (see bootstrapBanListReloader).
 	await bootstrapBanListReloader(logger);
 
-	await server.initialize();
-	WebSocketSingleton.getInstance();
-	hostServer.initialize();
-	wsHostServer.initialize();
-
 	// config.windbot is validated for fail-fast at module load (src/config/index.ts).
+	// Bootstrapped BEFORE any server/socket initialization below: it has no
+	// dependency on them (only on config + the mercury port number), so a bad
+	// botlist (see FileBotlistRepository's boot-time validation) aborts boot
+	// pre-listen instead of crashing the process with sockets already open.
 	const windbotModule = config.windbot.enabled
 		? bootstrapWindbot(config.windbot, config.servers.mercury.port)
 		: undefined;
@@ -58,6 +57,11 @@ async function start(): Promise<void> {
 	if (windbotModule) {
 		logger.info("🤖 Windbot enabled");
 	}
+
+	await server.initialize();
+	WebSocketSingleton.getInstance();
+	hostServer.initialize();
+	wsHostServer.initialize();
 
 	// After windbot so the queue's bot-fallback availability check reflects it.
 	bootstrapMatchmaking(logger);

--- a/src/ygopro/ban-list/domain/YGOProBanList.ts
+++ b/src/ygopro/ban-list/domain/YGOProBanList.ts
@@ -1,8 +1,24 @@
 import { BanList } from "src/shared/ban-list/BanList";
 
 export class YGOProBanList extends BanList {
+	private _alias: string | null = null;
+
 	setHash(hash: number) {
 		this._hash = hash;
+	}
+
+	/**
+	 * The alias is the canonical directory name a format banlist was loaded
+	 * from (e.g. "jtp" for formats/jtp/lflist.conf), stored normalized to
+	 * lowercase. Lists loaded outside a formats/<alias>/ directory (e.g. the
+	 * base pool) have no alias.
+	 */
+	setAlias(alias: string): void {
+		this._alias = alias.toLowerCase();
+	}
+
+	get alias(): string | null {
+		return this._alias;
 	}
 
 	add(cardId: number, quantity: number, points?: number): void {

--- a/src/ygopro/ban-list/infrastructure/YGOProBanListLoader.ts
+++ b/src/ygopro/ban-list/infrastructure/YGOProBanListLoader.ts
@@ -88,13 +88,16 @@ export class YGOProBanListLoader {
 
 		this.logger.info("Loading ban lists from YGOPro resources...");
 
-		for await (const { item: lflist, text } of loader.getLFLists()) {
+		for await (const { item: lflist, text, alias } of loader.getLFLists()) {
 			const normalizedName = this.appendOcgSuffix(this.normalizeName(lflist.name || "Unnamed"));
 			const hash = lflist.getHash();
 
 			const banList = new YGOProBanList();
 			banList.setName(normalizedName);
 			banList.setHash(hash);
+			if (alias) {
+				banList.setAlias(alias);
+			}
 
 			const isWhitelist = text.includes("$whitelist");
 			if (isWhitelist) {

--- a/src/ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository.test.ts
+++ b/src/ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository.test.ts
@@ -1,0 +1,224 @@
+import { YGOProBanList } from "../domain/YGOProBanList";
+import YGOProBanListMemoryRepository from "./YGOProBanListMemoryRepository";
+import LoggerFactory from "src/shared/logger/infrastructure/LoggerFactory";
+
+function makeBanList(name: string, hash: number, alias?: string): YGOProBanList {
+	const banList = new YGOProBanList();
+	banList.setName(name);
+	banList.setHash(hash);
+	if (alias !== undefined) {
+		banList.setAlias(alias);
+	}
+	return banList;
+}
+
+describe("YGOProBanListMemoryRepository", () => {
+	afterEach(() => {
+		YGOProBanListMemoryRepository.clear();
+		jest.restoreAllMocks();
+	});
+
+	describe("findIndexByAlias", () => {
+		it("matches by normalized (lowercased, whitespace-stripped) substring inclusion", () => {
+			YGOProBanListMemoryRepository.add(makeBanList("2026.04 Edison Format", 1));
+			expect(YGOProBanListMemoryRepository.findIndexByAlias("edison")).toBe(0);
+			expect(YGOProBanListMemoryRepository.findIndexByAlias("EDISON")).toBe(0);
+			expect(YGOProBanListMemoryRepository.findIndexByAlias("Edison Format")).toBe(0);
+		});
+
+		it("ignores internal whitespace differences when normalizing", () => {
+			YGOProBanListMemoryRepository.add(makeBanList("Master Duel Classic", 1));
+			expect(YGOProBanListMemoryRepository.findIndexByAlias("masterduelclassic")).toBe(0);
+		});
+
+		it("returns -1 when no list matches the alias", () => {
+			YGOProBanListMemoryRepository.add(makeBanList("2026.04 OCG", 1));
+			expect(YGOProBanListMemoryRepository.findIndexByAlias("edison")).toBe(-1);
+		});
+
+		it("prefers an EXACT normalized-name match over a substring match elsewhere in the list", () => {
+			// "goat" is a substring of "goatee format" (index 0), but "GOAT" (index 1)
+			// is an exact normalized match — exact match must win regardless of order.
+			YGOProBanListMemoryRepository.add(makeBanList("Goatee Format", 1));
+			YGOProBanListMemoryRepository.add(makeBanList("GOAT", 2));
+
+			expect(YGOProBanListMemoryRepository.findIndexByAlias("goat")).toBe(1);
+		});
+
+		it("falls back to substring inclusion when there is no exact match", () => {
+			YGOProBanListMemoryRepository.add(makeBanList("2026.04 Edison Format", 1));
+			expect(YGOProBanListMemoryRepository.findIndexByAlias("edison")).toBe(0);
+		});
+
+		it("logs a warning naming the alias and the winners when the substring path matches more than one list", () => {
+			const warnSpy = jest
+				.spyOn(LoggerFactory.getLogger(), "warn")
+				.mockImplementation(() => undefined);
+
+			YGOProBanListMemoryRepository.add(makeBanList("2026.04 Edison Format", 1));
+			YGOProBanListMemoryRepository.add(makeBanList("2026.05 Edison Revised", 2));
+
+			const result = YGOProBanListMemoryRepository.findIndexByAlias("edison");
+
+			// Ambiguous substring match resolves deterministically by shortest
+			// normalized name ("2026.04 Edison Format" is shorter than "2026.05
+			// Edison Revised") and surfaces a warning so the ambiguity is diagnosable.
+			expect(result).toBe(0);
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("edison"));
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("2026.04 Edison Format"));
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("2026.05 Edison Revised"));
+		});
+
+		it("does NOT warn when the substring path matches exactly one list", () => {
+			const warnSpy = jest
+				.spyOn(LoggerFactory.getLogger(), "warn")
+				.mockImplementation(() => undefined);
+
+			YGOProBanListMemoryRepository.add(makeBanList("2026.04 Edison Format", 1));
+			YGOProBanListMemoryRepository.findIndexByAlias("edison");
+
+			expect(warnSpy).not.toHaveBeenCalled();
+		});
+
+		describe.each([
+			[
+				"A added before B",
+				(a: YGOProBanList, b: YGOProBanList) => {
+					YGOProBanListMemoryRepository.add(a);
+					YGOProBanListMemoryRepository.add(b);
+				},
+			],
+			[
+				"B added before A",
+				(a: YGOProBanList, b: YGOProBanList) => {
+					YGOProBanListMemoryRepository.add(b);
+					YGOProBanListMemoryRepository.add(a);
+				},
+			],
+		])("resolution independent of insertion order (%s)", (_label, insert) => {
+			it("resolves an alias-field exact match, and a name-substring query with no alias/name match, to the correct list", () => {
+				const jtp = makeBanList("JTP", 1, "jtp");
+				const jtpAdv = makeBanList("JTP Adv 2007-03", 2, "jtp-adv-2007-03");
+				insert(jtp, jtpAdv);
+
+				expect(YGOProBanListMemoryRepository.findByAlias("jtp")).toBe(jtp);
+				expect(YGOProBanListMemoryRepository.findByAlias("adv2007-03")).toBe(jtpAdv);
+			});
+
+			it("breaks a substring tie by shortest normalized name when neither an alias nor an exact name matches", () => {
+				const warnSpy = jest
+					.spyOn(LoggerFactory.getLogger(), "warn")
+					.mockImplementation(() => undefined);
+				const shorter = makeBanList("2026.04 Tengu", 1);
+				const longer = makeBanList("2026.04 Tengu Community Edition", 2);
+				insert(shorter, longer);
+
+				expect(YGOProBanListMemoryRepository.findByAlias("tengu")).toBe(shorter);
+				expect(YGOProBanListMemoryRepository.findByAlias("tengu")).toBe(shorter);
+
+				expect(warnSpy).toHaveBeenCalledTimes(1);
+			});
+		});
+
+		it("resolves the alias field even when a name-substring match would pick a different list", () => {
+			// "goat" is a substring of both names below; without the alias-field
+			// check the shorter (substring-tie-break) name would win instead.
+			const decoy = makeBanList("Goat Legacy Format", 1);
+			const target = makeBanList("2026.01 Goat Community", 2, "goat");
+
+			YGOProBanListMemoryRepository.add(decoy);
+			YGOProBanListMemoryRepository.add(target);
+
+			expect(YGOProBanListMemoryRepository.findByAlias("goat")).toBe(target);
+		});
+
+		it("resolves a base-pool list with no alias via existing name-based matching", () => {
+			YGOProBanListMemoryRepository.add(makeBanList("2026.04 Edison Format", 1));
+
+			expect(YGOProBanListMemoryRepository.findIndexByAlias("edison")).toBe(0);
+		});
+
+		// The shipping corpus (resources/current/ygopro) has exactly one banlist
+		// whose normalized name contains each of these aliases, so alias-field
+		// resolution and the substring tie-break both agree with plain
+		// exact/substring matching — this pins that today's real aliases resolve
+		// to the same list before and after the alias field and tie-break exist.
+		it("resolves today's real format aliases unambiguously", () => {
+			const md = makeBanList("2026.03 MD", 1, "md");
+			const edison = makeBanList("2010.03 Edison", 2, "edison");
+			const tengu = makeBanList("2011.09 Tengu", 3, "tengu");
+			const jtp = makeBanList("JTP", 4, "jtp");
+			const genesys = makeBanList("Genesys", 5, "genesys");
+			const world = makeBanList("2026.05 Worlds", 6, "world");
+
+			YGOProBanListMemoryRepository.add(md);
+			YGOProBanListMemoryRepository.add(edison);
+			YGOProBanListMemoryRepository.add(tengu);
+			YGOProBanListMemoryRepository.add(jtp);
+			YGOProBanListMemoryRepository.add(genesys);
+			YGOProBanListMemoryRepository.add(world);
+
+			expect(YGOProBanListMemoryRepository.findByAlias("md")).toBe(md);
+			expect(YGOProBanListMemoryRepository.findByAlias("edison")).toBe(edison);
+			expect(YGOProBanListMemoryRepository.findByAlias("tengu")).toBe(tengu);
+			expect(YGOProBanListMemoryRepository.findByAlias("jtp")).toBe(jtp);
+			expect(YGOProBanListMemoryRepository.findByAlias("genesys")).toBe(genesys);
+			expect(YGOProBanListMemoryRepository.findByAlias("world")).toBe(world);
+		});
+	});
+
+	describe("getFirstTCGIndex", () => {
+		it("returns the index of the first banlist whose name includes ' TCG'", () => {
+			YGOProBanListMemoryRepository.add(makeBanList("2026.04 OCG", 1));
+			YGOProBanListMemoryRepository.add(makeBanList("2026.05 TCG", 2));
+			expect(YGOProBanListMemoryRepository.getFirstTCGIndex()).toBe(1);
+		});
+
+		it("falls back to 0 when no TCG banlist is loaded", () => {
+			YGOProBanListMemoryRepository.add(makeBanList("2026.04 OCG", 1));
+			expect(YGOProBanListMemoryRepository.getFirstTCGIndex()).toBe(0);
+		});
+	});
+
+	describe("getFirstOCGIndex", () => {
+		it("returns the index of the first banlist whose name includes ' OCG'", () => {
+			YGOProBanListMemoryRepository.add(makeBanList("2026.05 TCG", 1));
+			YGOProBanListMemoryRepository.add(makeBanList("2026.04 OCG", 2));
+			expect(YGOProBanListMemoryRepository.getFirstOCGIndex()).toBe(1);
+		});
+
+		it("falls back to 0 when no OCG banlist is loaded", () => {
+			YGOProBanListMemoryRepository.add(makeBanList("2026.05 TCG", 1));
+			expect(YGOProBanListMemoryRepository.getFirstOCGIndex()).toBe(0);
+		});
+
+		// Mirrors resolveAliasIndex's warn-on-miss pattern (RuleMappings.ts): a
+		// silent 0-fallback here mislabels every OCG-list token (otto/oor/or/
+		// oomr/omr/ocg/ocgpre/ocgart) with whatever list happens to sit at index
+		// 0, with nothing in the logs to explain why. Warn once so the miss is
+		// diagnosable without flooding logs on every call.
+		it("warns once when falling back to 0 because no OCG banlist is loaded", () => {
+			const warnSpy = jest
+				.spyOn(LoggerFactory.getLogger(), "warn")
+				.mockImplementation(() => undefined);
+			YGOProBanListMemoryRepository.add(makeBanList("2026.05 TCG", 1));
+
+			YGOProBanListMemoryRepository.getFirstOCGIndex();
+			YGOProBanListMemoryRepository.getFirstOCGIndex();
+
+			expect(warnSpy).toHaveBeenCalledTimes(1);
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("OCG"));
+		});
+
+		it("does NOT warn when an OCG banlist is loaded", () => {
+			const warnSpy = jest
+				.spyOn(LoggerFactory.getLogger(), "warn")
+				.mockImplementation(() => undefined);
+			YGOProBanListMemoryRepository.add(makeBanList("2026.04 OCG", 1));
+
+			YGOProBanListMemoryRepository.getFirstOCGIndex();
+
+			expect(warnSpy).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository.ts
+++ b/src/ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository.ts
@@ -1,6 +1,20 @@
 import { YGOProBanList } from "../domain/YGOProBanList";
+import LoggerFactory from "src/shared/logger/infrastructure/LoggerFactory";
 
 const banLists: YGOProBanList[] = [];
+
+// Reset by clear()/replaceAll() so the warning stays scoped to "no OCG list
+// currently loaded", not "never warn again for the lifetime of the process".
+let hasWarnedMissingOCGList = false;
+
+// Tracked per normalized alias, and reset by clear()/replaceAll(), so an
+// ambiguous substring match warns once per alias instead of re-logging the
+// same, already-known ambiguity on every lookup.
+const warnedAmbiguousSubstringAliases = new Set<string>();
+
+function normalizeAliasKey(value: string): string {
+	return value.toLowerCase().replace(/\s+/g, "");
+}
 
 export default {
 	add(banList: YGOProBanList): void {
@@ -22,6 +36,30 @@ export default {
 		return tcgIndex >= 0 ? tcgIndex : 0;
 	},
 
+	/**
+	 * Mirror of getFirstTCGIndex — returns the index of the first banlist that
+	 * contains " OCG" in its name (the naming convention EDOpro/YGOProBanListLoader
+	 * produces for OCG lists, e.g. "2026.04 OCG"). Used by rule tokens that mean
+	 * "the OCG list" (otto, oor/ocgonly, or, oomr, omr, ocg, ocgpre, ocgart).
+	 * Returns 0 as fallback if no OCG banlist is found, warning once (like
+	 * RuleMappings.resolveAliasIndex) instead of silently mislabeling every
+	 * room using an OCG-list token.
+	 */
+	getFirstOCGIndex(): number {
+		const ocgIndex = banLists.findIndex((list) => list.name && list.name.includes(" OCG"));
+		if (ocgIndex >= 0) {
+			return ocgIndex;
+		}
+
+		if (!hasWarnedMissingOCGList) {
+			hasWarnedMissingOCGList = true;
+			LoggerFactory.getLogger().warn(
+				'YGOProBanListMemoryRepository.getFirstOCGIndex: no banlist name contains " OCG" — falling back to index 0. Rooms using OCG-list tokens (otto/oor/or/oomr/omr/ocg/ocgpre/ocgart) will be mislabeled with whatever list sits there.',
+			);
+		}
+		return 0;
+	},
+
 	findByHash(hash: number): YGOProBanList | null {
 		return banLists.find((list) => list.hash === hash) ?? null;
 	},
@@ -35,13 +73,65 @@ export default {
 		return index !== -1 ? banLists[index] : null;
 	},
 
+	/**
+	 * Resolves an alias to a banlist index, fully deterministic and
+	 * independent of load/insertion order:
+	 *  1. an exact match on the alias field set at load time (e.g. the
+	 *     formats/<alias>/lflist.conf directory name);
+	 *  2. an exact normalized-name match;
+	 *  3. a substring-inclusion scan over normalized names, tie-broken by
+	 *     shortest normalized name, then lexicographically on the normalized
+	 *     name.
+	 * When the substring scan (step 3) matches more than one list, a warning
+	 * names the alias, the chosen winner, and every candidate — so the
+	 * ambiguity is diagnosable instead of silent. The warning fires once per
+	 * normalized alias.
+	 */
 	findIndexByAlias(alias: string): number {
-		const normalizedAlias = alias.toLowerCase().replace(/\s+/g, "");
-		return banLists.findIndex((list) => {
+		const normalizedAlias = normalizeAliasKey(alias);
+
+		const aliasFieldIndex = banLists.findIndex((list) => list.alias === normalizedAlias);
+		if (aliasFieldIndex !== -1) {
+			return aliasFieldIndex;
+		}
+
+		const exactIndex = banLists.findIndex((list) => {
 			if (!list.name) return false;
-			const normalizedName = list.name.toLowerCase().replace(/\s+/g, "");
-			return normalizedName.includes(normalizedAlias);
+			return normalizeAliasKey(list.name) === normalizedAlias;
 		});
+		if (exactIndex !== -1) {
+			return exactIndex;
+		}
+
+		const substringMatches = banLists
+			.map((list, index) => ({ list, index }))
+			.filter(({ list }) => {
+				if (!list.name) return false;
+				return normalizeAliasKey(list.name).includes(normalizedAlias);
+			});
+
+		if (substringMatches.length === 0) {
+			return -1;
+		}
+
+		const [winner] = [...substringMatches].sort((a, b) => {
+			const nameA = normalizeAliasKey(a.list.name ?? "");
+			const nameB = normalizeAliasKey(b.list.name ?? "");
+			if (nameA.length !== nameB.length) {
+				return nameA.length - nameB.length;
+			}
+			return nameA < nameB ? -1 : nameA > nameB ? 1 : 0;
+		});
+
+		if (substringMatches.length > 1 && !warnedAmbiguousSubstringAliases.has(normalizedAlias)) {
+			warnedAmbiguousSubstringAliases.add(normalizedAlias);
+			const winners = substringMatches.map(({ list }) => list.name).join(", ");
+			LoggerFactory.getLogger().warn(
+				`YGOProBanListMemoryRepository.findIndexByAlias: alias "${alias}" matched ${substringMatches.length} ban lists by substring — using "${winner.list.name}" (shortest normalized name, ties broken lexicographically). Candidates: ${winners}`,
+			);
+		}
+
+		return winner.index;
 	},
 
 	findIndexByHash(hash: number): number {
@@ -54,6 +144,8 @@ export default {
 
 	clear(): void {
 		banLists.length = 0;
+		hasWarnedMissingOCGList = false;
+		warnedAmbiguousSubstringAliases.clear();
 	},
 
 	/**
@@ -63,5 +155,7 @@ export default {
 	replaceAll(next: YGOProBanList[]): void {
 		banLists.length = 0;
 		banLists.push(...next);
+		hasWarnedMissingOCGList = false;
+		warnedAmbiguousSubstringAliases.clear();
 	},
 };

--- a/src/ygopro/room/application/YGOProJoinHandler.ts
+++ b/src/ygopro/room/application/YGOProJoinHandler.ts
@@ -45,8 +45,21 @@ export class YGOProJoinHandler implements JoinMessageHandler {
 		const joinMessage = new YGOProCtosJoinGame().fromPayload(message.data);
 
 		// NOTE: password is the single segment after the first "#", matching
-		// YGOProRoom.create's own parsing. Do NOT join the rest with "#" — a room
-		// password containing "#" must still compare equal in DefaultJoinStrategy.
+		// YGOProRoom.create's own parsing (`command.split("#")` there too — same
+		// two-segment destructure, same truncation). Do NOT join the rest with
+		// "#": a room password that itself contains "#" is silently truncated at
+		// the FIRST "#" on BOTH sides — the host's password is truncated the same
+		// way at room-creation time (YGOProRoom.create), and a joiner's password
+		// is truncated here. Whatever comes after the second "#" is simply
+		// dropped, on both ends, every time. This keeps
+		// YGOProRoomList.findByNameAndPassword's strict `===` password
+		// comparison consistent (both sides truncate identically), but it does
+		// mean a full pass string like "room#pa#ss" is
+		// effectively "room#pa": the room password becomes "pa", the "#ss" tail
+		// vanishes, and anyone sending "room#pa" gets in — a "#" inside a room
+		// password silently weakens it. Documented in docs/join-commands.md, not
+		// fixed here: joining the tail back would have to change host and joiner
+		// parsing simultaneously and would lock out rooms alive during a rollout.
 		// AI/AIJOIN strategies read ctx.rawPass directly, so they are unaffected.
 		const [command, password = ""] = joinMessage.pass.split("#");
 

--- a/src/ygopro/room/application/join-strategies/DefaultJoinStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/DefaultJoinStrategy.test.ts
@@ -78,9 +78,14 @@ describe("DefaultJoinStrategy", () => {
 	});
 
 	describe("handle()", () => {
-		it("destroys the socket when the room exists but password is wrong", async () => {
+		// Room identity for non-pairing joins is the exact (name, password)
+		// pair (see findOrCreateRoom), so a mismatched password identifies a
+		// DIFFERENT room rather than rejecting the join: no matching pair
+		// creates a new room and routes the joiner into it, leaving the
+		// original room untouched.
+		it("creates a new room and routes JOIN into it when the existing same-named room's password does not match", async () => {
 			const emitter = new EventEmitter();
-			const room = YGOProRoom.create(
+			const existingRoom = YGOProRoom.create(
 				9999,
 				"SECRETROOM#correctpass",
 				makeLogger() as never,
@@ -89,19 +94,69 @@ describe("DefaultJoinStrategy", () => {
 				"sock-original",
 				makeMessageRepository() as never,
 			);
-			YGOProRoomList.addRoom(room);
+			YGOProRoomList.addRoom(existingRoom);
+
+			const waitingSpy = jest
+				.spyOn(YGOProRoom.prototype, "waiting")
+				.mockImplementation(() => undefined);
+			const emitSpy = jest.spyOn(YGOProRoom.prototype, "emit").mockImplementation(() => undefined);
 
 			const socket = makeSocket();
+			const messageRepository = makeMessageRepository();
 			const ctx = makeCtx({
 				rawPass: "SECRETROOM#wrongpass",
 				command: "SECRETROOM",
 				password: "wrongpass",
 				socket: socket as never,
+				messageRepository: messageRepository as never,
 			});
 
 			await strategy.handle(ctx);
 
-			expect(socket.destroy).toHaveBeenCalled();
+			expect(socket.close).not.toHaveBeenCalled();
+			expect(messageRepository.errorMessage).not.toHaveBeenCalled();
+
+			const rooms = YGOProRoomList.getRooms();
+			expect(rooms).toHaveLength(2);
+			const newRoom = rooms.find((candidate) => candidate !== existingRoom);
+			expect(newRoom?.name).toBe("SECRETROOM");
+			expect(newRoom?.password).toBe("wrongpass");
+			expect(emitSpy).toHaveBeenCalledWith("JOIN", expect.anything(), ctx.socket);
+			expect(emitSpy.mock.instances[0]).toBe(newRoom);
+
+			waitingSpy.mockRestore();
+			emitSpy.mockRestore();
+		});
+
+		it("routes JOIN to the same room mid-duel when the password matches (spectating is decided downstream by the room's own state)", async () => {
+			const emitter = new EventEmitter();
+			const room = YGOProRoom.create(
+				6666,
+				"DUELROOM#pass",
+				makeLogger() as never,
+				emitter,
+				{ name: "TestPlayer", password: "", previousMessage: Buffer.alloc(0) } as never,
+				"sock-original",
+				makeMessageRepository() as never,
+			);
+			YGOProRoomList.addRoom(room);
+			room.rps(); // lightweight non-waiting transition, no OCGCore needed
+
+			const emitSpy = jest.spyOn(room, "emit").mockImplementation(() => undefined);
+
+			const socket = makeSocket();
+			const ctx = makeCtx({
+				rawPass: "DUELROOM#pass",
+				command: "DUELROOM",
+				password: "pass",
+				socket: socket as never,
+				eventEmitter: emitter,
+			});
+
+			await strategy.handle(ctx);
+
+			expect(emitSpy).toHaveBeenCalledWith("JOIN", expect.anything(), ctx.socket);
+			expect(YGOProRoomList.getRooms()).toHaveLength(1);
 		});
 
 		it("calls room.emit(JOIN) when the existing room has the correct password", async () => {
@@ -188,6 +243,45 @@ describe("DefaultJoinStrategy", () => {
 			emitSpy.mockRestore();
 
 			expect(YGOProRoomList.findByName("NEWROOM")).not.toBeNull();
+		});
+
+		// "TCG" is a recognized rule token with no password segment, so the second
+		// sender must land in the FIRST sender's waiting room instead of creating a
+		// separate one (see findOrCreateRoom.test.ts for the full pairing-scenario
+		// matrix; this is the thin end-to-end proof that DefaultJoinStrategy wires
+		// into it).
+		it("routes a second joiner with the same recognized command into the first's waiting room (pairing)", async () => {
+			const emitter = new EventEmitter();
+
+			const waitingSpy = jest
+				.spyOn(YGOProRoom.prototype, "waiting")
+				.mockImplementation(() => undefined);
+			const emitSpy = jest.spyOn(YGOProRoom.prototype, "emit").mockImplementation(() => undefined);
+
+			const firstCtx = makeCtx({
+				rawPass: "TCG",
+				command: "TCG",
+				password: "",
+				socket: makeSocket() as never,
+				eventEmitter: emitter,
+				messageRepository: makeMessageRepository() as never,
+			});
+			await strategy.handle(firstCtx);
+
+			const secondCtx = makeCtx({
+				rawPass: "TCG",
+				command: "TCG",
+				password: "",
+				socket: makeSocket() as never,
+				eventEmitter: emitter,
+				messageRepository: makeMessageRepository() as never,
+			});
+			await strategy.handle(secondCtx);
+
+			waitingSpy.mockRestore();
+			emitSpy.mockRestore();
+
+			expect(YGOProRoomList.getRooms()).toHaveLength(1);
 		});
 	});
 });

--- a/src/ygopro/room/application/join-strategies/DefaultJoinStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/DefaultJoinStrategy.ts
@@ -1,14 +1,11 @@
-import { generateUniqueId } from "src/utils/generateUniqueId";
-
 import { JoinContext, JoinStrategy } from "./JoinStrategy";
-import { YGOProRoom } from "../../domain/YGOProRoom";
-import YGOProRoomList from "../../infrastructure/YGOProRoomList";
+import { findOrCreateRoom } from "./findOrCreateRoom";
 
 /**
  * DefaultJoinStrategy — terminal fallback.
  *
- * Behavior is an EXACT extraction of the original YGOProJoinHandler.findOrCreateRoom logic.
- * No behavioral changes — only the existing find-or-create + JOIN emit.
+ * Delegates find-or-create to findOrCreateRoom and routes the JOIN event;
+ * it holds no room-matching logic of its own.
  *
  * This strategy always matches (terminal).
  */
@@ -18,40 +15,13 @@ export class DefaultJoinStrategy implements JoinStrategy {
 	}
 
 	async handle(ctx: JoinContext): Promise<void> {
-		const room = this._findOrCreateRoom(ctx);
-
-		if (!room) {
-			ctx.logger.info("JOIN_GAME rejected: wrong password");
-			ctx.socket.destroy();
-			return;
-		}
+		// rankedOverride is left `undefined` (not `false`): RoomLeague.determine
+		// treats undefined as "fall through to hasPin", so an anonymous join
+		// carrying a PIN still resolves to the External league.
+		const room = findOrCreateRoom(ctx, { rankedOverride: undefined });
 
 		// Admission — ranked auth and league segregation — is decided inside the
 		// room's WaitingState via AdmitToRoom. The strategy only routes the join.
 		room.emit("JOIN", ctx.message, ctx.socket);
-	}
-
-	private _findOrCreateRoom(ctx: JoinContext): YGOProRoom | null {
-		const existingRoom = YGOProRoomList.findByName(ctx.command);
-		if (existingRoom) {
-			if (existingRoom.password !== ctx.password) {
-				return null;
-			}
-			return existingRoom;
-		}
-
-		const room = YGOProRoom.create(
-			generateUniqueId(),
-			ctx.rawPass,
-			ctx.logger,
-			ctx.eventEmitter,
-			ctx.playerInfo,
-			ctx.socketId,
-			ctx.messageRepository,
-		);
-		YGOProRoomList.addRoom(room);
-		room.waiting();
-
-		return room;
 	}
 }

--- a/src/ygopro/room/application/join-strategies/JoinStrategyRegistry.test.ts
+++ b/src/ygopro/room/application/join-strategies/JoinStrategyRegistry.test.ts
@@ -83,6 +83,38 @@ describe("JoinStrategyRegistry", () => {
 			const instance = JoinStrategyRegistry.getInstance();
 			expect(instance).toBeDefined();
 		});
+
+		// The never-initialized lazy fallback must build the same base chain as
+		// composeJoinStrategies() with no windbot arg — otherwise any process
+		// that reaches getInstance() before bootstrap wires
+		// composeJoinStrategies() in would silently drop TicketJoinStrategy.
+		it("the never-initialized lazy fallback still routes ticket-authenticated sockets to TicketJoinStrategy", () => {
+			JoinStrategyRegistry.reset();
+			const instance = JoinStrategyRegistry.getInstance();
+
+			const ctx = {
+				rawPass: "ROOM",
+				command: "ROOM",
+				password: "",
+				socket: { resolvedUserId: "some-user-id" },
+			} as unknown as JoinContext;
+
+			expect(instance.resolve(ctx)).toBeInstanceOf(TicketJoinStrategy);
+		});
+
+		it("the never-initialized lazy fallback still falls through to DefaultJoinStrategy", () => {
+			JoinStrategyRegistry.reset();
+			const instance = JoinStrategyRegistry.getInstance();
+
+			const ctx = {
+				rawPass: "ROOM",
+				command: "ROOM",
+				password: "",
+				socket: { resolvedUserId: undefined },
+			} as unknown as JoinContext;
+
+			expect(instance.resolve(ctx)).toBeInstanceOf(DefaultJoinStrategy);
+		});
 	});
 
 	describe("bootstrap — base chain [TicketJoinStrategy, DefaultJoinStrategy]", () => {

--- a/src/ygopro/room/application/join-strategies/JoinStrategyRegistry.ts
+++ b/src/ygopro/room/application/join-strategies/JoinStrategyRegistry.ts
@@ -1,5 +1,5 @@
 import { JoinContext, JoinStrategy } from "./JoinStrategy";
-import { DefaultJoinStrategy } from "./DefaultJoinStrategy";
+import { composeJoinStrategies } from "./composeJoinStrategies";
 
 /**
  * JoinStrategyRegistry — ordered resolver for join strategies.
@@ -7,7 +7,8 @@ import { DefaultJoinStrategy } from "./DefaultJoinStrategy";
  * Priority order (highest to lowest):
  *   1. AIJoinTokenStrategy  — catches reverse-connecting bot first (AIJOIN# prefix)
  *   2. WindBotJoinStrategy  — matches the explicit "ai" token (AI / AI#name) when windbot enabled
- *   3. DefaultJoinStrategy  — terminal fallback, always matches (blank password lands here)
+ *   3. TicketJoinStrategy   — matches sockets authenticated via a WS handshake ticket
+ *   4. DefaultJoinStrategy  — terminal fallback, always matches (blank password lands here)
  *
  * Mirrors the YGOProRoomList module-level singleton pattern.
  *
@@ -35,12 +36,14 @@ export class JoinStrategyRegistry {
 
 	/**
 	 * Returns the module-level singleton.
-	 * Lazily constructed with a DefaultJoinStrategy-only chain on first call
-	 * (windbot strategies are added when WindbotModule is initialized).
+	 * Lazily constructed with the base chain (composeJoinStrategies() called
+	 * with no windbot arg → [TicketJoinStrategy, DefaultJoinStrategy]) on first
+	 * call — windbot strategies are added when WindbotModule is initialized via
+	 * setStrategies().
 	 */
 	static getInstance(): JoinStrategyRegistry {
 		if (!JoinStrategyRegistry._instance) {
-			JoinStrategyRegistry._instance = new JoinStrategyRegistry([new DefaultJoinStrategy()]);
+			JoinStrategyRegistry._instance = new JoinStrategyRegistry(composeJoinStrategies());
 		}
 		return JoinStrategyRegistry._instance;
 	}

--- a/src/ygopro/room/application/join-strategies/SocketCloseOnError.test.ts
+++ b/src/ygopro/room/application/join-strategies/SocketCloseOnError.test.ts
@@ -5,17 +5,34 @@
  * close the socket AFTER the send — using close() (graceful), NOT destroy().
  *
  * Why close() and not destroy():
- *   destroy() → ws.terminate() is abrupt and can drop the queued error frame, so the
- *   client never receives the JOINERROR it needs to react to. close() → ws.close()
- *   performs the closing handshake and flushes queued frames first, so the error is
- *   delivered AND the socket is torn down (no live-but-rejected connection the client
- *   keeps reusing). Pure-rejection paths with no message (wrong password) still use
- *   destroy() — see DefaultJoinStrategy / TicketJoinStrategy.
+ *   destroy() → ws.terminate()/socket.destroy() is abrupt and can drop the queued
+ *   error frame, so the client never receives the JOINERROR it needs to react to.
+ *   close() → ws.close()/socket.end() performs a graceful (half-)close and flushes
+ *   queued frames first, so the error is delivered AND the socket is torn down (no
+ *   live-but-rejected connection the client keeps reusing).
+ *
+ *   BOTH the tag-mode rejection AND the requestBot-failure paths send + close().
+ *   close() being a half-close (TCP: end(), WS: close()) rather than an
+ *   immediate hard reset is a deliberate UX tradeoff: it is
+ *   attacker-triggerable (a client can force this path repeatedly, e.g. by
+ *   resending an invalid AI join token or an unresolvable windbot request),
+ *   so a half-close lingers slightly longer than destroy() would. Revisit if
+ *   FIN_WAIT abuse / socket exhaustion from repeated triggering is observed in
+ *   production.
+ *
+ *   DefaultJoinStrategy and TicketJoinStrategy never reject on a mismatched
+ *   room password — a mismatch resolves to a different room via
+ *   findOrCreateRoom's (name, password) identity, not an error path. The one
+ *   remaining destroy()-only path with a message is
+ *   RoomState.sendExistingPlayerErrorMessage (duplicate player name), which
+ *   is not covered by this suite.
  *
  * Covered error paths:
  *   WindBotJoinStrategy:
  *     1. Tag-mode rejection → send + close
- *     2. requestBot failure → send + close
+ *     2. requestBot failure → send + close (must run BEFORE
+ *        FinalizeYGOProRoom.run() tears the room's clients down — see
+ *        WindBotJoinStrategy.test.ts for the ordering regression test)
  *
  *   AIJoinTokenStrategy:
  *     3. Invalid token → send + close
@@ -23,6 +40,21 @@
  */
 
 import { EventEmitter } from "stream";
+
+// WindBotJoinStrategy's requestBot-failure path delegates to
+// FinalizeYGOProRoom.run(), which broadcasts REMOVE-ROOM via WebSocketSingleton.
+// Mock it so tests don't spin up a real HTTP+WS server (mirrors
+// FinalizeYGOProRoom.test.ts / WindBotJoinStrategy.test.ts).
+jest.mock("../../../../web-socket-server/WebSocketSingleton", () => {
+	const mockBroadcast = jest.fn();
+	return {
+		__esModule: true,
+		default: {
+			getInstance: () => ({ broadcast: mockBroadcast }),
+		},
+		mockBroadcast,
+	};
+});
 
 import { WindBotJoinStrategy } from "./WindBotJoinStrategy";
 import { AIJoinTokenStrategy } from "./AIJoinTokenStrategy";

--- a/src/ygopro/room/application/join-strategies/TicketJoinStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/TicketJoinStrategy.test.ts
@@ -19,6 +19,7 @@ const makeSocket = (resolvedUserId?: string) => ({
 	id: "sock-1",
 	resolvedUserId,
 	destroy: jest.fn(),
+	close: jest.fn(),
 	send: jest.fn(),
 });
 
@@ -165,7 +166,12 @@ describe("TicketJoinStrategy", () => {
 			expect(emitSpy).toHaveBeenCalledWith("JOIN", expect.anything(), ctx.socket);
 		});
 
-		it("rejects the join when the existing room password does NOT match", async () => {
+		// Room identity for non-pairing joins is the exact (name, password)
+		// pair (see findOrCreateRoom), so a mismatched password identifies a
+		// DIFFERENT room rather than rejecting the join: no matching pair
+		// creates a new ranked room (TicketJoinStrategy's rankedOverride=true)
+		// and routes the joiner into it, leaving the original room untouched.
+		it("creates a new ranked room and routes JOIN into it when the existing room's password does NOT match", async () => {
 			const { YGOProRoom } = await import("../../domain/YGOProRoom");
 			const { MessageRepositoryMock } = await import("@test-support/mocks/MessageRepositoryMock");
 			const { LoggerMock } = await import("@test-support/mocks/logger/LoggerMock");
@@ -184,20 +190,40 @@ describe("TicketJoinStrategy", () => {
 				true,
 			);
 			YGOProRoomList.addRoom(existingRoom);
-			const emitSpy = jest.spyOn(existingRoom, "emit").mockImplementation(() => undefined);
+			const originalEmitSpy = jest.spyOn(existingRoom, "emit").mockImplementation(() => undefined);
+
+			const waitingSpy = jest
+				.spyOn(YGOProRoom.prototype, "waiting")
+				.mockImplementation(() => undefined);
+			const emitSpy = jest.spyOn(YGOProRoom.prototype, "emit").mockImplementation(() => undefined);
 
 			const socket = makeSocket("ticket-user");
+			const messageRepository = makeMessageRepository();
 			const ctx = makeCtx({
 				socket: socket as never,
 				command: "TESTROOM",
-				password: "",
-				rawPass: "TESTROOM",
+				password: "wrong",
+				rawPass: "TESTROOM#wrong",
+				messageRepository: messageRepository as never,
 			});
 
 			await strategy.handle(ctx);
 
-			expect(socket.destroy).toHaveBeenCalled();
-			expect(emitSpy).not.toHaveBeenCalled();
+			expect(socket.close).not.toHaveBeenCalled();
+			expect(messageRepository.errorMessage).not.toHaveBeenCalled();
+			expect(originalEmitSpy).not.toHaveBeenCalled();
+
+			const rooms = YGOProRoomList.getRooms();
+			expect(rooms).toHaveLength(2);
+			const newRoom = rooms.find((candidate) => candidate !== existingRoom);
+			expect(newRoom?.name).toBe("TESTROOM");
+			expect(newRoom?.password).toBe("wrong");
+			expect(newRoom?.ranked).toBe(true);
+			expect(emitSpy).toHaveBeenCalledWith("JOIN", expect.anything(), ctx.socket);
+			expect(emitSpy.mock.instances[0]).toBe(newRoom);
+
+			waitingSpy.mockRestore();
+			emitSpy.mockRestore();
 		});
 
 		it("joins an existing room when a non-empty room password matches", async () => {
@@ -231,6 +257,43 @@ describe("TicketJoinStrategy", () => {
 			await strategy.handle(ctx);
 
 			expect(emitSpy).toHaveBeenCalledWith("JOIN", expect.anything(), ctx.socket);
+		});
+
+		// "TCG" is a recognized rule token with no password segment, so a second
+		// ticket-authenticated sender must land in the FIRST sender's waiting
+		// room instead of creating a separate one (see findOrCreateRoom.test.ts
+		// for the full pairing-scenario matrix).
+		it("routes a second ticket joiner with the same recognized command into the first's waiting room (pairing)", async () => {
+			const { YGOProRoom } = await import("../../domain/YGOProRoom");
+			const emitter = new EventEmitter();
+
+			const waitingSpy = jest
+				.spyOn(YGOProRoom.prototype, "waiting")
+				.mockImplementation(() => undefined);
+			const emitSpy = jest.spyOn(YGOProRoom.prototype, "emit").mockImplementation(() => undefined);
+
+			const firstCtx = makeCtx({
+				rawPass: "TCG",
+				command: "TCG",
+				password: "",
+				socket: makeSocket("ticket-user-1") as never,
+				eventEmitter: emitter,
+			});
+			await strategy.handle(firstCtx);
+
+			const secondCtx = makeCtx({
+				rawPass: "TCG",
+				command: "TCG",
+				password: "",
+				socket: makeSocket("ticket-user-2") as never,
+				eventEmitter: emitter,
+			});
+			await strategy.handle(secondCtx);
+
+			waitingSpy.mockRestore();
+			emitSpy.mockRestore();
+
+			expect(YGOProRoomList.getRooms()).toHaveLength(1);
 		});
 	});
 });

--- a/src/ygopro/room/application/join-strategies/TicketJoinStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/TicketJoinStrategy.ts
@@ -1,8 +1,5 @@
-import { generateUniqueId } from "src/utils/generateUniqueId";
-
 import { JoinContext, JoinStrategy } from "./JoinStrategy";
-import { YGOProRoom } from "../../domain/YGOProRoom";
-import YGOProRoomList from "../../infrastructure/YGOProRoomList";
+import { findOrCreateRoom } from "./findOrCreateRoom";
 
 /**
  * TicketJoinStrategy — handles joins from sockets that were authenticated
@@ -16,9 +13,12 @@ import YGOProRoomList from "../../infrastructure/YGOProRoomList";
  * - JOIN is emitted directly.
  *
  * The ticket only replaces the username:password LOGIN credential — it does
- * NOT bypass the per-room password (the "command#password" room key). An
- * existing room with a password must still be joined with the matching key,
- * exactly like DefaultJoinStrategy, so private rooms stay private.
+ * NOT bypass the per-room password (the "command#password" room key). Room
+ * identity is the exact (name, password) pair (see findOrCreateRoom /
+ * YGOProRoomList.findByNameAndPassword), so a mismatched key never reaches an
+ * existing room — it identifies a DIFFERENT room outright, exactly like
+ * DefaultJoinStrategy. This is what keeps private rooms private: the
+ * (name, password) pair never matches without the correct password.
  */
 export class TicketJoinStrategy implements JoinStrategy {
 	matches(ctx: JoinContext): boolean {
@@ -26,37 +26,8 @@ export class TicketJoinStrategy implements JoinStrategy {
 	}
 
 	async handle(ctx: JoinContext): Promise<void> {
-		const room = this._findOrCreateRankedRoom(ctx);
-		if (!room) {
-			ctx.logger.info("JOIN_GAME rejected: wrong password");
-			ctx.socket.destroy();
-			return;
-		}
+		// rankedOverride: true — ticket users always join ranked rooms.
+		const room = findOrCreateRoom(ctx, { rankedOverride: true });
 		room.emit("JOIN", ctx.message, ctx.socket);
-	}
-
-	private _findOrCreateRankedRoom(ctx: JoinContext): YGOProRoom | null {
-		const existingRoom = YGOProRoomList.findByName(ctx.command);
-		if (existingRoom) {
-			if (existingRoom.password !== ctx.password) {
-				return null;
-			}
-			return existingRoom;
-		}
-
-		const room = YGOProRoom.create(
-			generateUniqueId(),
-			ctx.rawPass,
-			ctx.logger,
-			ctx.eventEmitter,
-			ctx.playerInfo,
-			ctx.socketId,
-			ctx.messageRepository,
-			true, // rankedOverride — ticket users always join ranked rooms
-		);
-		YGOProRoomList.addRoom(room);
-		room.waiting();
-
-		return room;
 	}
 }

--- a/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.test.ts
@@ -1,5 +1,23 @@
 import { EventEmitter } from "stream";
 
+// The requestBot failure path delegates to FinalizeYGOProRoom.run(), which
+// broadcasts REMOVE-ROOM via WebSocketSingleton. Mock it so tests don't spin
+// up a real HTTP+WS server (mirrors FinalizeYGOProRoom.test.ts).
+jest.mock("../../../../web-socket-server/WebSocketSingleton", () => {
+	const mockBroadcast = jest.fn();
+	return {
+		__esModule: true,
+		default: {
+			getInstance: () => ({ broadcast: mockBroadcast }),
+		},
+		mockBroadcast,
+	};
+});
+
+import { Seat } from "@shared/room/admission/domain/Seat";
+
+import { MessageRepositoryMock } from "@test-support/mocks/MessageRepositoryMock";
+
 import { JoinContext } from "./JoinStrategy";
 import { WindBotJoinStrategy } from "./WindBotJoinStrategy";
 import { WindbotModule, WindbotModuleDeps } from "../../../windbot/application/WindbotModule";
@@ -7,6 +25,8 @@ import { WindbotTokenStore } from "../../../windbot/domain/WindbotTokenStore";
 import { WindbotUnreachableError } from "../../../windbot/domain/WindbotErrors";
 import YGOProRoomList from "../../infrastructure/YGOProRoomList";
 import { YGOProRoom } from "../../domain/YGOProRoom";
+import { FinalizeYGOProRoom } from "../FinalizeYGOProRoom";
+import WebSocketSingleton from "../../../../web-socket-server/WebSocketSingleton";
 
 // ---- helpers ----
 
@@ -111,6 +131,7 @@ describe("WindBotJoinStrategy", () => {
 	afterEach(() => {
 		waitingSpy.mockRestore();
 		emitSpy.mockRestore();
+		jest.clearAllMocks();
 		const rooms = YGOProRoomList.getRooms();
 		while (rooms.length) {
 			YGOProRoomList.deleteRoom(rooms[0]);
@@ -368,6 +389,57 @@ describe("WindBotJoinStrategy", () => {
 			});
 		});
 
+		describe("format-aware random pool resolution (REQ-WINDBOT-POOL)", () => {
+			it("'ed,ai' requests a random bot from the edison pool", async () => {
+				const repo = makeRepo();
+				const mod = makeModule({ repo });
+				const strategy = new WindBotJoinStrategy(mod);
+
+				const ctx = makeCtx("ed,ai");
+
+				await strategy.handle(ctx);
+
+				expect(repo.pickRandom).toHaveBeenCalledWith("edison");
+			});
+
+			it("bare 'ai' keeps the generic pool (undefined)", async () => {
+				const repo = makeRepo();
+				const mod = makeModule({ repo });
+				const strategy = new WindBotJoinStrategy(mod);
+
+				const ctx = makeCtx("ai");
+
+				await strategy.handle(ctx);
+
+				expect(repo.pickRandom).toHaveBeenCalledWith(undefined);
+			});
+
+			it("'pre,ai' requests a random bot from the tcg pool", async () => {
+				const repo = makeRepo();
+				const mod = makeModule({ repo });
+				const strategy = new WindBotJoinStrategy(mod);
+
+				const ctx = makeCtx("pre,ai");
+
+				await strategy.handle(ctx);
+
+				expect(repo.pickRandom).toHaveBeenCalledWith("tcg");
+			});
+
+			it("does not consult the pool when a bot name is given (named lookup, not random)", async () => {
+				const repo = makeRepo();
+				const mod = makeModule({ repo });
+				const strategy = new WindBotJoinStrategy(mod);
+
+				const ctx = makeCtx("ed,ai#Blackwing");
+
+				await strategy.handle(ctx);
+
+				expect(repo.findByName).toHaveBeenCalledWith("Blackwing");
+				expect(repo.pickRandom).not.toHaveBeenCalled();
+			});
+		});
+
 		describe("requestBot failure path", () => {
 			it("sends error to human and closes socket when requestBot throws", async () => {
 				const provider = {
@@ -404,6 +476,98 @@ describe("WindBotJoinStrategy", () => {
 
 				// Room must be deleted
 				expect(YGOProRoomList.getRooms().length).toBe(0);
+			});
+
+			// The failure path must run the CANONICAL teardown
+			// (FinalizeYGOProRoom.run), not a bare YGOProRoomList.deleteRoom(room).
+			// A bare deleteRoom leaks the human's reconnection token (issued by
+			// YGOProWaitingState) into the no-TTL TokenIndex.
+			it("runs the canonical teardown (finalizing flag + REMOVE-ROOM broadcast) on requestBot failure", async () => {
+				const provider = {
+					requestJoin: jest.fn().mockRejectedValue(new WindbotUnreachableError("Anna", 10)),
+				};
+				const mod = makeModule({ provider: provider as never });
+				const strategy = new WindBotJoinStrategy(mod);
+
+				const ctx = makeCtx("AI");
+
+				await strategy.handle(ctx);
+				const room = YGOProRoomList.getRooms()[0];
+				expect(room).toBeDefined();
+
+				await new Promise((r) => setImmediate(r));
+
+				expect(room.finalizing).toBe(true);
+				expect(WebSocketSingleton.getInstance().broadcast).toHaveBeenCalledWith(
+					expect.objectContaining({ action: "REMOVE-ROOM" }),
+				);
+			});
+
+			// FinalizeYGOProRoom.run(room) destroys every seated client's socket.
+			// The human is seated by the earlier JOIN emit, so if run() executes
+			// before the JOINERROR send()/close(), the human's socket would already
+			// be destroyed by the time send() runs — a silent no-op (WS) or
+			// ERR_STREAM_DESTROYED (TCP), leaving the human with a bare disconnect
+			// and no error frame.
+			//
+			// This scenario deliberately does NOT rely on the global `emit` mock
+			// (which leaves room.clients empty and makes ordering regressions
+			// invisible — see SocketCloseOnError.test.ts). It seats a REAL client
+			// on ctx.socket via room.admissionTarget, mirroring what the real JOIN
+			// handler does, so FinalizeYGOProRoom.run() has an actual client to
+			// tear down and any ordering regression is observable.
+			it("delivers JOINERROR to the seated human's socket BEFORE FinalizeYGOProRoom tears the room down", async () => {
+				const provider = {
+					requestJoin: jest.fn().mockRejectedValue(new WindbotUnreachableError("Anna", 10)),
+				};
+				const mod = makeModule({ provider: provider as never });
+				const strategy = new WindBotJoinStrategy(mod);
+
+				const callOrder: string[] = [];
+				const socket = {
+					...makeSocket(),
+					send: jest.fn(() => callOrder.push("send")),
+					close: jest.fn(() => callOrder.push("close")),
+					destroy: jest.fn(() => callOrder.push("destroy")),
+					onMessage: jest.fn(),
+					removeAllListeners: jest.fn(),
+				};
+				const ctx = makeCtx("AI", {
+					socket: socket as never,
+					// The seatPlayer() call below exercises real room bookkeeping
+					// (typeChangeMessage / playerEnterMessage) that this file's local
+					// message-repository stub doesn't implement.
+					messageRepository: new MessageRepositoryMock() as never,
+				});
+
+				await strategy.handle(ctx);
+				const room = YGOProRoomList.getRooms()[0];
+				expect(room).toBeDefined();
+
+				// Reproduce "the human was seated by the earlier JOIN emit" — emit()
+				// is mocked away in this suite, so seat the human explicitly via the
+				// same admission path the real JOIN handler uses.
+				await room
+					.admissionTarget(socket as never, { name: "Human", password: "" } as never)
+					.seatPlayer({ kind: "guest", name: "Human" }, new Seat(0, 0));
+				expect(room.clients).toHaveLength(1);
+
+				// Seating itself already sent lobby-bookkeeping frames (joinGame /
+				// typeChange) through this same socket — clear those out so the
+				// assertion below is only about the failure-path ordering.
+				callOrder.length = 0;
+
+				const runSpy = jest.spyOn(FinalizeYGOProRoom, "run");
+
+				await new Promise((r) => setImmediate(r));
+
+				// The JOINERROR must reach the human's still-open socket, and the
+				// socket must be gracefully closed, BEFORE the canonical teardown
+				// (which destroys every remaining client's socket) runs.
+				expect(callOrder).toEqual(["send", "close", "destroy"]);
+				expect(runSpy).toHaveBeenCalledTimes(1);
+
+				runSpy.mockRestore();
 			});
 		});
 

--- a/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.ts
@@ -3,9 +3,11 @@ import { generateUniqueId } from "src/utils/generateUniqueId";
 import { ErrorMessageType } from "ygopro-msg-encode";
 
 import { WindbotModule } from "../../../windbot/application/WindbotModule";
+import { resolveBotPool } from "../../../windbot/domain/resolveBotPool";
 import { JoinContext, JoinStrategy } from "./JoinStrategy";
 import { YGOProRoom } from "../../domain/YGOProRoom";
 import YGOProRoomList from "../../infrastructure/YGOProRoomList";
+import { FinalizeYGOProRoom } from "../FinalizeYGOProRoom";
 
 /**
  * WindBotJoinStrategy — handles AI / AI#name join passwords (explicit "ai" token).
@@ -29,13 +31,22 @@ export class WindBotJoinStrategy implements JoinStrategy {
 			return false;
 		}
 
-		// Extract config segment (everything before the first "#"), split by comma,
-		// trim and lowercase — check if "ai" is among the tokens.
-		// This is ORDER-INDEPENDENT and CASE-INSENSITIVE.
-		// Examples: "AI#Anna", "ai,jtp#Joey", "nc,ns,ai#joey", "jtp,ai", "ai"
-		const configSegment = ctx.rawPass.split("#")[0];
-		const tokens = configSegment.split(",").map((t) => t.trim().toLowerCase());
+		const tokens = WindBotJoinStrategy._extractTokens(ctx.rawPass);
 		return tokens.includes("ai");
+	}
+
+	/**
+	 * Extract config segment (everything before the first "#"), split by
+	 * comma, trim and lowercase. Shared by matches() (checks for the "ai"
+	 * token) and handle() (resolves the format-scoped random pool from the
+	 * same tokens via resolveBotPool).
+	 *
+	 * This is ORDER-INDEPENDENT and CASE-INSENSITIVE.
+	 * Examples: "AI#Anna", "ai,jtp#Joey", "nc,ns,ai#joey", "jtp,ai", "ai"
+	 */
+	private static _extractTokens(rawPass: string): string[] {
+		const configSegment = rawPass.split("#")[0];
+		return configSegment.split(",").map((t) => t.trim().toLowerCase());
 	}
 
 	async handle(ctx: JoinContext): Promise<void> {
@@ -45,6 +56,11 @@ export class WindBotJoinStrategy implements JoinStrategy {
 		// "nc,ns,ai#joey" → botName = "joey"
 		// "ai" / "nc,ai" (no "#") → botName = null (random)
 		const botNameOrNull = ctx.password !== "" ? ctx.password : null;
+
+		// Resolve the format-scoped random pool from the SAME config tokens
+		// matches() used (e.g. "ed,ai" → "edison", "pre,ai" → "tcg"). Only
+		// consulted by requestBot when botNameOrNull is null (random selection).
+		const pool = resolveBotPool(WindBotJoinStrategy._extractTokens(ctx.rawPass)) ?? undefined;
 
 		// Create the room through the SAME path as the default flow
 		const room = YGOProRoom.create(
@@ -63,7 +79,7 @@ export class WindBotJoinStrategy implements JoinStrategy {
 			ctx.socket.send(errorBuf);
 			// close() (not destroy()): graceful close flushes the queued JOINERROR frame
 			// to the human before tearing the socket down. destroy()/terminate() is abrupt
-			// and can drop it. (destroy() stays only for message-less rejects, e.g. wrong password.)
+			// and can drop it. (destroy() stays only for message-less rejects.)
 			ctx.socket.close();
 			// Room was NOT added to the list — no cleanup needed
 			return;
@@ -84,28 +100,40 @@ export class WindBotJoinStrategy implements JoinStrategy {
 		// Fire-and-forget: request bot — handle failure internally.
 		// Pass () => room.finalizing so the retry loop aborts as soon as the room
 		// begins teardown (e.g. triggered by a concurrent failure).
-		this._requestBotFireAndForget(room, botNameOrNull, ctx);
+		this._requestBotFireAndForget(room, botNameOrNull, ctx, pool);
 	}
 
 	private _requestBotFireAndForget(
 		room: YGOProRoom,
 		botNameOrNull: string | null,
 		ctx: JoinContext,
+		pool: string | undefined,
 	): void {
 		this.module
-			.requestBot(room.id, botNameOrNull, () => room.finalizing)
+			.requestBot(room.id, botNameOrNull, () => room.finalizing, undefined, pool)
 			.then(({ bot }) => {
 				// Set windbot data on the room now that we know the bot
 				room.windbot = { name: bot.name, deck: bot.deck };
 			})
 			.catch(() => {
-				// On trigger failure, destroy room + notify human
-				YGOProRoomList.deleteRoom(room);
-
+				// Deliver the JOINERROR to the human BEFORE tearing the room down.
+				// FinalizeYGOProRoom.run() below destroys every seated client's
+				// socket, including the human's (seated by the earlier JOIN emit) —
+				// running it first would turn the subsequent send() into a silent
+				// no-op (WS) or ERR_STREAM_DESTROYED (TCP), leaving the human with a
+				// bare disconnect and no error frame.
 				const errorBuf = ctx.messageRepository.errorMessage(ErrorMessageType.JOINERROR, 0);
 				ctx.socket.send(errorBuf);
 				// close() flushes the JOINERROR to the human before tearing down.
 				ctx.socket.close();
+
+				// Tear the room down through the canonical path (finalizing flag,
+				// windbot cleanup, reconnection-token revocation, list removal,
+				// REMOVE-ROOM broadcast) — a bare deleteRoom() would leak the
+				// human's reconnection token into the no-TTL TokenIndex. run() is
+				// idempotent (finalizing guard) and skips clients whose socket is
+				// already closed, so calling it AFTER the send/close above is safe.
+				FinalizeYGOProRoom.run(room);
 			});
 	}
 }

--- a/src/ygopro/room/application/join-strategies/findOrCreateRoom.test.ts
+++ b/src/ygopro/room/application/join-strategies/findOrCreateRoom.test.ts
@@ -1,0 +1,708 @@
+import { EventEmitter } from "stream";
+
+import { MessageRepositoryMock } from "@test-support/mocks/MessageRepositoryMock";
+
+import { JoinContext } from "./JoinStrategy";
+import { findOrCreateRoom } from "./findOrCreateRoom";
+import { YGOProRoom } from "../../domain/YGOProRoom";
+import YGOProRoomList from "../../infrastructure/YGOProRoomList";
+
+// ---- helpers ----
+
+const makeLogger = () => ({
+	child: jest.fn().mockReturnThis(),
+	info: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn(),
+	debug: jest.fn(),
+});
+
+const makeMessageRepository = () => ({
+	errorMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
+});
+
+const makeCtx = (overrides: Partial<JoinContext> = {}): JoinContext =>
+	({
+		rawPass: "TESTROOM",
+		command: "TESTROOM",
+		password: "",
+		playerInfo: { name: "TestPlayer", password: "", previousMessage: Buffer.alloc(0) },
+		socket: { id: "sock-1", destroy: jest.fn(), close: jest.fn(), send: jest.fn() },
+		socketId: "sock-1",
+		eventEmitter: new EventEmitter(),
+		messageRepository: makeMessageRepository(),
+		logger: makeLogger(),
+		message: { data: Buffer.alloc(0), previousMessage: Buffer.alloc(0) },
+		...overrides,
+	}) as unknown as JoinContext;
+
+async function seatGuest(room: YGOProRoom, name: string): Promise<void> {
+	const socket = {
+		id: `s-${name}`,
+		send: jest.fn(),
+		close: jest.fn(),
+		destroy: jest.fn(),
+		onMessage: jest.fn(),
+		removeAllListeners: jest.fn(),
+	};
+	const target = room.admissionTarget(socket as never, { name, password: "" } as never);
+	const seat = target.freeSeat();
+	if (!seat) throw new Error(`seatGuest: no free seat for ${name}`);
+	await target.seatPlayer({ kind: "guest", name }, seat);
+}
+
+// ---- tests ----
+
+/**
+ * findOrCreateRoom is the shared find-or-create logic used by
+ * DefaultJoinStrategy and TicketJoinStrategy, parameterized by
+ * { rankedOverride }. This is a pure characterization of that shared
+ * behavior; DefaultJoinStrategy.test.ts and TicketJoinStrategy.test.ts
+ * continue to cover the strategies' own contracts end-to-end.
+ */
+describe("findOrCreateRoom", () => {
+	let waitingSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		waitingSpy = jest.spyOn(YGOProRoom.prototype, "waiting").mockImplementation(() => undefined);
+		const rooms = YGOProRoomList.getRooms();
+		while (rooms.length) {
+			YGOProRoomList.deleteRoom(rooms[0]);
+		}
+	});
+
+	afterEach(() => {
+		waitingSpy.mockRestore();
+	});
+
+	it("returns the existing room when both its name and password match the joiner's", () => {
+		const room = YGOProRoom.create(
+			1,
+			"TESTROOM#secret",
+			makeLogger() as never,
+			new EventEmitter(),
+			{ name: "P", password: "", previousMessage: Buffer.alloc(0) } as never,
+			"sock-orig",
+			makeMessageRepository() as never,
+		);
+		YGOProRoomList.addRoom(room);
+
+		const result = findOrCreateRoom(makeCtx({ command: "TESTROOM", password: "secret" }), {
+			rankedOverride: undefined,
+		});
+
+		expect(result).toBe(room);
+	});
+
+	it("returns the same room mid-duel when the (name, password) pair matches — state-blind, spectating decided downstream", () => {
+		const room = YGOProRoom.create(
+			1,
+			"TESTROOM#secret",
+			makeLogger() as never,
+			new EventEmitter(),
+			{ name: "P", password: "", previousMessage: Buffer.alloc(0) } as never,
+			"sock-orig",
+			makeMessageRepository() as never,
+		);
+		YGOProRoomList.addRoom(room);
+		room.rps(); // lightweight non-waiting transition, no OCGCore needed
+
+		const result = findOrCreateRoom(makeCtx({ command: "TESTROOM", password: "secret" }), {
+			rankedOverride: undefined,
+		});
+
+		expect(result).toBe(room);
+	});
+
+	it("creates a new room with the joiner's own password when no room matches the (name, password) pair, leaving the mismatched room untouched", () => {
+		const room = YGOProRoom.create(
+			1,
+			"TESTROOM#secret",
+			makeLogger() as never,
+			new EventEmitter(),
+			{ name: "P", password: "", previousMessage: Buffer.alloc(0) } as never,
+			"sock-orig",
+			makeMessageRepository() as never,
+		);
+		YGOProRoomList.addRoom(room);
+
+		const result = findOrCreateRoom(
+			makeCtx({ rawPass: "TESTROOM#wrong", command: "TESTROOM", password: "wrong" }),
+			{ rankedOverride: undefined },
+		);
+
+		expect(result).not.toBe(room);
+		expect(result.name).toBe("TESTROOM");
+		expect(result.password).toBe("wrong");
+		expect(YGOProRoomList.getRooms()).toHaveLength(2);
+	});
+
+	// A bare-token pairing room (password "") sharing a name with a joiner's
+	// passworded command must not block the passworded room from being
+	// created — the two are distinguished by the full (name, password) pair.
+	it("a passwordless room with the same name does not block a passworded join from creating its own room", () => {
+		const passwordless = YGOProRoom.create(
+			1,
+			"edison",
+			makeLogger() as never,
+			new EventEmitter(),
+			{ name: "P", password: "", previousMessage: Buffer.alloc(0) } as never,
+			"sock-orig",
+			makeMessageRepository() as never,
+		);
+		YGOProRoomList.addRoom(passwordless);
+
+		const result = findOrCreateRoom(
+			makeCtx({ rawPass: "edison#123", command: "edison", password: "123" }),
+			{ rankedOverride: undefined },
+		);
+
+		expect(result).not.toBe(passwordless);
+		expect(result.name).toBe("edison");
+		expect(result.password).toBe("123");
+	});
+
+	it("two joins with the same name but different passwords land in two distinct rooms", () => {
+		const first = findOrCreateRoom(
+			makeCtx({ rawPass: "edison#123", command: "edison", password: "123" }),
+			{ rankedOverride: undefined },
+		);
+		const second = findOrCreateRoom(
+			makeCtx({ rawPass: "edison#456", command: "edison", password: "456" }),
+			{ rankedOverride: undefined },
+		);
+
+		expect(second).not.toBe(first);
+		expect(first.password).toBe("123");
+		expect(second.password).toBe("456");
+	});
+
+	it("a second join with the same (name, password) pair lands in the first joiner's room and can seat as its second player", async () => {
+		const first = findOrCreateRoom(
+			makeCtx({
+				rawPass: "edison#123",
+				command: "edison",
+				password: "123",
+				messageRepository: new MessageRepositoryMock() as never,
+			}),
+			{ rankedOverride: undefined },
+		);
+		await seatGuest(first, "P1");
+
+		const second = findOrCreateRoom(
+			makeCtx({
+				rawPass: "edison#123",
+				command: "edison",
+				password: "123",
+				messageRepository: new MessageRepositoryMock() as never,
+			}),
+			{ rankedOverride: undefined },
+		);
+
+		expect(second).toBe(first);
+
+		await seatGuest(second, "P2");
+
+		expect(second.playersCount).toBe(2);
+	});
+
+	it("resolves a matchmaking-shaped join string by the exact (name, password) pair", () => {
+		const room = YGOProRoom.create(
+			1,
+			"tt,mmabc12#xyz1234",
+			makeLogger() as never,
+			new EventEmitter(),
+			{ name: "P", password: "", previousMessage: Buffer.alloc(0) } as never,
+			"sock-orig",
+			makeMessageRepository() as never,
+		);
+		YGOProRoomList.addRoom(room);
+
+		const result = findOrCreateRoom(
+			makeCtx({
+				rawPass: "tt,mmabc12#xyz1234",
+				command: "tt,mmabc12",
+				password: "xyz1234",
+			}),
+			{ rankedOverride: undefined },
+		);
+
+		expect(result).toBe(room);
+	});
+
+	// Matchmaking passwords are machine-generated (randomBase36) and never
+	// typed by a human, so this mismatch is not reachable in practice — it is
+	// pinned here only to document that the (name, password) model applies
+	// uniformly, with no special case for matchmaking-shaped commands.
+	it("creates a throwaway room when a matchmaking-shaped password does not match", () => {
+		const room = YGOProRoom.create(
+			1,
+			"tt,mmabc12#xyz1234",
+			makeLogger() as never,
+			new EventEmitter(),
+			{ name: "P", password: "", previousMessage: Buffer.alloc(0) } as never,
+			"sock-orig",
+			makeMessageRepository() as never,
+		);
+		YGOProRoomList.addRoom(room);
+
+		const result = findOrCreateRoom(
+			makeCtx({
+				rawPass: "tt,mmabc12#wrongpass",
+				command: "tt,mmabc12",
+				password: "wrongpass",
+			}),
+			{ rankedOverride: undefined },
+		);
+
+		expect(result).not.toBe(room);
+		expect(result.name).toBe("tt,mmabc12");
+	});
+
+	it("creates a new ranked room with the joiner's password when no room matches the (name, password) pair (TicketJoinStrategy's contract)", () => {
+		const room = YGOProRoom.create(
+			1,
+			"edison",
+			makeLogger() as never,
+			new EventEmitter(),
+			{ name: "P", password: "", previousMessage: Buffer.alloc(0) } as never,
+			"sock-orig",
+			makeMessageRepository() as never,
+		);
+		YGOProRoomList.addRoom(room);
+
+		const result = findOrCreateRoom(
+			makeCtx({ rawPass: "edison#123", command: "edison", password: "123" }),
+			{ rankedOverride: true },
+		);
+
+		expect(result).not.toBe(room);
+		expect(result.password).toBe("123");
+		expect(result.ranked).toBe(true);
+	});
+
+	it("creates and registers a new room, calling waiting(), when none exists", () => {
+		const result = findOrCreateRoom(
+			makeCtx({ rawPass: "NEWROOM", command: "NEWROOM", password: "" }),
+			{ rankedOverride: undefined },
+		);
+
+		expect(result).not.toBeNull();
+		expect(YGOProRoomList.findByName("NEWROOM")).toBe(result);
+		expect(waitingSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("logs a single info line naming the room and the non-pairing path when creating a room for a non-pairing join", () => {
+		const logger = makeLogger();
+
+		findOrCreateRoom(
+			makeCtx({ rawPass: "LOGGEDROOM#secret", command: "LOGGEDROOM", password: "secret", logger }),
+			{ rankedOverride: undefined },
+		);
+
+		expect(logger.info).toHaveBeenCalledTimes(1);
+		expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("LOGGEDROOM"));
+		expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("non-pairing"));
+	});
+
+	it("logs a single info line naming the room and the pairing path when creating a room for a pairing join", () => {
+		const logger = makeLogger();
+
+		findOrCreateRoom(
+			makeCtx({
+				rawPass: "TCG",
+				command: "TCG",
+				password: "",
+				logger,
+				messageRepository: new MessageRepositoryMock() as never,
+			}),
+			{ rankedOverride: undefined },
+		);
+
+		expect(logger.info).toHaveBeenCalledTimes(1);
+		expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("TCG"));
+		expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("pairing"));
+	});
+
+	it("does not log when a non-pairing join reuses an existing room", () => {
+		const existing = YGOProRoom.create(
+			1,
+			"REUSEDROOM",
+			makeLogger() as never,
+			new EventEmitter(),
+			{ name: "P", password: "", previousMessage: Buffer.alloc(0) } as never,
+			"sock-orig",
+			makeMessageRepository() as never,
+		);
+		YGOProRoomList.addRoom(existing);
+		const logger = makeLogger();
+
+		findOrCreateRoom(
+			makeCtx({ rawPass: "REUSEDROOM", command: "REUSEDROOM", password: "", logger }),
+			{
+				rankedOverride: undefined,
+			},
+		);
+
+		expect(logger.info).not.toHaveBeenCalled();
+	});
+
+	it("creates a ranked room when rankedOverride is true (TicketJoinStrategy's contract)", () => {
+		const result = findOrCreateRoom(
+			makeCtx({ rawPass: "RANKEDROOM", command: "RANKEDROOM", password: "" }),
+			{ rankedOverride: true },
+		);
+
+		expect(result?.ranked).toBe(true);
+	});
+
+	it("creates an unranked room when rankedOverride is undefined and no pin was supplied (DefaultJoinStrategy's contract)", () => {
+		const result = findOrCreateRoom(
+			makeCtx({ rawPass: "PLAINROOM", command: "PLAINROOM", password: "" }),
+			{ rankedOverride: undefined },
+		);
+
+		expect(result?.ranked).toBe(false);
+	});
+
+	// Pairing joins. A join is a PAIRING JOIN when the password is empty and
+	// every comma-separated token is recognized (or "casual"). For a pairing
+	// join, findOrCreateRoom routes via findJoinableByName (state- and
+	// seat-aware) instead of findByNameAndPassword (first-match on the exact
+	// pair, state-blind) — so a pairing join can NEVER land in a dueling or
+	// full room. Non-pairing joins use the findByNameAndPassword behavior
+	// tested above.
+	describe("pairing joins", () => {
+		// Uses the full MessageRepositoryMock (not the local ad-hoc stub) because
+		// scenario 8 seats real players, which exercises joinGameMessage /
+		// typeChangeMessage / playerEnterMessage / playerChangeMessage too.
+		const pairCtx = (command: string) =>
+			makeCtx({
+				rawPass: command,
+				command,
+				password: "",
+				messageRepository: new MessageRepositoryMock() as never,
+			});
+
+		it("scenario 1 — a second joiner with the same recognized command joins the first's waiting room", () => {
+			const first = findOrCreateRoom(pairCtx("TCG"), { rankedOverride: undefined });
+			const second = findOrCreateRoom(pairCtx("TCG"), { rankedOverride: undefined });
+
+			expect(second).toBe(first);
+		});
+
+		it("scenario 2 — a third sender while the room duels gets a NEW room, never the dueling one", () => {
+			const first = findOrCreateRoom(pairCtx("TCG"), { rankedOverride: undefined })!;
+			first.rps(); // lightweight non-waiting transition, no OCGCore needed
+
+			const third = findOrCreateRoom(pairCtx("TCG"), { rankedOverride: undefined });
+
+			expect(third).not.toBe(first);
+			expect(third?.duelState).toBe("waiting");
+		});
+
+		it("scenario 3 — a fourth sender pairs with the third's waiting room, not the dueling one", () => {
+			const first = findOrCreateRoom(pairCtx("TCG"), { rankedOverride: undefined })!;
+			first.rps();
+			const third = findOrCreateRoom(pairCtx("TCG"), { rankedOverride: undefined })!;
+			// Sanity: the third sender must have landed in a NEW room, not the
+			// dueling one — otherwise "fourth pairs with third" would be trivially
+			// true even without real pairing behavior.
+			expect(third).not.toBe(first);
+
+			const fourth = findOrCreateRoom(pairCtx("TCG"), { rankedOverride: undefined });
+
+			expect(fourth).toBe(third);
+			expect(fourth).not.toBe(first);
+		});
+
+		it("scenario 4 — a passworded command (edison#torneo) resolves by the (name, password) pair, unchanged when it matches", () => {
+			const room = findOrCreateRoom(
+				makeCtx({ rawPass: "edison#torneo", command: "edison", password: "torneo" }),
+				{ rankedOverride: undefined },
+			);
+			room.rps(); // dueling-like — findByNameAndPassword must NOT skip it (state-blind)
+
+			const second = findOrCreateRoom(
+				makeCtx({ rawPass: "edison#torneo", command: "edison", password: "torneo" }),
+				{ rankedOverride: undefined },
+			);
+
+			expect(second).toBe(room);
+		});
+
+		it("scenario 5 — an unrecognized command (salaDeJuan) still resolves by the (name, password) pair, unchanged", () => {
+			const room = findOrCreateRoom(pairCtx("salaDeJuan"), { rankedOverride: undefined });
+			room.rps();
+
+			const second = findOrCreateRoom(pairCtx("salaDeJuan"), { rankedOverride: undefined });
+
+			expect(second).toBe(room);
+		});
+
+		it("scenario 6 — TCG and tcg remain distinct pairing pools (case-sensitive room identity)", () => {
+			const upper = findOrCreateRoom(pairCtx("TCG"), { rankedOverride: undefined });
+			const lower = findOrCreateRoom(pairCtx("tcg"), { rankedOverride: undefined });
+
+			expect(upper).not.toBe(lower);
+		});
+
+		it('scenario 7 — "edison,ns,tm" is NOT a pairing join ("tm" has no digits, unrecognized) — findByNameAndPassword applies', () => {
+			const command = "edison,ns,tm";
+			const room = findOrCreateRoom(pairCtx(command), { rankedOverride: undefined });
+			room.rps(); // dueling-like
+
+			const second = findOrCreateRoom(pairCtx(command), { rankedOverride: undefined });
+
+			// If this were (wrongly) treated as a pairing join, the dueling room
+			// would be skipped and a NEW room created instead.
+			expect(second).toBe(room);
+		});
+
+		it("scenario 8 — a tag room (t,edison) pairs joiners until all 4 seats fill, then creates a new room", async () => {
+			const command = "t,edison";
+			const room = findOrCreateRoom(pairCtx(command), { rankedOverride: undefined })!;
+
+			// TAG mode: team0=2, team1=2 → 4 total seats.
+			await seatGuest(room, "P1");
+			expect(findOrCreateRoom(pairCtx(command), { rankedOverride: undefined })).toBe(room);
+
+			await seatGuest(room, "P2");
+			await seatGuest(room, "P3");
+			await seatGuest(room, "P4");
+
+			// Room is now full (4/4) — the next pairing joiner must get a NEW room.
+			const fifth = findOrCreateRoom(pairCtx(command), { rankedOverride: undefined });
+			expect(fifth).not.toBe(room);
+		});
+
+		it("a passworded edison#123 room created by a non-pairing join does not block a later bare edison pairing join from creating its own passwordless room", () => {
+			const passworded = findOrCreateRoom(
+				makeCtx({ rawPass: "edison#123", command: "edison", password: "123" }),
+				{ rankedOverride: undefined },
+			);
+			expect(passworded.password).toBe("123");
+
+			const firstPairing = findOrCreateRoom(pairCtx("edison"), { rankedOverride: undefined });
+			expect(firstPairing).not.toBe(passworded);
+			expect(firstPairing?.password).toBe("");
+
+			const secondPairing = findOrCreateRoom(pairCtx("edison"), { rankedOverride: undefined });
+			expect(secondPairing).toBe(firstPairing);
+		});
+
+		// The pairing scan must evaluate password === "" per candidate, not as a
+		// post-check on whatever findJoinableByName returns first — otherwise
+		// one passworded `tcg#secret` room in WAITING would permanently shadow
+		// every later passwordless `tcg` room, and no pairing joiner would ever
+		// pair.
+		describe("password does not permanently disable pairing", () => {
+			it("a passworded waiting room does not block pairing — a later passwordless waiting room pairs instead", () => {
+				const passworded = YGOProRoom.create(
+					1,
+					"TCG#secret",
+					makeLogger() as never,
+					new EventEmitter(),
+					{ name: "P", password: "", previousMessage: Buffer.alloc(0) } as never,
+					"sock-orig",
+					makeMessageRepository() as never,
+				);
+				YGOProRoomList.addRoom(passworded);
+
+				const passwordless = YGOProRoom.create(
+					2,
+					"TCG",
+					makeLogger() as never,
+					new EventEmitter(),
+					{ name: "Q", password: "", previousMessage: Buffer.alloc(0) } as never,
+					"sock-orig-2",
+					makeMessageRepository() as never,
+				);
+				YGOProRoomList.addRoom(passwordless);
+
+				const joiner = findOrCreateRoom(pairCtx("TCG"), { rankedOverride: undefined });
+
+				expect(joiner).toBe(passwordless);
+			});
+
+			it("when only a passworded same-named room exists, pairing creates a new room, and a second pairing joiner pairs with THAT one (not another new room)", () => {
+				const passworded = YGOProRoom.create(
+					1,
+					"TCG#secret",
+					makeLogger() as never,
+					new EventEmitter(),
+					{ name: "P", password: "", previousMessage: Buffer.alloc(0) } as never,
+					"sock-orig",
+					makeMessageRepository() as never,
+				);
+				YGOProRoomList.addRoom(passworded);
+
+				const created = findOrCreateRoom(pairCtx("TCG"), { rankedOverride: undefined });
+				expect(created).not.toBe(passworded);
+				expect(created?.password).toBe("");
+
+				const pairedWithCreated = findOrCreateRoom(pairCtx("TCG"), { rankedOverride: undefined });
+				expect(pairedWithCreated).toBe(created);
+			});
+		});
+
+		// The pairing scan must account for room.league — otherwise a `tcg`
+		// room created by a PIN/authenticated (External/ranked) player would
+		// capture guest pairing joins, and RoomAdmission would then hard-REJECT
+		// the guest (JOINERROR + close) instead of falling back to a new room.
+		describe("legacy by-name reconnect routing", () => {
+			function makeSocket(overrides: { remoteAddress?: string; closed?: boolean } = {}) {
+				return {
+					id: `sock-${Math.random()}`,
+					send: jest.fn(),
+					close: jest.fn(),
+					destroy: jest.fn(),
+					onMessage: jest.fn(),
+					removeAllListeners: jest.fn(),
+					remoteAddress: overrides.remoteAddress ?? "1.2.3.4",
+					closed: overrides.closed ?? false,
+				} as unknown as JoinContext["socket"];
+			}
+
+			async function seatPlayer(
+				room: YGOProRoom,
+				name: string,
+				socket: JoinContext["socket"],
+			): Promise<void> {
+				const target = room.admissionTarget(socket, {
+					name,
+					password: "",
+					previousMessage: Buffer.alloc(0),
+				} as never);
+				const seat = target.freeSeat();
+				if (!seat) throw new Error(`seatPlayer: no free seat for ${name}`);
+				await target.seatPlayer({ kind: "guest", name }, seat);
+			}
+
+			function makeDuelingRoom(name: string): YGOProRoom {
+				const room = YGOProRoom.create(
+					1,
+					name,
+					makeLogger() as never,
+					new EventEmitter(),
+					{ name: "Host", password: "", previousMessage: Buffer.alloc(0) } as never,
+					"sock-orig",
+					new MessageRepositoryMock() as never,
+				);
+				YGOProRoomList.addRoom(room);
+				return room;
+			}
+
+			const reconnectCtx = (
+				name: string,
+				playerName: string,
+				socket: JoinContext["socket"],
+			): JoinContext =>
+				makeCtx({
+					rawPass: name,
+					command: name,
+					password: "",
+					playerInfo: {
+						name: playerName,
+						password: "",
+						previousMessage: Buffer.alloc(0),
+					} as never,
+					socket,
+					messageRepository: new MessageRepositoryMock() as never,
+				});
+
+			it("scenario 1 - a disconnected player re-sending their bare command is routed back to their own dueling room", async () => {
+				const room = makeDuelingRoom("TCG");
+				const originalSocket = makeSocket({ remoteAddress: "1.2.3.4", closed: false });
+				await seatPlayer(room, "Player1", originalSocket);
+				room.rps(); // lightweight non-waiting transition, no OCGCore needed
+				originalSocket.closed = true;
+
+				const result = findOrCreateRoom(
+					reconnectCtx("TCG", "Player1", makeSocket({ remoteAddress: "1.2.3.4" })),
+					{ rankedOverride: undefined },
+				);
+
+				expect(result).toBe(room);
+				expect(result.id).toBe(room.id);
+			});
+
+			it("scenario 2 - a stranger sharing the nickname from a different remote address gets a new room, not the dueling one", async () => {
+				const room = makeDuelingRoom("TCG");
+				const originalSocket = makeSocket({ remoteAddress: "1.2.3.4", closed: true });
+				await seatPlayer(room, "Player1", originalSocket);
+				room.rps(); // lightweight non-waiting transition, no OCGCore needed
+
+				const result = findOrCreateRoom(
+					reconnectCtx("TCG", "Player1", makeSocket({ remoteAddress: "9.9.9.9" })),
+					{ rankedOverride: undefined },
+				);
+
+				expect(result).not.toBe(room);
+				expect(result.duelState).toBe("waiting");
+			});
+
+			it("scenario 3 - the original socket still open blocks the reconnect route (ghosting guard) and yields a new room", async () => {
+				const room = makeDuelingRoom("TCG");
+				const originalSocket = makeSocket({ remoteAddress: "1.2.3.4", closed: false });
+				await seatPlayer(room, "Player1", originalSocket);
+				room.rps(); // lightweight non-waiting transition, no OCGCore needed
+				// originalSocket is left open (closed stays false).
+
+				const result = findOrCreateRoom(
+					reconnectCtx("TCG", "Player1", makeSocket({ remoteAddress: "1.2.3.4" })),
+					{ rankedOverride: undefined },
+				);
+
+				expect(result).not.toBe(room);
+				expect(result.duelState).toBe("waiting");
+			});
+
+			it("scenario 4 - with no dueling room for the name, ordinary pairing behavior is unaffected", () => {
+				const first = findOrCreateRoom(pairCtx("TCG-RECONNECT-REGRESSION"), {
+					rankedOverride: undefined,
+				});
+				const second = findOrCreateRoom(pairCtx("TCG-RECONNECT-REGRESSION"), {
+					rankedOverride: undefined,
+				});
+
+				expect(second).toBe(first);
+			});
+		});
+
+		describe("league-compatible pairing for guests", () => {
+			const authedCtx = (name: string, pin: string) =>
+				makeCtx({
+					rawPass: "TCG",
+					command: "TCG",
+					password: "",
+					playerInfo: { name, password: pin, previousMessage: Buffer.alloc(0) } as never,
+					messageRepository: new MessageRepositoryMock() as never,
+				});
+
+			it("a guest pairing join skips an External (PIN-hosted) same-named room and gets a NEW room instead of being rejected", () => {
+				const authedRoom = findOrCreateRoom(authedCtx("Host", "1234"), {
+					rankedOverride: undefined,
+				})!;
+				expect(authedRoom.league.type).toBe("external");
+
+				const guestJoin = findOrCreateRoom(pairCtx("TCG"), { rankedOverride: undefined });
+
+				expect(guestJoin).not.toBeNull();
+				expect(guestJoin).not.toBe(authedRoom);
+			});
+
+			it("an authenticated (PIN-carrying) pairing joiner still pairs into the same External room", () => {
+				const authedRoom = findOrCreateRoom(authedCtx("Host", "1234"), {
+					rankedOverride: undefined,
+				})!;
+
+				const secondAuthed = findOrCreateRoom(authedCtx("Guest2", "5678"), {
+					rankedOverride: undefined,
+				});
+
+				expect(secondAuthed).toBe(authedRoom);
+			});
+		});
+	});
+});

--- a/src/ygopro/room/application/join-strategies/findOrCreateRoom.ts
+++ b/src/ygopro/room/application/join-strategies/findOrCreateRoom.ts
@@ -1,0 +1,122 @@
+import { generateUniqueId } from "src/utils/generateUniqueId";
+
+import { findReconnectingPlayer } from "@shared/room/domain/findReconnectingPlayer";
+
+import { JoinContext } from "./JoinStrategy";
+import { isPairingJoin } from "./isPairingJoin";
+import { YGOProRoom } from "../../domain/YGOProRoom";
+import YGOProRoomList from "../../infrastructure/YGOProRoomList";
+
+export interface FindOrCreateRoomOptions {
+	/**
+	 * Forwarded verbatim to YGOProRoom.create's rankedOverride param.
+	 * MUST stay optional/undefined-capable — RoomLeague.determine treats
+	 * `undefined` (fall through to hasPin) differently from an explicit
+	 * `false` (force Casual). DefaultJoinStrategy relies on `undefined` so a
+	 * PIN-carrying anonymous join still resolves to the External league.
+	 */
+	rankedOverride: boolean | undefined;
+}
+
+/**
+ * Shared find-or-create logic used by both DefaultJoinStrategy and
+ * TicketJoinStrategy.
+ *
+ * PAIRING joins (see isPairingJoin) resolve the existing-room lookup via
+ * findJoinableByName (state-, seat-, password- and league-aware) instead of
+ * findByName (first-match, state-blind): the same-name room is only reused
+ * when it is WAITING, has a free seat, carries no password, AND its league
+ * would not hard-reject this joiner if it's a guest. Every one of those
+ * constraints is evaluated PER CANDIDATE inside the scan itself, not as a
+ * post-check on whatever comes back first — a disqualified candidate (e.g. a
+ * `tcg#secret` room) can therefore never permanently shadow a later
+ * qualifying `tcg` room. Otherwise (no room yet, or every same-named room is
+ * dueling/full/passworded/league-incompatible) a NEW room is created — a
+ * pairing join can therefore never land in a non-waiting room as a fresh
+ * spectator, so that path is unreachable for a STRANGER.
+ *
+ * Because findJoinableByName only ever considers WAITING rooms, a pairing
+ * join is otherwise blind to its own room once that room leaves WAITING (e.g.
+ * mid-duel) — a client that reconnects by simply re-sending its original bare
+ * command (no token, unlike the first-party reconnect flow) would land in a
+ * brand-new room instead of resuming its seat. Before the WAITING-only scan,
+ * findPairingReconnectTarget looks for a same-name, passwordless, non-WAITING
+ * room containing a disconnected occupant this joiner may legitimately
+ * resume, reusing findReconnectingPlayer's own eligibility rules so the two
+ * paths never diverge. Only ROUTING happens here; the actual re-seat runs
+ * downstream, under the room's mutex, when the room's state machine handles
+ * the JOIN event.
+ *
+ * Non-pairing joins identify a room by the exact (name, password) pair
+ * (findByNameAndPassword: first-match, state-blind). A matching pair is
+ * reused regardless of state (spectating a passworded room mid-duel keeps
+ * working); no matching pair creates a new room under that name and
+ * password, even when other rooms already share the name under a different
+ * password. This function never returns null.
+ */
+export function findOrCreateRoom(
+	ctx: JoinContext,
+	{ rankedOverride }: FindOrCreateRoomOptions,
+): YGOProRoom {
+	if (isPairingJoin(ctx)) {
+		// A guest is a joiner with neither a resolved (ticket) identity nor a PIN
+		// in its player info; mirrors CredentialResolver.resolve's guest
+		// fallthrough. Only guests are hard-rejected by a ranked league
+		// (RoomAdmission: ranked + guest → rejected, not spectator), so only
+		// guests need the league filter — non-guests keep pairing unchanged.
+		const isGuestJoiner = !ctx.socket.resolvedUserId && !ctx.playerInfo.password;
+
+		const reconnectTarget = YGOProRoomList.findPairingReconnectTarget(
+			ctx.command,
+			(room) =>
+				findReconnectingPlayer({
+					players: room.players,
+					name: ctx.playerInfo.name,
+					remoteAddress: ctx.socket.remoteAddress,
+					ranked: room.ranked,
+				}) !== null,
+		);
+		if (reconnectTarget) {
+			return reconnectTarget;
+		}
+
+		const joinable = YGOProRoomList.findJoinableByName(ctx.command, {
+			requireEmptyPassword: true,
+			excludeRankedForGuest: isGuestJoiner,
+		});
+		if (joinable) {
+			return joinable;
+		}
+		return createRoom(ctx, rankedOverride, "pairing");
+	}
+
+	const existingRoom = YGOProRoomList.findByNameAndPassword(ctx.command, ctx.password);
+	if (existingRoom) {
+		return existingRoom;
+	}
+
+	return createRoom(ctx, rankedOverride, "non-pairing");
+}
+
+function createRoom(
+	ctx: JoinContext,
+	rankedOverride: boolean | undefined,
+	path: "pairing" | "non-pairing",
+): YGOProRoom {
+	const room = YGOProRoom.create(
+		generateUniqueId(),
+		ctx.rawPass,
+		ctx.logger,
+		ctx.eventEmitter,
+		ctx.playerInfo,
+		ctx.socketId,
+		ctx.messageRepository,
+		rankedOverride,
+	);
+	YGOProRoomList.addRoom(room);
+	room.waiting();
+
+	ctx.logger.info(`Created room "${room.name}" via ${path} path (no existing room to reuse)`);
+
+	return room;
+}

--- a/src/ygopro/room/application/join-strategies/isPairingJoin.test.ts
+++ b/src/ygopro/room/application/join-strategies/isPairingJoin.test.ts
@@ -1,0 +1,87 @@
+import { JoinContext } from "./JoinStrategy";
+import { isPairingJoin } from "./isPairingJoin";
+
+const makeCtx = (rawPass: string): JoinContext => {
+	const [command, password = ""] = rawPass.split("#");
+	return { rawPass, command, password } as unknown as JoinContext;
+};
+
+/**
+ * A join is a PAIRING JOIN when the password segment is empty, the command
+ * is non-empty, AND every comma-separated token (trimmed, lowercased) is
+ * either isRecognizedToken(token) or the literal "casual".
+ */
+describe("isPairingJoin", () => {
+	it("is a pairing join for a single recognized token", () => {
+		expect(isPairingJoin(makeCtx("TCG"))).toBe(true);
+		expect(isPairingJoin(makeCtx("tcg"))).toBe(true);
+	});
+
+	it("is a pairing join for multiple recognized tokens", () => {
+		expect(isPairingJoin(makeCtx("edison,ns"))).toBe(true);
+	});
+
+	it('treats "casual" as recognized even though it is not a rule token', () => {
+		expect(isPairingJoin(makeCtx("tcg,casual"))).toBe(true);
+	});
+
+	it("is NOT a pairing join when a password segment is present", () => {
+		expect(isPairingJoin(makeCtx("tcg#torneo"))).toBe(false);
+		expect(isPairingJoin(makeCtx("edison#torneo"))).toBe(false);
+	});
+
+	it('is NOT a pairing join when the command is blank ("#pass" or "")', () => {
+		expect(isPairingJoin(makeCtx(""))).toBe(false);
+		expect(isPairingJoin(makeCtx("#pass"))).toBe(false);
+	});
+
+	it("is NOT a pairing join when any token is unrecognized", () => {
+		expect(isPairingJoin(makeCtx("salaDeJuan"))).toBe(false);
+		// "tm" with no digits does not match /^(tm|time)\d+$/ — unrecognized.
+		expect(isPairingJoin(makeCtx("edison,ns,tm"))).toBe(false);
+	});
+
+	it('is NOT a pairing join for the "ai" token', () => {
+		expect(isPairingJoin(makeCtx("ai"))).toBe(false);
+	});
+
+	it("is NOT a pairing join for a matchmaking marker token", () => {
+		expect(isPairingJoin(makeCtx("tcg,mm12345"))).toBe(false);
+	});
+
+	it("is a pairing join for tag-mode tokens", () => {
+		expect(isPairingJoin(makeCtx("t,edison"))).toBe(true);
+	});
+
+	it("trims and lowercases tokens before recognition", () => {
+		expect(isPairingJoin(makeCtx(" TCG , NS "))).toBe(true);
+	});
+
+	// A trailing/double comma produces an EMPTY token after split(","), and
+	// isRecognizedToken("") is false (not "casual" either), so `.every()`
+	// would silently disqualify the whole command as a pairing join even
+	// though every non-empty token was perfectly recognized. Empty tokens
+	// must be filtered out BEFORE the recognition check — the pairing LOOKUP
+	// KEY is unaffected: it stays the raw, unfiltered command string
+	// (findOrCreateRoom uses ctx.command directly), so "tcg," only pairs with
+	// another literal "tcg,", never with "tcg".
+	describe("empty tokens from trailing/double commas", () => {
+		it("is a pairing join for a trailing comma", () => {
+			expect(isPairingJoin(makeCtx("tcg,"))).toBe(true);
+		});
+
+		it("is a pairing join for a double comma in the middle", () => {
+			expect(isPairingJoin(makeCtx("tcg,,ns"))).toBe(true);
+		});
+
+		it("is NOT a pairing join when every token is empty (bare commas only)", () => {
+			expect(isPairingJoin(makeCtx(","))).toBe(false);
+			expect(isPairingJoin(makeCtx(",,"))).toBe(false);
+		});
+
+		it("is a pairing join for bare 'casual' and for 'casual' combined with a recognized token", () => {
+			expect(isPairingJoin(makeCtx("casual"))).toBe(true);
+			expect(isPairingJoin(makeCtx("casual,tcg"))).toBe(true);
+		});
+	});
+});

--- a/src/ygopro/room/application/join-strategies/isPairingJoin.ts
+++ b/src/ygopro/room/application/join-strategies/isPairingJoin.ts
@@ -1,0 +1,51 @@
+import { isRecognizedToken } from "../../domain/RuleMappings";
+import { JoinContext } from "./JoinStrategy";
+
+/**
+ * Pairing join predicate — for any client that sends a bare token command
+ * (e.g. "TCG", "edison") expecting to be matched with another player who sent
+ * exactly the same command.
+ *
+ * A join is a PAIRING JOIN when:
+ *   - the password segment is empty (no "#" in the command, or nothing after it)
+ *   - the command is non-empty
+ *   - every comma-separated token (trimmed, lowercased) is recognized:
+ *     isRecognizedToken(token) OR token === "casual"
+ *
+ * Deliberately NOT pairing joins:
+ *   - "ai" — WindBotJoinStrategy intercepts it earlier when windbot is enabled;
+ *     when disabled it falls through here and is unrecognized (conservative).
+ *   - "mm<...>" (matchmaking's generated join string) — unrecognized token.
+ *   - arbitrary player-chosen room names — unrecognized token.
+ *   - the blank command — no token can be "every token recognized" vacuously
+ *     here because an empty command is rejected outright before the token scan.
+ */
+export function isPairingJoin(ctx: JoinContext): boolean {
+	if (ctx.password !== "") {
+		return false;
+	}
+	if (ctx.command === "") {
+		return false;
+	}
+
+	// A trailing or double comma ("tcg,", "tcg,,ns") produces empty tokens
+	// after split(","). isRecognizedToken("") is false and "" is not "casual",
+	// so an empty token would silently disqualify the WHOLE command from
+	// pairing even when every other token was recognized. Filtering empties
+	// out classifies by the non-empty tokens instead. This is purely a
+	// classification concern — the pairing LOOKUP KEY (used by
+	// findOrCreateRoom) stays the raw, unfiltered ctx.command string, so
+	// "tcg," still only pairs with another literal "tcg,", never with "tcg".
+	const tokens = ctx.command
+		.split(",")
+		.map((token) => token.trim().toLowerCase())
+		.filter((token) => token !== "");
+
+	// Every token was empty (e.g. "," or ",,") — nothing to recognize, so
+	// `.every()` would otherwise be vacuously true. Not a pairing join.
+	if (tokens.length === 0) {
+		return false;
+	}
+
+	return tokens.every((token) => isRecognizedToken(token) || token === "casual");
+}

--- a/src/ygopro/room/domain/RuleMappings.test.ts
+++ b/src/ygopro/room/domain/RuleMappings.test.ts
@@ -1,7 +1,206 @@
 import { GameMode } from "ygopro-msg-encode";
 
 import MercuryBanListMemoryRepository from "../../ban-list/infrastructure/YGOProBanListMemoryRepository";
-import { formatRuleMappings, priorityRuleMappings } from "./RuleMappings";
+import { YGOProBanList } from "../../ban-list/domain/YGOProBanList";
+import LoggerFactory from "src/shared/logger/infrastructure/LoggerFactory";
+import { formatRuleMappings, isRecognizedToken, priorityRuleMappings } from "./RuleMappings";
+
+// isRecognizedToken(token) is the predicate the pairing feature uses to
+// decide whether every comma-separated token in a join command is a known
+// rule token. True iff the lowercased token matches at least one validate()
+// across the three tiers (mode / format / priority).
+describe("isRecognizedToken", () => {
+	it("recognizes tokens from the mode tier", () => {
+		expect(isRecognizedToken("m")).toBe(true);
+		expect(isRecognizedToken("tag")).toBe(true);
+	});
+
+	it("recognizes tokens from the format tier", () => {
+		expect(isRecognizedToken("edison")).toBe(true);
+		expect(isRecognizedToken("goat")).toBe(true);
+	});
+
+	it("recognizes tokens from the priority tier, including parametric ones", () => {
+		expect(isRecognizedToken("tcg")).toBe(true);
+		expect(isRecognizedToken("lp8000")).toBe(true);
+		expect(isRecognizedToken("bo3")).toBe(true);
+	});
+
+	it("is case-insensitive", () => {
+		expect(isRecognizedToken("TCG")).toBe(true);
+		expect(isRecognizedToken("Edison")).toBe(true);
+	});
+
+	it("returns false for unrecognized tokens", () => {
+		expect(isRecognizedToken("notarealtoken")).toBe(false);
+		expect(isRecognizedToken("salaDeJuan")).toBe(false);
+	});
+
+	it('returns false for "casual" — it is handled as a separate league token, not a rule token', () => {
+		expect(isRecognizedToken("casual")).toBe(false);
+	});
+
+	it("returns false for the blank token", () => {
+		expect(isRecognizedToken("")).toBe(false);
+	});
+});
+
+function createBanList(name: string, hash: number): YGOProBanList {
+	const banList = new YGOProBanList();
+	banList.setName(name);
+	banList.setHash(hash);
+	return banList;
+}
+
+// Tokens that mean "the OCG list" must resolve via getFirstOCGIndex, not a
+// literal 0 — this fixture puts TCG first so a hardcoded-0 regression is
+// caught immediately.
+describe("OCG-list-meaning lflist tokens resolve via getFirstOCGIndex, not a literal 0", () => {
+	const OCG_INDEX = 1;
+
+	beforeEach(() => {
+		MercuryBanListMemoryRepository.clear();
+		MercuryBanListMemoryRepository.add(createBanList("2026.05 TCG", 100)); // index 0
+		MercuryBanListMemoryRepository.add(createBanList("2026.04 OCG", 200)); // index 1
+	});
+
+	afterEach(() => {
+		MercuryBanListMemoryRepository.clear();
+	});
+
+	it.each([
+		"otto",
+		"oor",
+		"or",
+		"oomr",
+		"omr",
+	])('priorityRuleMappings["%s"] resolves lflist to the OCG list index', (key) => {
+		const rule = priorityRuleMappings[key].get(key);
+		expect(rule.lflist).toBe(OCG_INDEX);
+	});
+
+	it.each([
+		"ocg",
+		"ocgpre",
+		"ocgart",
+	])('formatRuleMappings["%s"] resolves lflist to the OCG list index', (key) => {
+		const rule = formatRuleMappings[key].get(key);
+		expect(rule.lflist).toBe(OCG_INDEX);
+	});
+});
+
+// resolveAliasIndex falls back to index 0 when an alias has no matching
+// banlist (mislabeling the room with whatever list sits first) but warns so
+// the miss is diagnosable — gx/mdc are dead tokens today because their lists
+// are not shipped.
+describe("resolveAliasIndex — warns on alias miss instead of silently mislabeling", () => {
+	afterEach(() => {
+		MercuryBanListMemoryRepository.clear();
+		jest.restoreAllMocks();
+	});
+
+	it("warns when the gx alias has no matching banlist loaded", () => {
+		const warnSpy = jest
+			.spyOn(LoggerFactory.getLogger(), "warn")
+			.mockImplementation(() => undefined);
+
+		const rule = formatRuleMappings.gx.get("gx");
+
+		expect(rule.lflist).toBe(0);
+		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("gx"));
+	});
+
+	it("warns when the mdc alias has no matching banlist loaded", () => {
+		const warnSpy = jest
+			.spyOn(LoggerFactory.getLogger(), "warn")
+			.mockImplementation(() => undefined);
+
+		const rule = formatRuleMappings.mdc.get("mdc");
+
+		expect(rule.lflist).toBe(0);
+		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("mdc"));
+	});
+
+	it("does NOT warn when the alias resolves to a real banlist", () => {
+		MercuryBanListMemoryRepository.add(createBanList("2026.04 Edison Format", 1));
+		const warnSpy = jest
+			.spyOn(LoggerFactory.getLogger(), "warn")
+			.mockImplementation(() => undefined);
+
+		const rule = formatRuleMappings.edison.get("edison");
+
+		expect(rule.lflist).toBe(0);
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	// Memoize per alias so a missing-banlist alias (e.g. "gx"/"mdc") warns once
+	// instead of re-warning on every room creation that uses it.
+	//
+	// Uses "hat" (not "gx"/"mdc", already exercised by the tests above) so
+	// this test's outcome doesn't depend on the per-alias memoization state
+	// left behind by sibling tests running first.
+	it("warns only ONCE per alias even when resolved repeatedly", () => {
+		const warnSpy = jest
+			.spyOn(LoggerFactory.getLogger(), "warn")
+			.mockImplementation(() => undefined);
+
+		formatRuleMappings.hat.get("hat");
+		formatRuleMappings.hat.get("hat");
+		formatRuleMappings.hat.get("hat");
+
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("hat"));
+	});
+});
+
+// The clamp must operate on the number extracted via
+// extractNumberFromCommand, not a re-parsed parseInt(value) —
+// parseInt("lp8000", 10) is NaN, which would silently skip both clamp
+// branches (lp0 would leak start_lp 0, lp999999 would leak unclamped).
+describe("lp boundary clamps", () => {
+	it("clamps lp0 to start_lp 1", () => {
+		expect(priorityRuleMappings.lp.get("lp0").start_lp).toBe(1);
+	});
+
+	it("clamps lp999999 to start_lp 99999", () => {
+		expect(priorityRuleMappings.lp.get("lp999999").start_lp).toBe(99999);
+	});
+
+	it("passes an in-range lp8000 through unchanged", () => {
+		expect(priorityRuleMappings.lp.get("lp8000").start_lp).toBe(8000);
+	});
+});
+
+// Sibling tiers (tm/dr/st/bo) compute their clamp checks from the
+// extractNumberFromCommand() result, not from a re-parsed raw string, so they
+// do not share the lp NaN pitfall above.
+describe("sibling boundary clamps (tm/dr/st/bo)", () => {
+	it("tm0 passes the extracted 0 through as time_limit (no floor defined)", () => {
+		expect(priorityRuleMappings.tm.get("tm0").time_limit).toBe(0);
+	});
+
+	it("dr0 clamps to draw_count 1", () => {
+		expect(priorityRuleMappings.dr.get("dr0").draw_count).toBe(1);
+	});
+
+	it("dr36 clamps to draw_count 35", () => {
+		expect(priorityRuleMappings.dr.get("dr36").draw_count).toBe(35);
+	});
+
+	it("st0 clamps to start_hand 5", () => {
+		expect(priorityRuleMappings.st.get("st0").start_hand).toBe(5);
+	});
+
+	it("st41 clamps to start_hand 40", () => {
+		expect(priorityRuleMappings.st.get("st41").start_hand).toBe(40);
+	});
+
+	it("bo0 defaults to MATCH mode with best_of 3", () => {
+		const rule = priorityRuleMappings.bo.get("bo0");
+		expect(rule.mode).toBe(GameMode.MATCH);
+		expect(rule.best_of).toBe(3);
+	});
+});
 
 describe("match-mode shortcut mappings", () => {
 	// A MATCH shortcut without best_of leaves hostInfo.best_of at the SINGLE
@@ -27,6 +226,38 @@ describe("jm mapping (jtp best-of-3, used by matchmaking)", () => {
 		expect(formatRuleMappings.jm.validate("jm")).toBe(true);
 		expect(formatRuleMappings.jm.validate("jmx")).toBe(false);
 		expect(formatRuleMappings.jm.validate("jtp")).toBe(false);
+	});
+});
+
+describe("ed mapping (edison short alias, used by AI duel join commands)", () => {
+	it("produces the exact same payload as edison, and pins the full edison rule set", () => {
+		// findIndexByAlias is empty under jest (MercuryBanListMemoryRepository has
+		// no loaded ban lists), so both edison.get() and ed.get() would silently
+		// agree on lflist=-1 even if "ed" typo'd its alias lookup (e.g. "edisonn").
+		// Mock a sentinel return so the assertions actually exercise the lookup.
+		const findIndex = jest
+			.spyOn(MercuryBanListMemoryRepository, "findIndexByAlias")
+			.mockReturnValue(7);
+
+		const edison = formatRuleMappings.edison.get("edison");
+		const ed = formatRuleMappings.ed.get("ed");
+
+		expect(ed).toEqual(edison);
+		expect(ed).toEqual({
+			rule: 5,
+			lflist: 7,
+			duel_rule: 1,
+			time_limit: 450,
+		});
+		expect(findIndex).toHaveBeenCalledWith("edison");
+
+		findIndex.mockRestore();
+	});
+
+	it("validates only the exact token", () => {
+		expect(formatRuleMappings.ed.validate("ed")).toBe(true);
+		expect(formatRuleMappings.ed.validate("edison")).toBe(false);
+		expect(formatRuleMappings.ed.validate("edx")).toBe(false);
 	});
 });
 

--- a/src/ygopro/room/domain/RuleMappings.ts
+++ b/src/ygopro/room/domain/RuleMappings.ts
@@ -1,4 +1,5 @@
 import MercuryBanListMemoryRepository from "../../ban-list/infrastructure/YGOProBanListMemoryRepository";
+import LoggerFactory from "src/shared/logger/infrastructure/LoggerFactory";
 import { GameMode } from "ygopro-msg-encode";
 import { HostInfo } from "./host-info/HostInfo";
 
@@ -13,6 +14,36 @@ function extractNumberFromCommand(input: string): number | null {
 	const match = input.match(/-?\d+(\.\d+)?/);
 
 	return match ? parseFloat(match[0]) : null;
+}
+
+// Tracked per alias so a missing alias (gx/mdc today) warns once instead of
+// re-logging the same, already-known miss on every room creation that uses
+// it. (Module state, so this is "once per alias per module instance" — Jest
+// gives each test FILE a fresh module registry, so this caps repeats to once
+// per alias per file; a long-running server process gets true
+// once-per-alias-per-process.)
+const aliasesWarnedAsMissing = new Set<string>();
+
+/**
+ * Shared resolver for the "look up a format's banlist alias, default to
+ * `fallback` if it's not loaded" pattern. A miss logs a warning (once per
+ * alias — see aliasesWarnedAsMissing) instead of silently mislabeling the
+ * room with whichever list sits at `fallback` (index 0 by default) — see
+ * gx/mdc below, which are dead tokens today because their lists are not
+ * shipped in this corpus.
+ */
+function resolveAliasIndex(alias: string, fallback = 0): number {
+	const index = MercuryBanListMemoryRepository.findIndexByAlias(alias);
+	if (index === -1) {
+		if (!aliasesWarnedAsMissing.has(alias)) {
+			aliasesWarnedAsMissing.add(alias);
+			LoggerFactory.getLogger().warn(
+				`RuleMappings: banlist alias "${alias}" has no matching banlist loaded — falling back to index ${fallback}. The room will be labeled with whatever list sits there.`,
+			);
+		}
+		return fallback;
+	}
+	return index;
 }
 
 export const ruleMappings: RuleMappings = {
@@ -66,22 +97,20 @@ export const priorityRuleMappings: RuleMappings = {
 				};
 			}
 
-			const numberValue = parseInt(value, 10);
-
-			if (numberValue <= 0) {
+			if (lps <= 0) {
 				return {
 					start_lp: 1,
 				};
 			}
 
-			if (numberValue >= 99999) {
+			if (lps >= 99999) {
 				return {
 					start_lp: 99999,
 				};
 			}
 
 			return {
-				start_lp: +lps,
+				start_lp: lps,
 			};
 		},
 		validate: (value) => {
@@ -150,7 +179,7 @@ export const priorityRuleMappings: RuleMappings = {
 	},
 	// OCG with TCG and OCG cards allowed
 	otto: {
-		get: () => ({ rule: 5, lflist: 0 }),
+		get: () => ({ rule: 5, lflist: MercuryBanListMemoryRepository.getFirstOCGIndex() }),
 		validate: (value) => {
 			return value === "otto";
 		},
@@ -312,7 +341,7 @@ export const priorityRuleMappings: RuleMappings = {
 		get: () => {
 			return {
 				rule: 0,
-				lflist: 0,
+				lflist: MercuryBanListMemoryRepository.getFirstOCGIndex(),
 			};
 		},
 		validate: (value) => {
@@ -324,7 +353,7 @@ export const priorityRuleMappings: RuleMappings = {
 		get: () => {
 			return {
 				rule: 5,
-				lflist: 0,
+				lflist: MercuryBanListMemoryRepository.getFirstOCGIndex(),
 			};
 		},
 		validate: (value) => {
@@ -348,7 +377,7 @@ export const priorityRuleMappings: RuleMappings = {
 		get: () => {
 			return {
 				rule: 0,
-				lflist: 0,
+				lflist: MercuryBanListMemoryRepository.getFirstOCGIndex(),
 				mode: GameMode.MATCH,
 				best_of: 3,
 			};
@@ -362,7 +391,7 @@ export const priorityRuleMappings: RuleMappings = {
 		get: () => {
 			return {
 				rule: 5,
-				lflist: 0,
+				lflist: MercuryBanListMemoryRepository.getFirstOCGIndex(),
 				mode: GameMode.MATCH,
 				best_of: 3,
 			};
@@ -401,25 +430,41 @@ export const priorityRuleMappings: RuleMappings = {
 	},
 };
 
+// Shared payload for the "edison" / "ed" entries below (see comment on "ed").
+// Kept as one function so the two aliases can never drift apart.
+const edisonRuleSet = () => ({
+	rule: 5,
+	lflist: resolveAliasIndex("edison"),
+	duel_rule: 1,
+	time_limit: 450,
+});
+
 export const formatRuleMappings: RuleMappings = {
 	edison: {
-		get: () => {
-			return {
-				rule: 5,
-				lflist: Math.max(0, MercuryBanListMemoryRepository.findIndexByAlias("edison")),
-				duel_rule: 1,
-				time_limit: 450,
-			};
-		},
+		get: edisonRuleSet,
 		validate: (value) => {
 			return value === "edison";
+		},
+	},
+	// "ed" is the short alias of "edison". AI duel join passwords ride the
+	// CTOS_JOIN_GAME utf16[20] "pass" field as "<format-token>,ai#<botlist-name>",
+	// which silently truncates past 20 chars — see aiOpponents.ts (evolution-card-game).
+	// With the current short bot names, "edison,ai#Blackwing" (19) and even
+	// "edison,ai#Lightsworn" (20) DO fit under that ceiling. "ed" is a
+	// deliberate safety margin, not a hard requirement — "edison,ai#Lightsworn"
+	// sits exactly at the 20-char limit, leaving zero room for a longer bot
+	// name added later.
+	ed: {
+		get: edisonRuleSet,
+		validate: (value) => {
+			return value === "ed";
 		},
 	},
 	hat: {
 		get: () => {
 			return {
 				rule: 5,
-				lflist: Math.max(0, MercuryBanListMemoryRepository.findIndexByAlias("hat")),
+				lflist: resolveAliasIndex("hat"),
 				duel_rule: 2,
 				time_limit: 450,
 			};
@@ -432,7 +477,7 @@ export const formatRuleMappings: RuleMappings = {
 		get: () => {
 			return {
 				rule: 5,
-				lflist: Math.max(0, MercuryBanListMemoryRepository.findIndexByAlias("tengu")),
+				lflist: resolveAliasIndex("tengu"),
 				duel_rule: 2,
 				time_limit: 450,
 			};
@@ -443,10 +488,9 @@ export const formatRuleMappings: RuleMappings = {
 	},
 	md: {
 		get: () => {
-			const index = MercuryBanListMemoryRepository.findIndexByAlias("md");
 			return {
 				rule: 5,
-				lflist: Math.max(0, index),
+				lflist: resolveAliasIndex("md"),
 				duel_rule: 5,
 				time_limit: 450,
 			};
@@ -459,7 +503,7 @@ export const formatRuleMappings: RuleMappings = {
 		get: () => {
 			return {
 				rule: 5,
-				lflist: Math.max(0, MercuryBanListMemoryRepository.findIndexByAlias("jtp")),
+				lflist: resolveAliasIndex("jtp"),
 				duel_rule: 2,
 			};
 		},
@@ -471,7 +515,7 @@ export const formatRuleMappings: RuleMappings = {
 		get: () => {
 			return {
 				rule: 5,
-				lflist: Math.max(0, MercuryBanListMemoryRepository.findIndexByAlias("adv2007-03")),
+				lflist: resolveAliasIndex("adv2007-03"),
 				duel_rule: 2,
 			};
 		},
@@ -486,7 +530,7 @@ export const formatRuleMappings: RuleMappings = {
 		get: () => {
 			return {
 				rule: 5,
-				lflist: Math.max(0, MercuryBanListMemoryRepository.findIndexByAlias("jtp")),
+				lflist: resolveAliasIndex("jtp"),
 				duel_rule: 2,
 				mode: GameMode.MATCH,
 				best_of: 3,
@@ -496,11 +540,15 @@ export const formatRuleMappings: RuleMappings = {
 			return value === "jm";
 		},
 	},
+	// NOTE: the "gx" banlist is NOT shipped in this corpus, so resolveAliasIndex
+	// always misses and falls back to index 0 (logging a warning). Kept as a
+	// forward-compatible token, not deleted — do not remove without shipping
+	// the corresponding banlist.
 	gx: {
 		get: () => {
 			return {
 				rule: 5,
-				lflist: Math.max(0, MercuryBanListMemoryRepository.findIndexByAlias("gx")),
+				lflist: resolveAliasIndex("gx"),
 				duel_rule: 1,
 			};
 		},
@@ -508,11 +556,15 @@ export const formatRuleMappings: RuleMappings = {
 			return value === "gx";
 		},
 	},
+	// NOTE: the "mdc" banlist is NOT shipped in this corpus, so resolveAliasIndex
+	// always misses and falls back to index 0 (logging a warning). Kept as a
+	// forward-compatible token, not deleted — do not remove without shipping
+	// the corresponding banlist.
 	mdc: {
 		get: () => {
 			return {
 				rule: 5,
-				lflist: Math.max(0, MercuryBanListMemoryRepository.findIndexByAlias("mdc")),
+				lflist: resolveAliasIndex("mdc"),
 				duel_rule: 2,
 			};
 		},
@@ -524,7 +576,7 @@ export const formatRuleMappings: RuleMappings = {
 		get: () => {
 			return {
 				rule: 5,
-				lflist: Math.max(0, MercuryBanListMemoryRepository.findIndexByAlias("goat")),
+				lflist: resolveAliasIndex("goat"),
 				duel_rule: 4,
 			};
 		},
@@ -628,7 +680,7 @@ export const formatRuleMappings: RuleMappings = {
 		get: () => {
 			return {
 				rule: 0,
-				lflist: 0,
+				lflist: MercuryBanListMemoryRepository.getFirstOCGIndex(),
 				time_limit: 450,
 			};
 		},
@@ -653,7 +705,7 @@ export const formatRuleMappings: RuleMappings = {
 			return {
 				rule: 5,
 				duel_rule: 5,
-				lflist: 0,
+				lflist: MercuryBanListMemoryRepository.getFirstOCGIndex(),
 				time_limit: 450,
 			};
 		},
@@ -661,6 +713,12 @@ export const formatRuleMappings: RuleMappings = {
 			return value === "ocgpre";
 		},
 	},
+	// "tcgart" is byte-identical to "tcgpre" (rule-equivalent) but kept as a
+	// SEPARATE token on purpose: room identity is the raw command string (see
+	// docs/join-commands.md §4 and the pairing-join semantics), so "tcgart"
+	// and "tcgpre" are two distinct pairing pools even though they resolve to
+	// the same ruleset. Merging them into one alias would silently change
+	// which strangers end up paired together.
 	tcgart: {
 		get: () => {
 			return {
@@ -673,12 +731,14 @@ export const formatRuleMappings: RuleMappings = {
 			return value === "tcgart";
 		},
 	},
+	// Same rationale as "tcgart" above, for the OCG side: "ocgart" is
+	// rule-equivalent to "ocgpre" but intentionally a separate token/pairing pool.
 	ocgart: {
 		get: () => {
 			return {
 				rule: 5,
 				duel_rule: 5,
-				lflist: 0,
+				lflist: MercuryBanListMemoryRepository.getFirstOCGIndex(),
 				time_limit: 450,
 			};
 		},
@@ -687,6 +747,22 @@ export const formatRuleMappings: RuleMappings = {
 		},
 	},
 };
+
+/**
+ * True when the lowercased token matches at least one validate() across the
+ * three tiers (mode / format / priority). Used by the pairing-join predicate
+ * to decide whether every token in a join command is a known rule token —
+ * "casual" is intentionally NOT covered here, it is a separate
+ * league token handled directly by YGOProRoom.create.
+ */
+export function isRecognizedToken(token: string): boolean {
+	const normalized = token.toLowerCase();
+	return (
+		Object.values(ruleMappings).some((mapping) => mapping.validate(normalized)) ||
+		Object.values(formatRuleMappings).some((mapping) => mapping.validate(normalized)) ||
+		Object.values(priorityRuleMappings).some((mapping) => mapping.validate(normalized))
+	);
+}
 
 export const extendedCardPoolFormats = new Set([
 	"pre",

--- a/src/ygopro/room/domain/YGOProRoom.test.ts
+++ b/src/ygopro/room/domain/YGOProRoom.test.ts
@@ -632,6 +632,18 @@ describe("YGOProRoom", () => {
 		});
 	});
 
+	// The same-tier double-match throw is characterized with an isolated,
+	// mocked RuleMappings module in YGOProRoomTierCollapse.test.ts, because the
+	// tier arrays are module-level constants (Object.values computed once at
+	// import) and cannot be mutated at runtime from a normal test.
+	describe("cross-tier double match", () => {
+		it("does NOT throw when a command matches validators across DIFFERENT tiers", () => {
+			// "tcg" matches priorityRuleMappings.ot (priority tier) and "m" matches
+			// ruleMappings.m (mode tier) — two different tiers, so no throw.
+			expect(() => YGOProRoomMother.create({ command: "tcg,m#123" })).not.toThrow();
+		});
+	});
+
 	// A ban-list hot-reload must NOT affect rooms already constructed. A room snapshots
 	// its edopro ban-list hash as a primitive at construction, so a later replaceAll()
 	// on the repositories cannot mutate an in-flight room's value.

--- a/src/ygopro/room/domain/YGOProRoom.ts
+++ b/src/ygopro/room/domain/YGOProRoom.ts
@@ -60,6 +60,13 @@ const BEST_OF = {
 	[GameMode.TAG]: 1,
 };
 
+// Computed once at module load (not per YGOProRoom.create() call).
+// Order matters: later tiers overwrite earlier ones for the same hostInfo key.
+const MODE_TIER = Object.values(ruleMappings);
+const FORMAT_TIER = Object.values(formatRuleMappings);
+const PRIORITY_TIER = Object.values(priorityRuleMappings);
+const RULE_MAPPING_TIERS = [MODE_TIER, FORMAT_TIER, PRIORITY_TIER];
+
 export class YGOProRoom extends YgoRoom {
 	readonly name: string;
 	readonly password: string;
@@ -151,7 +158,6 @@ export class YGOProRoom extends YgoRoom {
 			rule: this._hostInfo.rule,
 			maxDeckPoints: this._hostInfo.max_deck_points,
 		});
-		banListHash;
 		const banList = MercuryBanListMemoryRepository.findByHash(banListHash);
 		const edoBanList = BanListMemoryRepository.findByName(banList?.name ?? "");
 		this._edoBanListHash = edoBanList?.hash ?? 0;
@@ -188,49 +194,24 @@ export class YGOProRoom extends YgoRoom {
 			.split(",")
 			.map((_) => _.trim());
 
-		const mappingKeys = Object.keys(ruleMappings);
-		const formatMappingKeys = Object.keys(formatRuleMappings);
-		const priorityMappingKeys = Object.keys(priorityRuleMappings);
-		const mappings = mappingKeys.map((key) => ruleMappings[key]);
-		const formatMappings = formatMappingKeys.map((key) => formatRuleMappings[key]);
-		const priorityMappings = priorityMappingKeys.map((key) => priorityRuleMappings[key]);
+		// One loop over the three tiers (mode → format → priority), each tier
+		// fully applied to every option before the next tier starts — so later
+		// tiers still overwrite earlier ones for the same hostInfo key, and a
+		// double-match is only ever checked WITHIN a single tier's mapping list.
+		for (const tierMappings of RULE_MAPPING_TIERS) {
+			options.forEach((option) => {
+				const items = tierMappings.filter((item) => item.validate(option));
+				if (items.length > 1) {
+					throw new Error(`Error: param match with two rules.`);
+				}
 
-		options.forEach((option) => {
-			const items = mappings.filter((item) => item.validate(option));
-			if (items.length > 1) {
-				throw new Error(`Error: param match with two rules.`);
-			}
-
-			const mapping = items.shift();
-			if (mapping) {
-				const rule = mapping.get(option);
-				hostInfo = { ...hostInfo, ...rule };
-			}
-		});
-
-		options.forEach((option) => {
-			const items = formatMappings.filter((item) => item.validate(option));
-			if (items.length > 1) {
-				throw new Error(`Error: param match with two rules.`);
-			}
-			const mapping = items.shift();
-			if (mapping) {
-				const rule = mapping.get(option);
-				hostInfo = { ...hostInfo, ...rule };
-			}
-		});
-
-		options.forEach((option) => {
-			const items = priorityMappings.filter((item) => item.validate(option));
-			if (items.length > 1) {
-				throw new Error(`Error: param match with two rules.`);
-			}
-			const mapping = items.shift();
-			if (mapping) {
-				const rule = mapping.get(option);
-				hostInfo = { ...hostInfo, ...rule };
-			}
-		});
+				const mapping = items.shift();
+				if (mapping) {
+					const rule = mapping.get(option);
+					hostInfo = { ...hostInfo, ...rule };
+				}
+			});
+		}
 
 		const teamCount = hostInfo.mode === GameMode.TAG ? 2 : 1;
 		// The host's explicit "casual" token wins over any ranked default — a
@@ -324,6 +305,18 @@ export class YGOProRoom extends YgoRoom {
 		);
 	}
 
+	/**
+	 * Minimal read-only routing hint for YGOProRoomList.findJoinableByName.
+	 * This is a LOCK-FREE read (does not take the room mutex) — it is only ever
+	 * used to decide whether a room is worth attempting to join. Real admission
+	 * still runs exclusively under AdmitToRoom / calculatePlace (which DOES take
+	 * the mutex), so a seat that looks free here can still lose the race by the
+	 * time admission actually runs — the caller must be able to tolerate that.
+	 */
+	hasFreeSeat(): boolean {
+		return this.calculatePlaceUnsafe() !== null;
+	}
+
 	get seed(): number[] {
 		return this._currentDuelRecord.seed;
 	}
@@ -345,7 +338,23 @@ export class YGOProRoom extends YgoRoom {
 	}
 
 	waiting(): void {
+		// Keep the DuelState label (_state, read by toRoomListDTO and
+		// DisconnectHandler) and the actual state object (_roomState, whose
+		// handleJoin() decides player-vs-spectator) moving together — every
+		// other transition (rps/choosingOrder/dueling/sideDecking) sets _state
+		// alongside swapping _roomState, so waiting() must too.
+		this._state = DuelState.WAITING;
 		this._roomState?.removeAllListener();
+		// A room can re-enter waiting after an aborted duel (setDuelFinished,
+		// ocgcore error) with both players still seated, isStart="start", and
+		// stale isReady flags from the crashed duel. Reset both here so a bare
+		// TRY_START can't silently re-arm a new duel — everyone must re-ready
+		// deliberately. No-op on first entry (no players seated yet, isStart is
+		// already "waiting" from the constructor) and on every other normal
+		// waiting() call site (room creation), so this is safe to run
+		// unconditionally.
+		this.isStart = "waiting";
+		this._players.forEach((player) => player.notReady());
 		const userProfileRepo = new UserProfilePostgresRepository();
 		const admitToRoom = new AdmitToRoom(
 			new CredentialResolver(userProfileRepo, new UserAuth(userProfileRepo), this._logger),
@@ -447,7 +456,7 @@ export class YGOProRoom extends YgoRoom {
 					});
 					socket.send(Buffer.from(chat.toFullPayload()));
 				}
-				socket.send(this.messageSender.errorMessage(ErrorMessageType.JOINERROR));
+				socket.send(this.messageSender.errorMessage(ErrorMessageType.JOINERROR, 0));
 				socket.close();
 			},
 		};
@@ -839,7 +848,25 @@ export class YGOProRoom extends YgoRoom {
 	}
 
 	setDuelFinished(): void {
-		this._state = DuelState.WAITING;
+		// The ocgcore-error path lands here with the OCGCore still alive inside
+		// the (about to be discarded) dueling state. Every other exit from
+		// dueling disposes the core before transitioning away (see
+		// YGOProDuelingState.finalizeWithReplays / transitionToSideDecking), so
+		// this path must too, or the core leaks. Guarded because
+		// setDuelFinished can only meaningfully dispose when the CURRENT state
+		// actually is a dueling state.
+		if (this._roomState instanceof YGOProDuelingState) {
+			this._roomState.disposeCore();
+		}
+
+		// Delegate to waiting() instead of flipping the _state label alone.
+		// Flipping only the label would leave _roomState pointing at the stale
+		// dueling state, so a room coming out of a broken duel (ocgcore error in
+		// YGOProDuelingState.handleResponse) would look "waiting" in
+		// toRoomListDTO while its live JOIN handler still spectated
+		// unconditionally. waiting() tears down the old state's listeners AND
+		// rearms real player admission (and resets isStart/isReady).
+		this.waiting();
 	}
 
 	get messageSender(): MessageRepository {

--- a/src/ygopro/room/domain/YGOProRoomAdmissionTarget.test.ts
+++ b/src/ygopro/room/domain/YGOProRoomAdmissionTarget.test.ts
@@ -113,4 +113,19 @@ describe("YGOProRoom.admissionTarget", () => {
 		// Only the generic JOINERROR — a genuine guest never sent credentials.
 		expect(socket.send).toHaveBeenCalledTimes(1);
 	});
+
+	// YGOProMessageRepository.errorMessage(type, code) requires `code`; the
+	// concrete implementation encodes it directly into the wire payload.
+	// Calling it with only `type` sends `code: undefined` on the real repository.
+	it("rejectAdmission calls errorMessage with an explicit JOINERROR code of 0", () => {
+		const room = YGOProRoomMother.create();
+		const socket = makeSocket();
+		const target = room.admissionTarget(socket, playerInfo("P"));
+
+		const errorMessageSpy = jest.spyOn(room.messageSender, "errorMessage");
+
+		target.rejectAdmission("ranked-requires-account");
+
+		expect(errorMessageSpy).toHaveBeenCalledWith(expect.anything(), 0);
+	});
 });

--- a/src/ygopro/room/domain/YGOProRoomStateCoherence.test.ts
+++ b/src/ygopro/room/domain/YGOProRoomStateCoherence.test.ts
@@ -1,0 +1,139 @@
+import { Seat } from "@shared/room/admission/domain/Seat";
+import { DuelState } from "@shared/room/domain/YgoRoom";
+import { YGOProRoomMother } from "@test-support/mothers/room/YGOProRoomMother";
+
+import { YGOProDuelingState } from "./states/YGOProDuelingState";
+import { YGOProWaitingState } from "./states/YGOProWaitingState";
+
+/**
+ * YGOProRoom carries two notions of "what state is this room in": `_state`
+ * (the DuelState enum read by toRoomListDTO / DisconnectHandler) and
+ * `_roomState` (the actual state OBJECT whose handleJoin() decides
+ * player-vs-spectator). Both must move together: `waiting()` must set
+ * `_state` to WAITING whenever it swaps `_roomState`, and `setDuelFinished()`
+ * (called from YGOProDuelingState when ocgcore errors out mid-response) must
+ * swap `_roomState` whenever it sets `_state` back to WAITING — otherwise a
+ * room could look "waiting" (joinable) in toRoomListDTO while its live JOIN
+ * handler is still the stale dueling state, spectating every new joiner
+ * unconditionally.
+ *
+ * rps()/choosingOrder() are used here (not dueling()) because they are
+ * lightweight state transitions with no OCGCore dependency, which is exactly
+ * what's needed to stand the room up in a "non-waiting" state for this test.
+ */
+describe("YGOProRoom — _state / _roomState coherence", () => {
+	it("waiting() also sets the DuelState label (_state) to WAITING, not just _roomState", () => {
+		const room = YGOProRoomMother.create();
+		room.rps();
+		expect(room.duelState).toBe(DuelState.RPS);
+
+		room.waiting();
+
+		expect(room.duelState).toBe(DuelState.WAITING);
+	});
+
+	it("setDuelFinished() swaps the ACTUAL room state (not just the label) so the JOIN handler stops being stale", () => {
+		const room = YGOProRoomMother.create();
+		room.rps();
+		const staleRoomState = (room as unknown as { _roomState: unknown })._roomState;
+
+		room.setDuelFinished();
+
+		const newRoomState = (room as unknown as { _roomState: unknown })._roomState;
+		expect(newRoomState).not.toBe(staleRoomState);
+		expect(newRoomState).toBeInstanceOf(YGOProWaitingState);
+		expect(room.duelState).toBe(DuelState.WAITING);
+	});
+
+	it("setDuelFinished() delegates to waiting() so both notions can never drift apart again", () => {
+		const room = YGOProRoomMother.create();
+		const waitingSpy = jest.spyOn(room, "waiting");
+
+		room.setDuelFinished();
+
+		expect(waitingSpy).toHaveBeenCalledTimes(1);
+		waitingSpy.mockRestore();
+	});
+
+	// The ocgcore-error path (YGOProDuelingState.handleResponse's catch) calls
+	// room.setDuelFinished() when OCGCore.setResponse() throws mid-duel.
+	// setDuelFinished() must swap _roomState AND unwind two things left behind
+	// by the aborted duel:
+	//   - the aborted dueling state's OCGCore must be disposed (every other
+	//     exit from dueling disposes first — see
+	//     YGOProDuelingState.finalizeWithReplays/transitionToSideDecking).
+	//   - isStart and both players' isReady flags must be reset, or a bare
+	//     TRY_START could silently re-arm a new duel without anyone
+	//     re-readying.
+	//
+	// Constructing a REAL YGOProDuelingState here would spin up the native
+	// OCGCore worker (via room.dueling()), which is exactly what the rest of
+	// this file's own comment says to avoid. Instead, this stands in a
+	// dueling-shaped state object (real prototype, so `instanceof
+	// YGOProDuelingState` still holds) with disposeCore/removeAllListener
+	// spied — the same "reach into privates" style already used above for
+	// _roomState.
+	describe("setDuelFinished() unwinds a real dueling state", () => {
+		function seatGuest(room: ReturnType<typeof YGOProRoomMother.create>, name: string, seat: Seat) {
+			const socket = {
+				id: `s-${name}`,
+				send: jest.fn(),
+				close: jest.fn(),
+				destroy: jest.fn(),
+				onMessage: jest.fn(),
+				removeAllListeners: jest.fn(),
+			};
+			return room
+				.admissionTarget(socket as never, { name, password: "" } as never)
+				.seatPlayer({ kind: "guest", name }, seat);
+		}
+
+		it("disposes the dueling state's OCGCore exactly once", async () => {
+			const room = YGOProRoomMother.create();
+			const disposeCore = jest.fn();
+			const fakeDuelingState = Object.create(YGOProDuelingState.prototype) as YGOProDuelingState;
+			Object.assign(fakeDuelingState, { disposeCore, removeAllListener: jest.fn() });
+			(room as unknown as { _roomState: unknown })._roomState = fakeDuelingState;
+
+			room.setDuelFinished();
+
+			expect(disposeCore).toHaveBeenCalledTimes(1);
+			const newRoomState = (room as unknown as { _roomState: unknown })._roomState;
+			expect(newRoomState).toBeInstanceOf(YGOProWaitingState);
+		});
+
+		it("does NOT try to dispose a core when the current state is not a dueling state (no-op guard)", () => {
+			const room = YGOProRoomMother.create();
+			room.rps(); // lightweight non-dueling transition — no ocgCore to dispose
+
+			expect(() => room.setDuelFinished()).not.toThrow();
+			expect((room as unknown as { _roomState: unknown })._roomState).toBeInstanceOf(
+				YGOProWaitingState,
+			);
+		});
+
+		it("resets the pre-duel isStart flag and clears every seated player's ready flag", async () => {
+			const room = YGOProRoomMother.create();
+			await seatGuest(room, "P1", new Seat(0, 0));
+			await seatGuest(room, "P2", new Seat(1, 1));
+			room.players.forEach((player) => player.ready());
+			(room as unknown as { isStart: string }).isStart = "start";
+
+			const fakeDuelingState = Object.create(YGOProDuelingState.prototype) as YGOProDuelingState;
+			Object.assign(fakeDuelingState, { disposeCore: jest.fn(), removeAllListener: jest.fn() });
+			(room as unknown as { _roomState: unknown })._roomState = fakeDuelingState;
+
+			room.setDuelFinished();
+
+			expect((room as unknown as { isStart: string }).isStart).toBe("waiting");
+			expect(room.players.every((player) => !player.isReady)).toBe(true);
+		});
+
+		it("waiting() at fresh room creation is a no-op for isStart/ready (no players seated yet)", () => {
+			const room = YGOProRoomMother.create();
+
+			expect((room as unknown as { isStart: string }).isStart).toBe("waiting");
+			expect(room.players).toHaveLength(0);
+		});
+	});
+});

--- a/src/ygopro/room/domain/YGOProRoomTierCollapse.test.ts
+++ b/src/ygopro/room/domain/YGOProRoomTierCollapse.test.ts
@@ -1,0 +1,147 @@
+import { EventEmitter } from "stream";
+
+import { LoggerMock } from "@test-support/mocks/logger/LoggerMock";
+import { MessageRepositoryMock } from "@test-support/mocks/MessageRepositoryMock";
+import { PlayerInfoMessageMother } from "@test-support/mothers/PlayerInfoMessageMother";
+
+import { YGOProRoom } from "./YGOProRoom";
+
+/**
+ * YGOProRoom.create() validates against RULE_MAPPING_TIERS, a module-level
+ * snapshot computed ONCE at import via `Object.values(...)`. Because the tier
+ * arrays are a module-level snapshot, reproducing a same-tier double match
+ * requires mocking "./RuleMappings" BEFORE YGOProRoom is first imported —
+ * mutating the real exported objects at test time (as a normal test would)
+ * is not observed by YGOProRoom's cached tiers.
+ */
+describe("YGOProRoom.create — same-tier double match (isolated RuleMappings mock)", () => {
+	afterEach(() => {
+		jest.resetModules();
+	});
+
+	it("throws when two validators in the SAME tier match the same token", () => {
+		jest.isolateModules(() => {
+			jest.doMock("./RuleMappings", () => {
+				const actual = jest.requireActual("./RuleMappings");
+				return {
+					...actual,
+					// "ot" already validates "tcg" in the real priority tier; adding a
+					// second entry that also validates "tcg" reproduces a same-tier
+					// double match without touching any real, shipped rule token.
+					priorityRuleMappings: {
+						...actual.priorityRuleMappings,
+						__testDuplicateTcg: {
+							get: () => ({}),
+							validate: (value: string) => value === "tcg",
+						},
+					},
+				};
+			});
+
+			// biome-ignore lint/style/noCommonJs: require inside jest.isolateModules re-evaluates the module graph after doMock
+			const { YGOProRoom } = require("./YGOProRoom");
+			// biome-ignore lint/style/noCommonJs: require inside jest.isolateModules re-evaluates the module graph after doMock
+			const { LoggerMock } = require("@test-support/mocks/logger/LoggerMock");
+			// biome-ignore lint/style/noCommonJs: require inside jest.isolateModules re-evaluates the module graph after doMock
+			const { MessageRepositoryMock } = require("@test-support/mocks/MessageRepositoryMock");
+			// biome-ignore lint/style/noCommonJs: require inside jest.isolateModules re-evaluates the module graph after doMock
+			const { PlayerInfoMessageMother } = require("@test-support/mothers/PlayerInfoMessageMother");
+
+			expect(() =>
+				YGOProRoom.create(
+					1,
+					"tcg#123",
+					new LoggerMock(),
+					new EventEmitter(),
+					PlayerInfoMessageMother.create(),
+					"sock-1",
+					new MessageRepositoryMock(),
+				),
+			).toThrow("Error: param match with two rules.");
+		});
+	});
+
+	it("does NOT throw when the duplicate validator is injected into a DIFFERENT tier than the matched token", () => {
+		jest.isolateModules(() => {
+			jest.doMock("./RuleMappings", () => {
+				const actual = jest.requireActual("./RuleMappings");
+				return {
+					...actual,
+					// Duplicate lives in the FORMAT tier; "tcg" is matched by the
+					// PRIORITY tier's "ot" entry — different tiers, so no throw.
+					formatRuleMappings: {
+						...actual.formatRuleMappings,
+						__testDuplicateTcg: {
+							get: () => ({}),
+							validate: (value: string) => value === "tcg",
+						},
+					},
+				};
+			});
+
+			// biome-ignore lint/style/noCommonJs: require inside jest.isolateModules re-evaluates the module graph after doMock
+			const { YGOProRoom } = require("./YGOProRoom");
+			// biome-ignore lint/style/noCommonJs: require inside jest.isolateModules re-evaluates the module graph after doMock
+			const { LoggerMock } = require("@test-support/mocks/logger/LoggerMock");
+			// biome-ignore lint/style/noCommonJs: require inside jest.isolateModules re-evaluates the module graph after doMock
+			const { MessageRepositoryMock } = require("@test-support/mocks/MessageRepositoryMock");
+			// biome-ignore lint/style/noCommonJs: require inside jest.isolateModules re-evaluates the module graph after doMock
+			const { PlayerInfoMessageMother } = require("@test-support/mothers/PlayerInfoMessageMother");
+
+			expect(() =>
+				YGOProRoom.create(
+					2,
+					"tcg#123",
+					new LoggerMock(),
+					new EventEmitter(),
+					PlayerInfoMessageMother.create(),
+					"sock-2",
+					new MessageRepositoryMock(),
+				),
+			).not.toThrow();
+		});
+	});
+
+	// The mocked-RuleMappings suite above proves same-tier vs cross-tier
+	// double-match detection with SYNTHETIC validators. This characterizes
+	// the actual production precedence rule (later tier wins for the same
+	// hostInfo key) with REAL shipping tokens, unmocked, so a regression that
+	// silently reordered RULE_MAPPING_TIERS would be caught here even though
+	// neither token throws.
+	//
+	// "ocg" (format tier) sets rule=0; "ot"/"tcg" (priority tier) sets
+	// rule=5. Deliberately NOT the "pre,ot" pair sometimes used as a
+	// shorthand example elsewhere: "pre" (format) ALSO sets rule=5, so
+	// "pre,ot" can't distinguish "priority tier ran after format tier" from
+	// "tier order was reversed" — both give the same final value either way.
+	// "ocg,ot" can, because format and priority disagree (0 vs 5).
+	describe("tier precedence with real shipping tokens (non-mocked)", () => {
+		it('"ocg,ot" — the priority tier\'s "ot" overwrites the format tier\'s "ocg" rule (priority runs LAST)', () => {
+			const room = YGOProRoom.create(
+				3,
+				"ocg,ot#123",
+				new LoggerMock(),
+				new EventEmitter(),
+				PlayerInfoMessageMother.create(),
+				"sock-3",
+				new MessageRepositoryMock(),
+			);
+
+			expect(room.hostInfo.rule).toBe(5);
+		});
+
+		it('token order does not change the outcome — "ot,ocg" resolves the same as "ocg,ot" (tiers, not token order, decide precedence)', () => {
+			const room = YGOProRoom.create(
+				4,
+				"ot,ocg#123",
+				new LoggerMock(),
+				new EventEmitter(),
+				PlayerInfoMessageMother.create(),
+				"sock-4",
+				new MessageRepositoryMock(),
+			);
+
+			expect(room.hostInfo.rule).toBe(5);
+		});
+	});
+});

--- a/src/ygopro/room/domain/states/YGOProDuelingState.ts
+++ b/src/ygopro/room/domain/states/YGOProDuelingState.ts
@@ -551,7 +551,14 @@ export class YGOProDuelingState extends RoomState {
 		this.sendDuelEndAndDisconnect();
 	}
 
-	private disposeCore(): void {
+	/**
+	 * Public so YGOProRoom.setDuelFinished() can dispose THIS state's OCGCore
+	 * before delegating to waiting() on the ocgcore-error recovery path
+	 * (handleResponse's catch, above). Every other exit from dueling disposes
+	 * before transitioning (see finalizeWithReplays and
+	 * transitionToSideDecking) — this path must too, or the core leaks.
+	 */
+	disposeCore(): void {
 		if (this.ocgCore.hasOcgcore()) {
 			this.ocgCore.dispose();
 			this.logger.info("OCGCore disposed");

--- a/src/ygopro/room/infrastructure/YGOProRoomList.test.ts
+++ b/src/ygopro/room/infrastructure/YGOProRoomList.test.ts
@@ -1,0 +1,318 @@
+import { EventEmitter } from "stream";
+
+import { PlayerInfoMessage } from "@edopro/messages/client-to-server/PlayerInfoMessage";
+import { Seat } from "@shared/room/admission/domain/Seat";
+import { ISocket } from "@shared/socket/domain/ISocket";
+
+import { LoggerMock } from "@test-support/mocks/logger/LoggerMock";
+import { MessageRepositoryMock } from "@test-support/mocks/MessageRepositoryMock";
+import { YGOProRoomMother } from "@test-support/mothers/room/YGOProRoomMother";
+
+import { YGOProRoom } from "../domain/YGOProRoom";
+import YGOProRoomList from "./YGOProRoomList";
+
+jest.mock("@ygopro/SimpleRoomMessageEmitter");
+
+const makeSocket = (): ISocket =>
+	({
+		id: `s-${Math.random()}`,
+		send: jest.fn(),
+		close: jest.fn(),
+		destroy: jest.fn(),
+		onMessage: jest.fn(),
+		removeAllListeners: jest.fn(),
+		remoteAddress: "127.0.0.1",
+		closed: false,
+	}) as unknown as ISocket;
+
+const playerInfo = (name: string): PlayerInfoMessage => ({ name, password: null }) as never;
+
+async function fillRoom(room: ReturnType<typeof YGOProRoomMother.create>): Promise<void> {
+	// SINGLE mode has team0=1/team1=1 → two seats total. Seat both so
+	// calculatePlaceUnsafe() (and therefore hasFreeSeat()) returns null/false.
+	const target = room.admissionTarget(makeSocket(), playerInfo("P1"));
+	await target.seatPlayer({ kind: "guest", name: "P1" }, new Seat(0, 0));
+	const target2 = room.admissionTarget(makeSocket(), playerInfo("P2"));
+	await target2.seatPlayer({ kind: "guest", name: "P2" }, new Seat(1, 1));
+}
+
+/**
+ * Characterization tests for YGOProRoomList, including the
+ * findJoinableByName() query used by the pairing feature.
+ */
+describe("YGOProRoomList", () => {
+	afterEach(() => {
+		const rooms = YGOProRoomList.getRooms();
+		while (rooms.length) {
+			YGOProRoomList.deleteRoom(rooms[0]);
+		}
+	});
+
+	describe("findByName", () => {
+		it("returns the FIRST of two same-named rooms, ignoring state", () => {
+			const first = YGOProRoomMother.create({ command: "DUPLICATE" });
+			const second = YGOProRoomMother.create({ command: "DUPLICATE" });
+			// Put the SECOND room in a non-waiting state — findByName must still
+			// return the first regardless of either room's state.
+			second.rps();
+
+			YGOProRoomList.addRoom(first);
+			YGOProRoomList.addRoom(second);
+
+			expect(YGOProRoomList.findByName("DUPLICATE")).toBe(first);
+		});
+	});
+
+	describe("findByNameAndPassword", () => {
+		it("returns null when no room with that name exists", () => {
+			expect(YGOProRoomList.findByNameAndPassword("NOTHING", "")).toBeNull();
+		});
+
+		it("returns the room whose name and password both match", () => {
+			const room = YGOProRoomMother.create({ command: "TESTROOM#secret" });
+			YGOProRoomList.addRoom(room);
+
+			expect(YGOProRoomList.findByNameAndPassword("TESTROOM", "secret")).toBe(room);
+		});
+
+		it("returns null when the name matches but the password does not", () => {
+			const room = YGOProRoomMother.create({ command: "TESTROOM#secret" });
+			YGOProRoomList.addRoom(room);
+
+			expect(YGOProRoomList.findByNameAndPassword("TESTROOM", "wrong")).toBeNull();
+		});
+
+		it("ignores room state, unlike findJoinableByName", () => {
+			const room = YGOProRoomMother.create({ command: "TESTROOM#secret" });
+			room.rps(); // lightweight non-waiting transition, no OCGCore needed
+			YGOProRoomList.addRoom(room);
+
+			expect(YGOProRoomList.findByNameAndPassword("TESTROOM", "secret")).toBe(room);
+		});
+
+		it("returns the FIRST of two rooms sharing the same (name, password) pair", () => {
+			const first = YGOProRoomMother.create({ command: "TESTROOM#secret" });
+			const second = YGOProRoomMother.create({ command: "TESTROOM#secret" });
+			YGOProRoomList.addRoom(first);
+			YGOProRoomList.addRoom(second);
+
+			expect(YGOProRoomList.findByNameAndPassword("TESTROOM", "secret")).toBe(first);
+		});
+
+		it("distinguishes two same-named rooms by password", () => {
+			const withPasswordA = YGOProRoomMother.create({ command: "TESTROOM#alpha" });
+			const withPasswordB = YGOProRoomMother.create({ command: "TESTROOM#beta" });
+			YGOProRoomList.addRoom(withPasswordA);
+			YGOProRoomList.addRoom(withPasswordB);
+
+			expect(YGOProRoomList.findByNameAndPassword("TESTROOM", "alpha")).toBe(withPasswordA);
+			expect(YGOProRoomList.findByNameAndPassword("TESTROOM", "beta")).toBe(withPasswordB);
+		});
+	});
+
+	describe("deleteRoom", () => {
+		it("is a no-op when the room is not in the list", () => {
+			const room = YGOProRoomMother.create({ command: "NEVERADDED" });
+			expect(() => YGOProRoomList.deleteRoom(room)).not.toThrow();
+			expect(YGOProRoomList.getRooms()).toHaveLength(0);
+		});
+
+		it("matches by id, not by object identity", () => {
+			const room = YGOProRoomMother.create({ id: 555, command: "BYID" });
+			YGOProRoomList.addRoom(room);
+
+			// A different object reference that merely shares the same id.
+			const staleReference = { id: 555 } as unknown as ReturnType<typeof YGOProRoomMother.create>;
+			YGOProRoomList.deleteRoom(staleReference);
+
+			expect(YGOProRoomList.findById(555)).toBeNull();
+		});
+	});
+
+	describe("findJoinableByName", () => {
+		it("returns null when no room with that name exists", () => {
+			expect(YGOProRoomList.findJoinableByName("NOTHING")).toBeNull();
+		});
+
+		it("skips a dueling room and returns the waiting one, regardless of list order", async () => {
+			const dueling = YGOProRoomMother.create({ command: "TCG" });
+			dueling.rps(); // lightweight non-waiting transition, no OCGCore needed
+
+			const waiting = YGOProRoomMother.create({ command: "TCG" });
+			waiting.waiting();
+
+			// Dueling-like room added FIRST so a naive first-match scan would pick it.
+			YGOProRoomList.addRoom(dueling);
+			YGOProRoomList.addRoom(waiting);
+
+			expect(YGOProRoomList.findJoinableByName("TCG")).toBe(waiting);
+		});
+
+		it("skips a full waiting room and returns a waiting room with a free seat, regardless of list order", async () => {
+			const full = YGOProRoomMother.create({ command: "TCG" });
+			full.waiting();
+			await fillRoom(full);
+
+			const joinable = YGOProRoomMother.create({ command: "TCG" });
+			joinable.waiting();
+
+			// Full room added FIRST so a naive first-match scan would pick it.
+			YGOProRoomList.addRoom(full);
+			YGOProRoomList.addRoom(joinable);
+
+			expect(YGOProRoomList.findJoinableByName("TCG")).toBe(joinable);
+		});
+
+		it("returns null when every same-named room is dueling or full", async () => {
+			const dueling = YGOProRoomMother.create({ command: "TCG" });
+			dueling.rps();
+
+			const full = YGOProRoomMother.create({ command: "TCG" });
+			full.waiting();
+			await fillRoom(full);
+
+			YGOProRoomList.addRoom(dueling);
+			YGOProRoomList.addRoom(full);
+
+			expect(YGOProRoomList.findJoinableByName("TCG")).toBeNull();
+		});
+
+		it("does NOT match a different room name", () => {
+			const waiting = YGOProRoomMother.create({ command: "TCG" });
+			waiting.waiting();
+			YGOProRoomList.addRoom(waiting);
+
+			expect(YGOProRoomList.findJoinableByName("tcg")).toBeNull(); // case-sensitive
+		});
+
+		// requireEmptyPassword must be evaluated as part of the scan predicate,
+		// not as a post-check on whatever findJoinableByName returns first —
+		// otherwise one passworded waiting room with the same name would
+		// permanently shadow every later passwordless one, since the scan would
+		// keep returning the passworded room (which then fails the post-check)
+		// instead of continuing to look.
+		describe("requireEmptyPassword option", () => {
+			it("skips a passworded waiting room and returns a passwordless waiting room with the same name", () => {
+				const passworded = YGOProRoomMother.create({ command: "TCG#secret" });
+				passworded.waiting();
+
+				const passwordless = YGOProRoomMother.create({ command: "TCG" });
+				passwordless.waiting();
+
+				// Passworded room added FIRST — a naive first-match scan (or a
+				// post-check bolted onto one) would pick it and stop there.
+				YGOProRoomList.addRoom(passworded);
+				YGOProRoomList.addRoom(passwordless);
+
+				expect(YGOProRoomList.findJoinableByName("TCG", { requireEmptyPassword: true })).toBe(
+					passwordless,
+				);
+			});
+
+			it("returns null when every same-named waiting room is passworded", () => {
+				const passworded = YGOProRoomMother.create({ command: "TCG#secret" });
+				passworded.waiting();
+				YGOProRoomList.addRoom(passworded);
+
+				expect(YGOProRoomList.findJoinableByName("TCG", { requireEmptyPassword: true })).toBeNull();
+			});
+
+			it("without the option (default), a passworded waiting room is still returned — existing callers unaffected", () => {
+				const passworded = YGOProRoomMother.create({ command: "TCG#secret" });
+				passworded.waiting();
+				YGOProRoomList.addRoom(passworded);
+
+				expect(YGOProRoomList.findJoinableByName("TCG")).toBe(passworded);
+			});
+		});
+
+		// The pairing scan must account for room.league — otherwise a `tcg`
+		// room created by a PIN/ticket-authenticated (ranked) player would
+		// capture every guest's pairing join, and RoomAdmission would then
+		// hard-reject a guest joining a ranked room (JOINERROR + close), with
+		// no fallback.
+		describe("excludeRankedForGuest option", () => {
+			const makeRankedRoom = (): YGOProRoom =>
+				YGOProRoom.create(
+					randomId(),
+					"TCG",
+					new LoggerMock(),
+					new EventEmitter(),
+					{ name: "Host", password: "1234", previousMessage: Buffer.alloc(0) } as never,
+					"sock-host",
+					new MessageRepositoryMock(),
+				);
+
+			it("skips a ranked (external) room and returns null when it's the only candidate", () => {
+				const ranked = makeRankedRoom();
+				expect(ranked.league.type).toBe("external");
+				YGOProRoomList.addRoom(ranked);
+
+				expect(
+					YGOProRoomList.findJoinableByName("TCG", { excludeRankedForGuest: true }),
+				).toBeNull();
+			});
+
+			it("without the option (default), the same ranked room is still returned", () => {
+				const ranked = makeRankedRoom();
+				YGOProRoomList.addRoom(ranked);
+
+				expect(YGOProRoomList.findJoinableByName("TCG")).toBe(ranked);
+			});
+		});
+	});
+
+	describe("findPairingReconnectTarget", () => {
+		it("returns null when no room with that name exists", () => {
+			expect(YGOProRoomList.findPairingReconnectTarget("NOTHING", () => true)).toBeNull();
+		});
+
+		it("skips a WAITING room even when the predicate would match", () => {
+			const waiting = YGOProRoomMother.create({ command: "TCG" });
+			waiting.waiting();
+			YGOProRoomList.addRoom(waiting);
+
+			expect(YGOProRoomList.findPairingReconnectTarget("TCG", () => true)).toBeNull();
+		});
+
+		it("skips a passworded room even when it is non-WAITING and the predicate would match", () => {
+			const passworded = YGOProRoomMother.create({ command: "TCG#secret" });
+			passworded.rps(); // lightweight non-waiting transition, no OCGCore needed
+			YGOProRoomList.addRoom(passworded);
+
+			expect(YGOProRoomList.findPairingReconnectTarget("TCG", () => true)).toBeNull();
+		});
+
+		it("does NOT match a different room name", () => {
+			const room = YGOProRoomMother.create({ command: "TCG" });
+			room.rps(); // lightweight non-waiting transition, no OCGCore needed
+			YGOProRoomList.addRoom(room);
+
+			expect(YGOProRoomList.findPairingReconnectTarget("tcg", () => true)).toBeNull(); // case-sensitive
+		});
+
+		it("returns null when the predicate rejects every matching candidate", () => {
+			const room = YGOProRoomMother.create({ command: "TCG" });
+			room.rps(); // lightweight non-waiting transition, no OCGCore needed
+			YGOProRoomList.addRoom(room);
+
+			expect(YGOProRoomList.findPairingReconnectTarget("TCG", () => false)).toBeNull();
+		});
+
+		it("returns the same-name, passwordless, non-WAITING room the predicate accepts", () => {
+			const room = YGOProRoomMother.create({ command: "TCG" });
+			room.rps(); // lightweight non-waiting transition, no OCGCore needed
+			YGOProRoomList.addRoom(room);
+
+			expect(
+				YGOProRoomList.findPairingReconnectTarget("TCG", (candidate) => candidate === room),
+			).toBe(room);
+		});
+	});
+});
+
+let idCounter = 90000;
+function randomId(): number {
+	idCounter += 1;
+	return idCounter;
+}

--- a/src/ygopro/room/infrastructure/YGOProRoomList.ts
+++ b/src/ygopro/room/infrastructure/YGOProRoomList.ts
@@ -1,6 +1,30 @@
 import { YGOProRoom } from "../domain/YGOProRoom";
+import { DuelState } from "@shared/room/domain/YgoRoom";
 
 const rooms: YGOProRoom[] = [];
+
+/**
+ * Extra constraints layered onto findJoinableByName's base scan (name match +
+ * WAITING + free seat). Both default to false so existing callers are
+ * byte-identical; the pairing feature (findOrCreateRoom) opts into both.
+ */
+export interface FindJoinableOptions {
+	/**
+	 * When true, a candidate whose password is non-empty is skipped instead of
+	 * being returned and rejected by a post-check — the constraint must be
+	 * part of the scan so a passworded same-named room can never shadow a
+	 * later passwordless one.
+	 */
+	requireEmptyPassword?: boolean;
+	/**
+	 * When true, a candidate whose league would hard-reject a guest
+	 * (RoomAdmission: ranked room + guest credential → rejected, not
+	 * spectator) is skipped. Only meaningful for a guest joiner — the caller
+	 * decides whether the current joiner is a guest and passes this
+	 * accordingly; non-guests are never restricted by this flag.
+	 */
+	excludeRankedForGuest?: boolean;
+}
 
 export default {
 	addRoom(room: YGOProRoom): void {
@@ -11,8 +35,76 @@ export default {
 		return rooms;
 	},
 
+	/**
+	 * Exact (case-sensitive) name match. Returns the FIRST room with that name
+	 * and ignores room state — other callers (join strategies' spectate-or-join
+	 * path) depend on this exact contract. Do NOT change it; see
+	 * findJoinableByName for the state-aware variant used by the pairing feature.
+	 */
 	findByName(name: string): YGOProRoom | null {
 		return rooms.find((room) => room.name === name) ?? null;
+	},
+
+	/**
+	 * Iterates ALL rooms with an exact (case-sensitive) name match and returns
+	 * the first whose state is WAITING and that has a free seat (a lock-free
+	 * routing hint — see YGOProRoom.hasFreeSeat). Unlike findByName, order
+	 * among same-named rooms does not matter: dueling/full rooms are skipped
+	 * instead of shadowing a joinable one further down the list. Returns null
+	 * when no same-named room is currently joinable.
+	 *
+	 * `options` fold extra pairing-only constraints INTO the same scan —
+	 * password and league are evaluated per-candidate, not as a post-check on
+	 * whatever this returns first, so a disqualified candidate can never
+	 * shadow a qualifying one further down the list.
+	 */
+	findJoinableByName(name: string, options: FindJoinableOptions = {}): YGOProRoom | null {
+		return (
+			rooms.find(
+				(room) =>
+					room.name === name &&
+					room.duelState === DuelState.WAITING &&
+					room.hasFreeSeat() &&
+					(!options.requireEmptyPassword || room.password === "") &&
+					(!options.excludeRankedForGuest || !room.league.isRanked),
+			) ?? null
+		);
+	},
+
+	/**
+	 * Iterates ALL rooms with an exact (case-sensitive) name match and returns
+	 * the FIRST whose password also matches exactly, ignoring room state — a
+	 * room stays matchable through every duel phase until it is removed from
+	 * the list, same as findByName. Two rooms sharing a name are only
+	 * distinguishable by this pair; see findOrCreateRoom for the caller that
+	 * treats (name, password) as room identity for non-pairing joins.
+	 */
+	findByNameAndPassword(name: string, password: string): YGOProRoom | null {
+		return rooms.find((room) => room.name === name && room.password === password) ?? null;
+	},
+
+	/**
+	 * Iterates ALL rooms with an exact (case-sensitive) name match, an empty
+	 * password, and a state other than WAITING, and returns the first for
+	 * which `isEligibleReconnectTarget` reports a matching occupant.
+	 * findJoinableByName only ever considers WAITING rooms, so a joiner's own
+	 * non-WAITING room (e.g. mid-duel) is otherwise unreachable through the
+	 * pairing scan; this lets findOrCreateRoom route a legitimate reconnect
+	 * back to that room before falling through to the ordinary pairing scan.
+	 */
+	findPairingReconnectTarget(
+		name: string,
+		isEligibleReconnectTarget: (room: YGOProRoom) => boolean,
+	): YGOProRoom | null {
+		return (
+			rooms.find(
+				(room) =>
+					room.name === name &&
+					room.password === "" &&
+					room.duelState !== DuelState.WAITING &&
+					isEligibleReconnectTarget(room),
+			) ?? null
+		);
 	},
 
 	findById(id: number): YGOProRoom | null {

--- a/src/ygopro/windbot/application/RequestWindBotJoin.test.ts
+++ b/src/ygopro/windbot/application/RequestWindBotJoin.test.ts
@@ -133,5 +133,35 @@ describe("RequestWindBotJoin", () => {
 			const payload = tokenStore.consume(token);
 			expect(payload.deck).toBe("Gear.ydk");
 		});
+
+		it("forwards the pool to repo.pickRandom when provided", () => {
+			const bot = makeBot({ name: "Gear", deck: "Gear.ydk" });
+			const repo = makeRepo({ pickRandom: jest.fn().mockReturnValue(bot) });
+			const useCase = new RequestWindBotJoin(repo, tokenStore);
+
+			useCase.execute(7, null, undefined, "edison");
+
+			expect(repo.pickRandom).toHaveBeenCalledWith("edison");
+		});
+
+		it("calls repo.pickRandom with undefined when no pool is provided (generic pool)", () => {
+			const bot = makeBot({ name: "Gear", deck: "Gear.ydk" });
+			const repo = makeRepo({ pickRandom: jest.fn().mockReturnValue(bot) });
+			const useCase = new RequestWindBotJoin(repo, tokenStore);
+
+			useCase.execute(7, null);
+
+			expect(repo.pickRandom).toHaveBeenCalledWith(undefined);
+		});
+
+		it("does not consult the pool when a bot name is given (named lookup takes priority)", () => {
+			const bot = makeBot();
+			const repo = makeRepo({ findByName: jest.fn().mockReturnValue(bot) });
+			const useCase = new RequestWindBotJoin(repo, tokenStore);
+
+			useCase.execute(1, "Anna", undefined, "edison");
+
+			expect(repo.pickRandom).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/src/ygopro/windbot/application/RequestWindBotJoin.ts
+++ b/src/ygopro/windbot/application/RequestWindBotJoin.ts
@@ -18,8 +18,9 @@ export class RequestWindBotJoin {
 		roomId: number,
 		botNameOrNull: string | null,
 		deckOverride?: string,
+		pool?: string,
 	): RequestWindBotJoinResult {
-		const resolved = this._resolveBot(botNameOrNull);
+		const resolved = this._resolveBot(botNameOrNull, pool);
 		const deck = deckOverride ?? resolved.deck;
 		// The override must reach BOTH the token store AND the bot the provider
 		// fires to windbot (buildUrl reads bot.deck for the `deck=` query param),
@@ -34,7 +35,7 @@ export class RequestWindBotJoin {
 		return { token, bot };
 	}
 
-	private _resolveBot(botNameOrNull: string | null): WindbotData {
+	private _resolveBot(botNameOrNull: string | null, pool?: string): WindbotData {
 		if (botNameOrNull !== null) {
 			const bot = this.repo.findByName(botNameOrNull);
 			if (bot === null) {
@@ -43,7 +44,7 @@ export class RequestWindBotJoin {
 			return bot;
 		}
 
-		const bot = this.repo.pickRandom();
+		const bot = this.repo.pickRandom(pool);
 		if (bot === null) {
 			throw new WindbotsExhaustedError();
 		}

--- a/src/ygopro/windbot/application/WindbotModule.test.ts
+++ b/src/ygopro/windbot/application/WindbotModule.test.ts
@@ -155,6 +155,19 @@ describe("WindbotModule", () => {
 
 			expect(result.bot.name).toBe("Gear");
 		});
+
+		it("forwards the pool param through to repo.pickRandom", async () => {
+			const provider = makeProvider();
+			const randomBot = makeBot({ name: "Blackwing", deck: "EdisonBlackwing" });
+			const repo = makeRepo({ pickRandom: jest.fn().mockReturnValue(randomBot) });
+			const mod = WindbotModule.createForTests(
+				makeDeps({ provider: provider as unknown as WindbotModuleDeps["provider"], repo }),
+			);
+
+			await mod.requestBot(1, null, () => false, undefined, "edison");
+
+			expect(repo.pickRandom).toHaveBeenCalledWith("edison");
+		});
 	});
 
 	describe("consumeToken()", () => {

--- a/src/ygopro/windbot/application/WindbotModule.ts
+++ b/src/ygopro/windbot/application/WindbotModule.ts
@@ -124,8 +124,14 @@ export class WindbotModule {
 		botNameOrNull: string | null,
 		isFinalizing: () => boolean,
 		deckOverride?: string,
+		pool?: string,
 	): Promise<{ token: string; bot: WindbotData }> {
-		const { token, bot } = this.requestJoinUseCase.execute(roomId, botNameOrNull, deckOverride);
+		const { token, bot } = this.requestJoinUseCase.execute(
+			roomId,
+			botNameOrNull,
+			deckOverride,
+			pool,
+		);
 
 		try {
 			await this.deps.provider.requestJoin({ token, bot, isFinalizing });

--- a/src/ygopro/windbot/domain/WindbotBotlistRepository.ts
+++ b/src/ygopro/windbot/domain/WindbotBotlistRepository.ts
@@ -3,5 +3,12 @@ import { WindbotData } from "./WindbotData";
 export interface WindbotBotlistRepository {
 	findAll(): WindbotData[];
 	findByName(name: string): WindbotData | null;
-	pickRandom(): WindbotData | null;
+	/**
+	 * No format → CURRENT behavior: visible bots only (hidden excluded).
+	 * With a format → pool is every bot whose `format` matches, INCLUDING
+	 * hidden ones (format-scoped random is an explicit opt-in, so hiding a
+	 * bot from the generic pool must not also hide it from its own format).
+	 * Empty pool → null.
+	 */
+	pickRandom(format?: string): WindbotData | null;
 }

--- a/src/ygopro/windbot/domain/WindbotData.ts
+++ b/src/ygopro/windbot/domain/WindbotData.ts
@@ -2,6 +2,18 @@ export type WindbotData = {
 	name: string;
 	deck: string;
 	dialog?: string;
+	/**
+	 * Excludes this bot from the GENERIC random pool (pickRandom() called with
+	 * no format) only. A hidden bot stays reachable by explicit name
+	 * (findByName) and by format-scoped random (pickRandom(format) when this
+	 * bot's `format` matches) — see WindbotBotlistRepository.pickRandom.
+	 */
 	hidden?: boolean;
 	deckcode?: string;
+	/**
+	 * Optional format tag (e.g. "jtp", "tcg", "edison") used to scope
+	 * pickRandom(format) to a themed pool. Bots without a format are only
+	 * reachable through the generic pool or by explicit name.
+	 */
+	format?: string;
 };

--- a/src/ygopro/windbot/domain/resolveBotPool.test.ts
+++ b/src/ygopro/windbot/domain/resolveBotPool.test.ts
@@ -1,0 +1,67 @@
+import { resolveBotPool } from "./resolveBotPool";
+
+describe("resolveBotPool", () => {
+	it.each([
+		["jtp", "jtp"],
+		["jm", "jtp"],
+		["edison", "edison"],
+		["ed", "edison"],
+		["tt", "tcg"],
+		["toot", "tcg"],
+		["tr", "tcg"],
+		["tmr", "tcg"],
+		["tomr", "tcg"],
+		["pre", "tcg"],
+	])('maps token "%s" to pool "%s"', (token, pool) => {
+		expect(resolveBotPool([token])).toBe(pool);
+	});
+
+	it("is case-insensitive", () => {
+		expect(resolveBotPool(["ED"])).toBe("edison");
+		expect(resolveBotPool(["JTP"])).toBe("jtp");
+	});
+
+	it("returns null for unknown tokens (generic pool)", () => {
+		expect(resolveBotPool(["nc", "ns"])).toBeNull();
+	});
+
+	it("returns null for an empty token list", () => {
+		expect(resolveBotPool([])).toBeNull();
+	});
+
+	it.each([
+		"constructor",
+		"__proto__",
+		"toString",
+		"valueOf",
+		"hasOwnProperty",
+	])('returns null for the prototype-colliding token "%s" instead of a prototype member', (token) => {
+		expect(resolveBotPool([token])).toBeNull();
+	});
+
+	it("picks the first matching FORMAT-tier token when no priority-tier token is present", () => {
+		// "jtp" (format) appears before "ed" (format) — first match wins within the tier.
+		expect(resolveBotPool(["nc", "jtp", "ed"])).toBe("jtp");
+	});
+
+	it("ignores non-mapping tokens interspersed with a mapping one", () => {
+		expect(resolveBotPool(["nc", "ns", "jtp"])).toBe("jtp");
+	});
+
+	describe("tier precedence (priority-tier ALWAYS overrides format-tier)", () => {
+		// Mirrors YGOProRoom.create applying ruleMappings -> formatRuleMappings ->
+		// priorityRuleMappings, where priority tokens always win regardless of
+		// position in the join string.
+		it('"ed,tt,ai" resolves to the priority-tier pool ("tcg"), not the format-tier one', () => {
+			expect(resolveBotPool(["ed", "tt", "ai"])).toBe("tcg");
+		});
+
+		it('"tt,ed,ai" also resolves to "tcg" (order-independent)', () => {
+			expect(resolveBotPool(["tt", "ed", "ai"])).toBe("tcg");
+		});
+
+		it('"ed,ai" (no priority-tier token) resolves to the format-tier pool ("edison")', () => {
+			expect(resolveBotPool(["ed", "ai"])).toBe("edison");
+		});
+	});
+});

--- a/src/ygopro/windbot/domain/resolveBotPool.ts
+++ b/src/ygopro/windbot/domain/resolveBotPool.ts
@@ -1,0 +1,64 @@
+/**
+ * Maps lowercase room-join config tokens to the windbot random-pool format
+ * they should draw from. Used by WindBotJoinStrategy to resolve which
+ * format-scoped pool a bare "ai" (no bot name) join command should roll a
+ * random bot from — see WindbotBotlistRepository.pickRandom(format).
+ *
+ * Resolution mirrors YGOProRoom.create's own tier precedence in
+ * RuleMappings.ts: ruleMappings -> formatRuleMappings -> priorityRuleMappings
+ * are applied in that order, so a priorityRuleMappings token (tt/toot/tr/
+ * tmr/tomr) ALWAYS overrides a formatRuleMappings token (edison/ed/jtp/jm/
+ * pre) regardless of which one appears first in the join string. This
+ * function replicates that: it scans for a priority-tier match across ALL
+ * tokens first, and only falls back to a positional first-match over the
+ * format tier when no priority-tier token is present.
+ *
+ * `pre` maps to "tcg" deliberately, at the format tier — the free-format
+ * random opponent should field a real TCG deck, mirroring the client's
+ * historical behavior of rolling TCG bots for the free-format card.
+ *
+ * Both maps are intentionally partial. Remaining TCG-ish tokens
+ * (tcgpre/ocgpre/tcgart/ocgart/ot/tcg) are left unmapped for now — they
+ * resolve to the generic pool (null) until there's a reason to special-case
+ * them.
+ *
+ * Unknown or absent tokens resolve to null (generic pool, unchanged
+ * pre-existing behavior). Lookups use Map (not a plain object) so a
+ * password token that collides with a prototype member (e.g. "constructor",
+ * "__proto__", "toString") can never resolve to a truthy value.
+ */
+const PRIORITY_TOKEN_TO_POOL = new Map<string, string>([
+	["tt", "tcg"],
+	["toot", "tcg"],
+	["tr", "tcg"],
+	["tmr", "tcg"],
+	["tomr", "tcg"],
+]);
+
+const FORMAT_TOKEN_TO_POOL = new Map<string, string>([
+	["jtp", "jtp"],
+	["jm", "jtp"],
+	["edison", "edison"],
+	["ed", "edison"],
+	["pre", "tcg"],
+]);
+
+export function resolveBotPool(tokens: string[]): string | null {
+	const lowerTokens = tokens.map((token) => token.toLowerCase());
+
+	for (const token of lowerTokens) {
+		const pool = PRIORITY_TOKEN_TO_POOL.get(token);
+		if (pool) {
+			return pool;
+		}
+	}
+
+	for (const token of lowerTokens) {
+		const pool = FORMAT_TOKEN_TO_POOL.get(token);
+		if (pool) {
+			return pool;
+		}
+	}
+
+	return null;
+}

--- a/src/ygopro/windbot/infrastructure/FileBotlistRepository.test.ts
+++ b/src/ygopro/windbot/infrastructure/FileBotlistRepository.test.ts
@@ -28,10 +28,17 @@ describe("FileBotlistRepository", () => {
 			expect(repo.findAll()[0].name).toBe("Anna");
 		});
 
-		it("accepts optional fields (dialog, hidden, deckcode)", () => {
+		it("accepts optional fields (dialog, hidden, deckcode, format)", () => {
 			const filePath = writeTempFile(
 				JSON.stringify([
-					{ name: "Anna", deck: "Anna.ydk", dialog: "anna_dlg", hidden: false, deckcode: "abc" },
+					{
+						name: "Anna",
+						deck: "Anna.ydk",
+						dialog: "anna_dlg",
+						hidden: false,
+						deckcode: "abc",
+						format: "tcg",
+					},
 				]),
 			);
 
@@ -41,6 +48,7 @@ describe("FileBotlistRepository", () => {
 			expect(bots[0].dialog).toBe("anna_dlg");
 			expect(bots[0].hidden).toBe(false);
 			expect(bots[0].deckcode).toBe("abc");
+			expect(bots[0].format).toBe("tcg");
 		});
 
 		it("throws on invalid JSON (malformed)", () => {
@@ -65,6 +73,30 @@ describe("FileBotlistRepository", () => {
 			const filePath = writeTempFile(JSON.stringify({ name: "Anna", deck: "Anna.ydk" }));
 
 			expect(() => new FileBotlistRepository(filePath)).toThrow();
+		});
+	});
+
+	describe("boot-time name length validation", () => {
+		// Every join command rides "<token>,ai#<name>" through the
+		// CTOS_JOIN_GAME utf16[20] pass field. Reserving 4 chars for "<token>,"
+		// (covers up to 3-char tokens like "jtp") and 3 chars for "ai#" leaves
+		// name.length <= 13 as the safe boot-time ceiling.
+		it("accepts a bot name at the 13-char ceiling", () => {
+			const filePath = writeTempFile(JSON.stringify([{ name: "A".repeat(13), deck: "Deck.ydk" }]));
+
+			expect(() => new FileBotlistRepository(filePath)).not.toThrow();
+		});
+
+		it("throws with the offending bot name when a name exceeds the 13-char ceiling", () => {
+			const filePath = writeTempFile(JSON.stringify([{ name: "A".repeat(14), deck: "Deck.ydk" }]));
+
+			expect(() => new FileBotlistRepository(filePath)).toThrow(/AAAAAAAAAAAAAA/);
+		});
+
+		it("scopes the thrown message's guarantee to tokens up to 3 chars, not unconditionally", () => {
+			const filePath = writeTempFile(JSON.stringify([{ name: "A".repeat(14), deck: "Deck.ydk" }]));
+
+			expect(() => new FileBotlistRepository(filePath)).toThrow(/tokens up to 3 chars/);
 		});
 	});
 
@@ -179,6 +211,70 @@ describe("FileBotlistRepository", () => {
 
 			expect(results.has("Anna")).toBe(true);
 			expect(results.has("Gear")).toBe(true);
+		});
+
+		describe("format-scoped random (pickRandom(format))", () => {
+			it("restricts the pool to bots whose format matches, INCLUDING hidden ones", () => {
+				const filePath = writeTempFile(
+					JSON.stringify([
+						{ name: "Anna", deck: "Anna.ydk", format: "tcg" },
+						{ name: "Hidden", deck: "Hidden.ydk", format: "tcg", hidden: true },
+						{ name: "Other", deck: "Other.ydk", format: "jtp" },
+					]),
+				);
+
+				const repo = new FileBotlistRepository(filePath);
+				const results = new Set<string>();
+
+				for (let i = 0; i < 40; i++) {
+					const bot = repo.pickRandom("tcg");
+					if (bot) results.add(bot.name);
+				}
+
+				expect(results.has("Anna")).toBe(true);
+				expect(results.has("Hidden")).toBe(true);
+				expect(results.has("Other")).toBe(false);
+			});
+
+			it("returns null when no bot matches the requested format", () => {
+				const filePath = writeTempFile(
+					JSON.stringify([{ name: "Anna", deck: "Anna.ydk", format: "tcg" }]),
+				);
+
+				const repo = new FileBotlistRepository(filePath);
+
+				expect(repo.pickRandom("edison")).toBeNull();
+			});
+
+			it("treats an empty-string format as an empty pool, NOT the generic pool", () => {
+				const filePath = writeTempFile(
+					JSON.stringify([{ name: "Anna", deck: "Anna.ydk", format: "tcg" }]),
+				);
+
+				const repo = new FileBotlistRepository(filePath);
+
+				expect(repo.pickRandom("")).toBeNull();
+			});
+
+			it("does not change the no-argument (generic pool) behavior", () => {
+				const filePath = writeTempFile(
+					JSON.stringify([
+						{ name: "Anna", deck: "Anna.ydk", format: "tcg" },
+						{ name: "Hidden", deck: "Hidden.ydk", format: "tcg", hidden: true },
+					]),
+				);
+
+				const repo = new FileBotlistRepository(filePath);
+				const results = new Set<string>();
+
+				for (let i = 0; i < 30; i++) {
+					const bot = repo.pickRandom();
+					if (bot) results.add(bot.name);
+				}
+
+				expect(results.has("Hidden")).toBe(false);
+				expect(results.has("Anna")).toBe(true);
+			});
 		});
 	});
 });

--- a/src/ygopro/windbot/infrastructure/FileBotlistRepository.ts
+++ b/src/ygopro/windbot/infrastructure/FileBotlistRepository.ts
@@ -9,9 +9,16 @@ const WindbotDataSchema = z.object({
 	dialog: z.string().optional(),
 	hidden: z.boolean().optional(),
 	deckcode: z.string().optional(),
+	format: z.string().optional(),
 });
 
 const BotlistSchema = z.array(WindbotDataSchema);
+
+// Every AI join command rides "<token>,ai#<name>" through the CTOS_JOIN_GAME
+// utf16[20] "pass" field (see RuleMappings.ts). Reserve 4 chars for
+// "<token>," (covers up to 3-char format tokens like "jtp") + 3 chars for the
+// literal "ai#", leaving name.length <= 20 - 4 - 3 = 13 for the bot name.
+const MAX_BOT_NAME_LENGTH = 13;
 
 export class FileBotlistRepository implements WindbotBotlistRepository {
 	private readonly bots: WindbotData[];
@@ -24,6 +31,14 @@ export class FileBotlistRepository implements WindbotBotlistRepository {
 			throw new Error(`Invalid botlist at ${filePath}: ${result.error.message}`);
 		}
 		this.bots = result.data;
+
+		for (const bot of this.bots) {
+			if (bot.name.length > MAX_BOT_NAME_LENGTH) {
+				throw new Error(
+					`Invalid botlist at ${filePath}: bot name "${bot.name}" exceeds ${MAX_BOT_NAME_LENGTH} chars — for tokens up to 3 chars (e.g. "jtp"), it cannot fit the CTOS_JOIN_GAME utf16[20] pass field as "<token>,ai#${bot.name}"`,
+				);
+			}
+		}
 	}
 
 	findAll(): WindbotData[] {
@@ -35,11 +50,14 @@ export class FileBotlistRepository implements WindbotBotlistRepository {
 		return this.bots.find((b) => b.name.toLowerCase() === lower) ?? null;
 	}
 
-	pickRandom(): WindbotData | null {
-		const visible = this.bots.filter((b) => b.hidden !== true);
-		if (visible.length === 0) {
+	pickRandom(format?: string): WindbotData | null {
+		const pool =
+			format !== undefined
+				? this.bots.filter((b) => b.format === format)
+				: this.bots.filter((b) => b.hidden !== true);
+		if (pool.length === 0) {
 			return null;
 		}
-		return visible[Math.floor(Math.random() * visible.length)];
+		return pool[Math.floor(Math.random() * pool.length)];
 	}
 }

--- a/src/ygopro/ygopro/YGOProResourceLoader.ts
+++ b/src/ygopro/ygopro/YGOProResourceLoader.ts
@@ -287,10 +287,31 @@ export class YGOProResourceLoader {
 			const buf = await file.read();
 			const text = Buffer.from(buf).toString("utf-8");
 			const lflist = new YGOProLFList().fromText(text);
+			const alias = this.deriveFormatAlias(file.path);
+
+			if (alias && lflist.items.length > 1) {
+				this.logger.warn(
+					`YGOProResourceLoader.getLFLists: "${file.path}" holds ${lflist.items.length} lflist entries under a formats/<alias>/ directory — an alias identifies exactly one list, so "${alias}" is assigned to the first entry only.`,
+				);
+			}
+
+			let itemIndex = 0;
 			for (const item of lflist.items) {
-				yield { item, text };
+				yield { item, text, alias: itemIndex === 0 ? alias : undefined };
+				itemIndex++;
 			}
 		}
+	}
+
+	/**
+	 * A banlist alias identifies exactly one list, so it is derived only from
+	 * paths shaped as formats/<alias>/lflist.conf. Lists outside a formats/
+	 * directory (e.g. the base pool) get no alias.
+	 */
+	private deriveFormatAlias(filePath: string): string | undefined {
+		const normalizedPath = filePath.split(path.sep).join("/");
+		const match = normalizedPath.match(/\/formats\/([^/]+)\/lflist\.conf$/);
+		return match?.[1]?.toLowerCase();
 	}
 
 	async logLFLists(): Promise<void> {


### PR DESCRIPTION
## Summary

- **Pairing joins for any client**: an empty-password command made purely of recognized tokens (`TCG`, `edison`, `m,tt`…) joins a waiting same-command room with a free seat and a compatible league, or creates a fresh one — never lands in a dueling/full room as a stranger-spectator. Keyed on the exact command string (case- and order-sensitive, by design). Disconnected pairing players re-sending the bare command are matched as legitimate reconnectors first.
- **Room identity = (name, password) pair** for non-pairing joins: a mismatched pair creates its own room instead of rejecting, so pairing rooms no longer block passworded rooms sharing their name. Mid-duel spectating with the correct password unchanged.
- **Edison windbots playable**: short botlist names fitting the utf16[20] pass field, `ed` format alias, format-tagged botlist with format-scoped random pools (a format room can no longer roll a bot with an illegal deck), boot-time bot-name length validation.
- **Determinism & correctness batch**: banlist alias resolution is order-independent (load-time format-dir aliases → exact name → tie-broken substring with warning); `lp0` no longer starts 0-LP duels (NaN clamp bug); room DuelState label and state object always transition together (ocgcore-error rewind no longer leaks the core or advertises an unjoinable room as waiting); windbot bootstrap fails fast pre-listen.

## Commits (reviewable work units)

| Commit | Scope |
|--------|-------|
| `feat(windbot)` | Edison bots, format pools, boot validation, teardown ordering |
| `feat(ban-list)` | Deterministic alias resolution, `getFirstOCGIndex` |
| `fix(room)` | lp clamps, state coherence, boot order, registry fallback |
| `feat(room)` | Pairing joins, (name,password) identity, `docs/join-commands.md` |

## Docs

`docs/join-commands.md` (new) is the reference for the whole command system: wire format, strategy chain, token catalog, room identity, pairing semantics, and known caveats.

## Test plan

- [x] Full suite: 123 suites / 1158 tests green (94+ new tests, TDD red→green per behavior)
- [x] `tsc --noEmit` clean, biome clean (pre-commit hooks)
- [x] Three independent adversarial review rounds over the diff; all CRITICAL/WARNING findings fixed and re-verified
- [x] Manual smoke: bare `edison` pairing + `edison#123` private-room creation against a local server

## Deploy notes

- `config/botlist.example.json` is the production botlist (docker-compose default): renames and `format` tags ship with this PR. Curated botlists MUST tag entries with `format` or format-scoped random joins fail (documented in Dockerfile).
- `G`/genesys join commands throw if the genesys banlist is not served — ensure it ships before advertising the token.
- Behavior notes: `jtp,ai`/`tt,ai`/`pre,ai` random is now format-scoped (the jtp change fixes an illegal-deck bug); bare `ai` unchanged. Wrong room password no longer rejects — it identifies a different room.