### PR TITLE
feat(matchmaking): add edison to the ranked queue

### DIFF
--- a/src/ygopro/matchmaking/application/MatchmakingRoomFactory.test.ts
+++ b/src/ygopro/matchmaking/application/MatchmakingRoomFactory.test.ts
@@ -87,6 +87,36 @@ describe("createMatchmakingRoom", () => {
 		expect(room.hostInfo.rule).toBe(5);
 	});
 
+	it('uses the "ed" token for edison single rooms (MR1 + edison banlist)', () => {
+		const { room } = createMatchmakingRoom({
+			format: "edison",
+			rankedOverride: false,
+			logger: makeLogger(),
+			emitter: new EventEmitter(),
+		});
+
+		expect(room.name.startsWith("ed,")).toBe(true);
+		// Edison is Master Rule 1 over the open pool — the banlist defines the format.
+		expect(room.hostInfo.rule).toBe(5);
+		expect(room.hostInfo.duel_rule).toBe(1);
+		expect(room.bestOf).toBe(1);
+	});
+
+	it('uses the "edm" token for edison MATCH rooms (edison rules + best-of-3)', () => {
+		const { room } = createMatchmakingRoom({
+			format: "edison",
+			rankedOverride: true,
+			matchMode: true,
+			logger: makeLogger(),
+			emitter: new EventEmitter(),
+		});
+
+		expect(room.bestOf).toBe(3);
+		expect(room.isMatch).toBe(true);
+		expect(room.name.startsWith("edm,")).toBe(true);
+		expect(room.hostInfo.duel_rule).toBe(1);
+	});
+
 	it("keeps rooms best-of-1 when matchMode is omitted (bot fallback — windbot cannot side-deck)", () => {
 		const { room } = createMatchmakingRoom({
 			rankedOverride: false,

--- a/src/ygopro/matchmaking/application/MatchmakingRoomFactory.ts
+++ b/src/ygopro/matchmaking/application/MatchmakingRoomFactory.ts
@@ -22,21 +22,24 @@ import YGOProRoomList from "../../room/infrastructure/YGOProRoomList";
  * "tt" is the short alias of "toot" (RuleMappings): rule 5 + first TCG lflist —
  * TCG banlist over an OPEN pool. The old "to" (rule 1, scoped pool) bounced
  * cards without a TCG release (recent OCG printings, ot=0x9) at join.
+ * "ed" is the short alias of "edison": rule 5 + edison lflist + Master Rule 1.
  */
 export const FORMAT_ROOM_TOKEN: Record<MatchmakingFormat, string> = {
 	tcg: "tt",
 	jtp: "jtp",
+	edison: "ed",
 };
 
 /**
  * Per-format MATCH (best-of-3) token, used for human pairs. Same banlist/rule
  * set as FORMAT_ROOM_TOKEN plus mode=MATCH + best_of=3 (RuleMappings: "tmr",
- * "jm"). "tmr" (3) sits at the 19-char wire ceiling like "jtp"; "jm" (2) has
- * one char of slack.
+ * "jm", "edm"). "tmr" and "edm" (3) sit at the 19-char wire ceiling like "jtp";
+ * "jm" (2) has one char of slack.
  */
 export const FORMAT_ROOM_TOKEN_MATCH: Record<MatchmakingFormat, string> = {
 	tcg: "tmr",
 	jtp: "jm",
+	edison: "edm",
 };
 
 export interface CreateMatchmakingRoomInput {

--- a/src/ygopro/matchmaking/domain/MatchmakingBotRoster.test.ts
+++ b/src/ygopro/matchmaking/domain/MatchmakingBotRoster.test.ts
@@ -18,6 +18,10 @@ describe("MATCHMAKING_BOT_ROSTER", () => {
 		expect(MATCHMAKING_BOT_ROSTER.jtp.length).toBe(2);
 	});
 
+	it("edison roster has exactly 3 entries", () => {
+		expect(MATCHMAKING_BOT_ROSTER.edison.length).toBe(3);
+	});
+
 	it("all roster entries have non-empty name and deck strings", () => {
 		for (const fmt of MATCHMAKING_FORMATS) {
 			for (const pair of MATCHMAKING_BOT_ROSTER[fmt]) {
@@ -33,6 +37,17 @@ describe("MATCHMAKING_BOT_ROSTER", () => {
 		const jtp = MATCHMAKING_BOT_ROSTER.jtp;
 		expect(jtp[0]).toEqual({ name: "Joey", deck: "JTP" });
 		expect(jtp[1]).toEqual({ name: "Yugi", deck: "Yugi" });
+	});
+
+	it("edison roster pairs each archetype name with its Edison deck", () => {
+		// Names and decks are verified against config/botlist.example.json, where
+		// the Edison bots are `hidden` (excluded from the random pool) but still
+		// reachable by explicit name — which is exactly how the roster requests them.
+		expect(MATCHMAKING_BOT_ROSTER.edison).toEqual([
+			{ name: "Blackwing", deck: "EdisonBlackwing" },
+			{ name: "Lightsworn", deck: "EdisonLightsworn" },
+			{ name: "Machina", deck: "EdisonMachina" },
+		]);
 	});
 });
 

--- a/src/ygopro/matchmaking/domain/MatchmakingBotRoster.ts
+++ b/src/ygopro/matchmaking/domain/MatchmakingBotRoster.ts
@@ -25,6 +25,12 @@ export interface BotIdentity {
  * JTP roster: Joey plays JTP, Yugi plays Yugi. Both are in the server botlist
  * (config/botlist.example.json) so requestBot will find them by name.
  *
+ * Edison roster: the three archetype bots shipped for the vs-AI screen —
+ * "Blackwing" ↔ EdisonBlackwing.ydk, "Lightsworn" ↔ EdisonLightsworn.ydk,
+ * "Machina" ↔ EdisonMachina.ydk. They are `hidden` in the botlist (kept out of
+ * the random pool) but stay reachable by explicit name, which is how the roster
+ * requests them.
+ *
  * IMPORTANT: All deck strings must be legal for the active banlist of that format.
  * Adjust if a deck-check rejects any entry.
  */
@@ -41,6 +47,11 @@ export const MATCHMAKING_BOT_ROSTER: Record<MatchmakingFormat, readonly BotIdent
 	jtp: [
 		{ name: "Joey", deck: "JTP" },
 		{ name: "Yugi", deck: "Yugi" },
+	],
+	edison: [
+		{ name: "Blackwing", deck: "EdisonBlackwing" },
+		{ name: "Lightsworn", deck: "EdisonLightsworn" },
+		{ name: "Machina", deck: "EdisonMachina" },
 	],
 };
 

--- a/src/ygopro/matchmaking/domain/QueueEntry.test.ts
+++ b/src/ygopro/matchmaking/domain/QueueEntry.test.ts
@@ -1,8 +1,8 @@
 import { MATCHMAKING_FORMATS, MatchmakingFormat } from "./QueueEntry";
 
 describe("MATCHMAKING_FORMATS", () => {
-	it('is exactly ["tcg","jtp"] as a const array', () => {
-		expect(MATCHMAKING_FORMATS).toEqual(["tcg", "jtp"]);
+	it('is exactly ["tcg","jtp","edison"] as a const array', () => {
+		expect(MATCHMAKING_FORMATS).toEqual(["tcg", "jtp", "edison"]);
 	});
 
 	it("contains only non-empty, unique format strings", () => {

--- a/src/ygopro/matchmaking/domain/QueueEntry.ts
+++ b/src/ygopro/matchmaking/domain/QueueEntry.ts
@@ -19,7 +19,7 @@ export const MATCHED_GRACE_MS = 30_000;
 
 /** All accepted matchmaking formats. Used as the single source of truth for the
  * Zod enum, type derivation, and per-format record maps. */
-export const MATCHMAKING_FORMATS = ["tcg", "jtp"] as const;
+export const MATCHMAKING_FORMATS = ["tcg", "jtp", "edison"] as const;
 export const SUPPORTED_QUEUE = "ranked" as const;
 
 export type MatchmakingFormat = (typeof MATCHMAKING_FORMATS)[number];

--- a/src/ygopro/room/domain/RuleMappings.test.ts
+++ b/src/ygopro/room/domain/RuleMappings.test.ts
@@ -261,6 +261,36 @@ describe("ed mapping (edison short alias, used by AI duel join commands)", () =>
 	});
 });
 
+describe("edm mapping (edison best-of-3, used by matchmaking)", () => {
+	it("maps the edison rule set to a best-of-3 match", () => {
+		const findIndex = jest
+			.spyOn(MercuryBanListMemoryRepository, "findIndexByAlias")
+			.mockReturnValue(7);
+
+		const rule = formatRuleMappings.edm.get("edm");
+
+		// Same rule set as "edison"/"ed" — MR1 over the open pool with the edison
+		// banlist and the 450s clock — plus MATCH + best-of-3 for ranked pairs.
+		expect(rule).toEqual({
+			rule: 5,
+			lflist: 7,
+			duel_rule: 1,
+			time_limit: 450,
+			mode: GameMode.MATCH,
+			best_of: 3,
+		});
+		expect(findIndex).toHaveBeenCalledWith("edison");
+
+		findIndex.mockRestore();
+	});
+
+	it("validates only the exact token", () => {
+		expect(formatRuleMappings.edm.validate("edm")).toBe(true);
+		expect(formatRuleMappings.edm.validate("ed")).toBe(false);
+		expect(formatRuleMappings.edm.validate("edison")).toBe(false);
+	});
+});
+
 describe("jtp-2007-03 mapping (JTP Advanced March 2007)", () => {
 	it("maps the historical JTP variant to MR2 over the open JTP pool", () => {
 		const findIndex = jest

--- a/src/ygopro/room/domain/RuleMappings.ts
+++ b/src/ygopro/room/domain/RuleMappings.ts
@@ -460,6 +460,20 @@ export const formatRuleMappings: RuleMappings = {
 			return value === "ed";
 		},
 	},
+	// "edm" is "edison" + best-of-3 match. Kept to 3 chars because it is the
+	// matchmaking MATCH token for the edison queue, whose join string must fit
+	// the utf16[20] wire field (token <= 3 chars — see MatchmakingRoomFactory).
+	// Spreads the shared edison payload so the two can never drift apart.
+	edm: {
+		get: () => ({
+			...edisonRuleSet(),
+			mode: GameMode.MATCH,
+			best_of: 3,
+		}),
+		validate: (value) => {
+			return value === "edm";
+		},
+	},
 	hat: {
 		get: () => {
 			return {


### PR DESCRIPTION
Companion to [evolution-card-game#134](https://github.com/diangogav/evolution-card-game/pull/134). **This one merges first** — the client cannot queue for a format the server's Zod enum rejects.

## Why

Edison already had everything it needed, just never in the queue: the rule set (`edison`/`ed`), the ban list, and three tuned windbots that the vs-AI screen has been serving for a while. The only missing piece was the format string itself.

## How

`MATCHMAKING_FORMATS` is the single source of truth — the Zod enum, the type, and every `Record<MatchmakingFormat, …>` derive from it. Adding `"edison"` is most of the wiring; the compiler then demands the two per-format maps below.

**Room tokens.** The join string rides `CTOS_JOIN_GAME`'s fixed `utf16[20]` `pass` field as `"<token>,mm<5>#<7>"` = `token.length + 16`. That caps a format's room token at **3 characters**, and `"edison"` is 6. Single duels reuse the existing `ed` alias. Ranked human pairs play best-of-3, and no MATCH variant existed, so `edm` joins `formatRuleMappings`:

```ts
edm: {
    get: () => ({ ...edisonRuleSet(), mode: GameMode.MATCH, best_of: 3 }),
    ...
}
```

It spreads the shared payload rather than restating it, so the MATCH variant cannot drift from `edison`/`ed`. One rule set, three tokens.

**Bots.** `MATCHMAKING_BOT_ROSTER.edison` pairs each archetype name with its deck — Blackwing/`EdisonBlackwing`, Lightsworn/`EdisonLightsworn`, Machina/`EdisonMachina`. They are `hidden: true` in the botlist, so they stay out of the random pool but remain reachable by explicit name, which is exactly how the roster requests them. Those rooms stay best-of-1: windbot never submits a side deck, so a MATCH room would stall in side-decking until the timeout kicked the bot mid-match.

## On the inverted test

`MATCHMAKING_FORMATS is exactly ["tcg","jtp"]` now pins the three-format set. It is a deliberate closed-set guard, not incidental — the client mirrors this list, and a silent divergence there surfaces as a 400 on enqueue.

## Test plan

- [x] `npx jest` — 123 suites, 1169 tests, all green
- [x] `npx tsc --noEmit` clean, `npx biome check src/ygopro` clean
- [x] The existing `it.each(MATCHMAKING_FORMATS)` wire-budget guards pick edison up automatically: 500 generated join strings per format, both single and MATCH, all within the 19-char ceiling
- [x] New coverage pins `ed` → MR1 + best-of-1 and `edm` → MR1 + best-of-3 through the real room factory

