### PR TITLE
fix(ban-list): announce whitelist lists with the hash ygopro clients compute

### DIFF
--- a/src/ygopro/ban-list/domain/YGOProBanList.test.ts
+++ b/src/ygopro/ban-list/domain/YGOProBanList.test.ts
@@ -19,6 +19,62 @@ describe("YGOProBanList", () => {
 		});
 	});
 
+	describe("recomputeWhitelistHash", () => {
+		// MDPro3 hashes EVERY entry it parses, including the 3-copy ones a
+		// whitelist enumerates, and then XORs the result with 0x0f0f0f0f when it
+		// sees `$whitelist`. EDOPro does neither, which is why this lives on the
+		// ygopro list only. The hash the ygopro lflist library gives us covers
+		// limit 0-2 entries and never matches a whitelist list on any client.
+		const WHITELIST_XOR = 0x0f0f0f0f;
+
+		function referenceHash(entries: [number, number][]): number {
+			let hash = 0x7dfcee6a;
+			for (const [cardId, quantity] of entries) {
+				hash =
+					hash ^
+					((((cardId >>> 0) << 18) >> 0) | (cardId >> 14)) ^
+					((((cardId >>> 0) << (27 + quantity)) >>> 0) | (cardId >>> (5 - quantity)));
+			}
+			return (hash ^ WHITELIST_XOR) >>> 0;
+		}
+
+		it("hashes every entry including the 3-copy ones, then applies the whitelist xor", () => {
+			const entries: [number, number][] = [
+				[72989439, 0],
+				[80604091, 1],
+				[89631139, 2],
+				[910003011, 3],
+			];
+			for (const [cardId, quantity] of entries) banList.add(cardId, quantity);
+			banList.setHash(0xdeadbeef);
+
+			banList.recomputeWhitelistHash();
+
+			expect(banList.hash >>> 0).toBe(referenceHash(entries));
+		});
+
+		it("replaces whatever hash the lflist library supplied", () => {
+			banList.add(910003011, 3);
+			banList.setHash(0xd802337f);
+			banList.recomputeWhitelistHash();
+			expect(banList.hash >>> 0).not.toBe(0xd802337f);
+		});
+
+		it("is order independent, since the entries are combined with xor", () => {
+			banList.add(72989439, 0);
+			banList.add(910003011, 3);
+			banList.recomputeWhitelistHash();
+			const forward = banList.hash >>> 0;
+
+			const reversed = new YGOProBanList();
+			reversed.add(910003011, 3);
+			reversed.add(72989439, 0);
+			reversed.recomputeWhitelistHash();
+
+			expect(reversed.hash >>> 0).toBe(forward);
+		});
+	});
+
 	describe("points (Genesys third column)", () => {
 		it("should store the point cost when provided", () => {
 			const cardId = 21044178;

--- a/src/ygopro/ban-list/domain/YGOProBanList.ts
+++ b/src/ygopro/ban-list/domain/YGOProBanList.ts
@@ -21,6 +21,42 @@ export class YGOProBanList extends BanList {
 		return this._alias;
 	}
 
+	/**
+	 * Recomputes the list hash the way a ygopro-family client computes it for a
+	 * whitelist list, replacing the one the lflist library supplied.
+	 *
+	 * Two divergences make the library hash unusable here. It parses only limit
+	 * 0-2 entries, so it ignores the thousands of 3-copy rows a whitelist has to
+	 * enumerate; and clients that support `$whitelist` fold 0x0f0f0f0f into the
+	 * hash when they see the directive. The result matches no client at all: a
+	 * room hosted with a whitelist list shows up as "Unknown Banlist".
+	 *
+	 * Scoped to the ygopro protocol on purpose. EDOPro parses the directive but
+	 * leaves its hash alone, so its side must keep the library value.
+	 *
+	 * XOR is commutative, so bucket order does not matter.
+	 */
+	recomputeWhitelistHash(): void {
+		const buckets: [number[], number][] = [
+			[this.forbidden, 0],
+			[this.limited, 1],
+			[this.semiLimited, 2],
+			[this.all, 3],
+		];
+
+		let hash = 0x7dfcee6a;
+		for (const [cardIds, quantity] of buckets) {
+			for (const cardId of cardIds) {
+				hash =
+					hash ^
+					((((cardId >>> 0) << 18) >> 0) | (cardId >> 14)) ^
+					((((cardId >>> 0) << (27 + quantity)) >>> 0) | (cardId >>> (5 - quantity)));
+			}
+		}
+
+		this._hash = (hash ^ 0x0f0f0f0f) >>> 0;
+	}
+
 	add(cardId: number, quantity: number, points?: number): void {
 		switch (quantity) {
 			case 0:

--- a/src/ygopro/ban-list/infrastructure/YGOProBanListLoader.ts
+++ b/src/ygopro/ban-list/infrastructure/YGOProBanListLoader.ts
@@ -110,6 +110,17 @@ export class YGOProBanListLoader {
 				this.parseUnrestrictedEntries(text, banList);
 			}
 
+			// The library hash covers limit 0-2 entries only and ignores the
+			// `$whitelist` directive, so a whitelist list is announced with a hash
+			// no client can match and the room reads "Unknown Banlist". Recompute
+			// it over every entry the way a ygopro-family client does. Genesys is
+			// excluded: it folds per-card point costs into its own hash, which we
+			// do not model, so recomputing there would trade one mismatch for
+			// another.
+			if (isWhitelist && !banList.isGenesys()) {
+				banList.recomputeWhitelistHash();
+			}
+
 			this._loaded.push(banList);
 
 			if (this._target !== null) {


### PR DESCRIPTION
A room hosted with the Edison list shows **Forbidden List: Unknown Banlist** in MDPro3. The client matches the hash the host announces against hashes it computed from its own lists, and ours matched nothing.

## Two divergences, both on the ygopro path

1. The lflist library we take the hash from **parses limit 0-2 entries only**. A whitelist has to enumerate its 3-copy rows — 3539 of the Edison list's 3671 — and they never reach the hash. The loader already works around this for the *entries* via `parseUnrestrictedEntries`; the hash still came from the library.
2. Clients that implement `$whitelist` **fold `0x0f0f0f0f` into the hash** when they parse the directive.

For the Edison list:

| | value | over |
|---|---|---|
| server announced | `0xd802337f` | 132 entries, no xor |
| client expects | `0x67989402` | 3671 entries + xor |

## Why this is safe in both directions

- **Normal lists are untouched.** They never enumerate 3-copy entries, so library and client already agree.
- **Whitelist lists could not get worse.** The old hash matched *no* client: classic YGOPro and YGOMobile do not implement the directive and discard the 3-copy rows outright, so they can never match a whitelist list regardless. The value being replaced was useful to nobody; now it is useful to the one client that can use it.
- **EDOPro is untouched.** It parses the directive without touching its hash (`deck_manager.cpp` — zero occurrences of `0x0f0f0f0f`), so its loader must keep the library value. Its path is a different loader, which is what makes the split possible.
- **Genesys is excluded.** It folds per-card point costs into its own hash, which we do not model; recomputing there would trade one mismatch for another.

## Test plan

- [x] `npx jest` — 123 suites, 1161 tests, all green
- [x] Unit tests: hashes every entry including 3-copy ones, applies the xor, replaces the library value, order independent
- [x] End to end: the real `edison.lflist.conf` run through `YGOProBanList` produces `0x67989402`, the value MDPro3 derives from the same file