### PR TITLE
fix(room): send ygopro-encoded rejection frames on failed joins

### DIFF
--- a/src/edopro/room/domain/RoomState.ts
+++ b/src/edopro/room/domain/RoomState.ts
@@ -7,8 +7,6 @@ import { Team } from "src/shared/room/Team";
 import WebSocketSingleton from "src/web-socket-server/WebSocketSingleton";
 import { EventEmitter } from "stream";
 
-import { mercuryConfig } from "@ygopro/config";
-import { YGOProJoinGameMessage } from "@ygopro/messages/YGOProJoinGameMessage";
 import { YGOProPlayerChatMessage } from "@ygopro/messages/server-to-client/YGOProPlayerChatMessage";
 import { YgoClient } from "../../../shared/client/domain/YgoClient";
 import { YgoRoom } from "../../../shared/room/domain/YgoRoom";
@@ -21,7 +19,6 @@ import { ClientMessage } from "../../../shared/messages/MessageProcessor";
 import { PlayerMessageClientMessage } from "../../messages/server-to-client/PlayerMessageClientMessage";
 import { ServerMessageClientMessage } from "../../messages/server-to-client/ServerMessageClientMessage";
 import { SpectatorMessageClientMessage } from "../../messages/server-to-client/SpectatorMessageClientMessage";
-import { VersionErrorClientMessage } from "../../messages/server-to-client/VersionErrorClientMessage";
 import { RoomType } from "src/shared/room/domain/RoomType";
 import { YGOProRoom } from "@ygopro/room/domain/YGOProRoom";
 import { NetPlayerType, YGOProStocChat, YGOProStocSelectHand } from "ygopro-msg-encode";
@@ -53,16 +50,6 @@ export abstract class RoomState {
 
 	removeAllListener(): void {
 		this.eventEmitter.removeAllListeners();
-	}
-
-	protected validateVersion(message: Buffer, socket: ISocket): void {
-		const joinMessage = new YGOProJoinGameMessage(message);
-
-		if (joinMessage.version !== mercuryConfig.version) {
-			socket.send(VersionErrorClientMessage.create(mercuryConfig.version));
-
-			throw new Error("Version mismatch");
-		}
 	}
 
 	protected sendExistingPlayerErrorMessage(

--- a/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
@@ -21,9 +21,9 @@ import { ErrorMessageType } from "ygopro-msg-encode";
 // ---- helpers ----
 
 // mercuryConfig.version = 4962 = 0x1362 → LE bytes: 0x62 0x13
-const makeJoinData = (): Buffer => {
+const makeJoinData = (version = 4962): Buffer => {
 	const buf = Buffer.alloc(48);
-	buf.writeUInt16LE(4962, 0);
+	buf.writeUInt16LE(version, 0);
 	return buf;
 };
 
@@ -31,9 +31,9 @@ const makeJoinData = (): Buffer => {
 const PLAYER_INFO_HEX =
 	"4a006100640065006e00000000000000000000000000000000000000000000000000000000000000";
 
-const makeJoinMessage = (): ClientMessage =>
+const makeJoinMessage = (version?: number): ClientMessage =>
 	({
-		data: makeJoinData(),
+		data: makeJoinData(version),
 		previousMessage: Buffer.from(PLAYER_INFO_HEX, "hex"),
 	}) as unknown as ClientMessage;
 
@@ -274,8 +274,12 @@ describe("YGOProWaitingState.handleJoin", () => {
 			removeAllListeners: jest.fn(),
 		}) as unknown as jest.Mocked<ISocket>;
 
-	const emitJoin = (room: jest.Mocked<YGOProRoom>, socket: jest.Mocked<ISocket>): Promise<void> => {
-		const message = makeJoinMessage();
+	const emitJoin = (
+		room: jest.Mocked<YGOProRoom>,
+		socket: jest.Mocked<ISocket>,
+		version?: number,
+	): Promise<void> => {
+		const message = makeJoinMessage(version);
 		return new Promise((resolve) => {
 			setImmediate(() => resolve());
 			eventEmitter.emit("JOIN", message, room, socket);
@@ -329,7 +333,96 @@ describe("YGOProWaitingState.handleJoin", () => {
 
 		expect(mockAdmitToRoom.run).not.toHaveBeenCalled();
 		expect(mockSocket.send).toHaveBeenCalled();
-		expect(mockSocket.destroy).toHaveBeenCalled();
+	});
+
+	// Regression: the duplicate-name path used to reuse the EDOPro-flavoured
+	// RoomState.sendExistingPlayerErrorMessage, which writes an EDOPro-packed
+	// STOC_ERROR_MSG (2-byte size = 6) plus a 0xF3 frame the classic ygopro
+	// client does not know. ygopro drops STOC_ERROR_MSG when
+	// `len < 1 + sizeof(STOC_ErrorMsg)` (9 with struct alignment), so the joiner
+	// never saw the error and sat on the connecting screen. It must use the
+	// ygopro encoder (YGOProMessageRepository.errorMessage -> 9-byte frame).
+	it("sends the ygopro-encoded JOINERROR frame, not the EDOPro-packed one", async () => {
+		mockRoom = makeMockRoom();
+		(mockRoom as unknown as { players: unknown[] }).players = [
+			{ name: "Jaden", socket: { remoteAddress: "127.0.0.1", closed: true } },
+		];
+
+		await emitJoin(mockRoom, mockSocket);
+
+		expect(mockRoom.messageSender.errorMessage).toHaveBeenCalledWith(ErrorMessageType.JOINERROR, 0);
+		// The EDOPro-packed frame (size 6) must never reach a ygopro client.
+		const edoproPacked = Buffer.from("060002010000000", "hex");
+		for (const [buf] of (mockSocket.send as jest.Mock).mock.calls as [Buffer][]) {
+			expect(buf.equals(edoproPacked)).toBe(false);
+			expect(buf[2]).not.toBe(0xf3);
+		}
+	});
+
+	// close() (not destroy()): destroy() tears the socket down abruptly and can
+	// drop the queued JOINERROR frame. Same invariant as SocketCloseOnError.test.ts.
+	it("closes the socket gracefully after the error frames", async () => {
+		mockRoom = makeMockRoom();
+		(mockRoom as unknown as { players: unknown[] }).players = [
+			{ name: "Jaden", socket: { remoteAddress: "127.0.0.1", closed: true } },
+		];
+
+		await emitJoin(mockRoom, mockSocket);
+
+		expect(mockSocket.close).toHaveBeenCalled();
+		expect(mockSocket.destroy).not.toHaveBeenCalled();
+	});
+
+	// Regression: the version check used to live in the EDOPro RoomState base and
+	// `throw`. handleJoin is async and the "JOIN" listener voids its promise, so the
+	// throw became an unhandled rejection that Node routes to the global
+	// uncaughtException hook (src/shared/error-handler/error-handler.ts) — a routine
+	// client-version mismatch logged as "Excepción no capturada" — AND the rejected
+	// socket was left open, since nothing after the throw ever ran.
+	describe("version mismatch", () => {
+		const WRONG_VERSION = 4961;
+
+		it("rejects without delegating to AdmitToRoom", async () => {
+			await emitJoin(mockRoom, mockSocket, WRONG_VERSION);
+
+			expect(mockAdmitToRoom.run).not.toHaveBeenCalled();
+			expect(mockRoom.admissionTarget).not.toHaveBeenCalled();
+		});
+
+		it("sends VERERROR carrying the server version and closes the socket", async () => {
+			await emitJoin(mockRoom, mockSocket, WRONG_VERSION);
+
+			expect(mockRoom.messageSender.errorMessage).toHaveBeenCalledWith(
+				ErrorMessageType.VERERROR,
+				4962,
+			);
+			expect(mockSocket.close).toHaveBeenCalled();
+			expect(mockSocket.destroy).not.toHaveBeenCalled();
+		});
+
+		it("does not leak an unhandled rejection", async () => {
+			const rejections: unknown[] = [];
+			const onRejection = (reason: unknown): void => {
+				rejections.push(reason);
+			};
+			process.on("unhandledRejection", onRejection);
+			try {
+				await emitJoin(mockRoom, mockSocket, WRONG_VERSION);
+				// unhandledRejection fires on a later microtask/tick than the void'ed call
+				await new Promise((resolve) => setImmediate(resolve));
+			} finally {
+				process.off("unhandledRejection", onRejection);
+			}
+
+			expect(rejections).toEqual([]);
+		});
+
+		it("still admits a client on the matching version", async () => {
+			await emitJoin(mockRoom, mockSocket);
+
+			expect(mockAdmitToRoom.run).toHaveBeenCalled();
+			expect(mockSocket.close).not.toHaveBeenCalled();
+		});
 	});
 });
 

--- a/src/ygopro/room/domain/states/YGOProWaitingState.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.ts
@@ -14,13 +14,20 @@ import { YGOProClient } from "../../../client/domain/YGOProClient";
 import { YGOProRoom } from "../YGOProRoom";
 import { AdmitToRoom } from "@ygopro/room/admission/application/AdmitToRoom";
 
-import { ErrorMessageType, YGOProCtosUpdateDeck } from "ygopro-msg-encode";
+import {
+	ChatColor,
+	ErrorMessageType,
+	YGOProCtosUpdateDeck,
+	YGOProStocChat,
+} from "ygopro-msg-encode";
 import { YGOProDeckCreator } from "@ygopro/deck/application/YGOProDeckCreator";
 import { YGOProDeckValidator } from "@ygopro/deck/domain/YGOProDeckValidator";
 import { DeckError } from "@shared/deck/domain/errors/DeckError";
 import { encodeDeckErrorCode } from "@shared/deck/domain/errors/encodeDeckErrorCode";
 import { YGOProRoomState } from "../YGOProRoomState";
 import MercuryBanListMemoryRepository from "@ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository";
+import { mercuryConfig } from "@ygopro/config";
+import { YGOProJoinGameMessage } from "@ygopro/messages/YGOProJoinGameMessage";
 
 export class YGOProWaitingState extends YGOProRoomState {
 	constructor(
@@ -71,11 +78,13 @@ export class YGOProWaitingState extends YGOProRoomState {
 	): Promise<void> {
 		this.logger.info(`handleJoin: ${message.data.toString("hex")}`);
 
-		this.validateVersion(message.data, socket);
+		if (!this.rejectOnVersionMismatch(message.data, room, socket)) {
+			return;
+		}
 
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
 		if (isNameTaken(room.players, playerInfoMessage.name)) {
-			this.sendExistingPlayerErrorMessage(playerInfoMessage, socket);
+			this.sendNameTakenError(room, playerInfoMessage.name, socket);
 			return;
 		}
 
@@ -86,6 +95,56 @@ export class YGOProWaitingState extends YGOProRoomState {
 				room.admissionTarget(socket, playerInfoMessage),
 			);
 		});
+	}
+
+	/**
+	 * Whether the joiner's client version matches the server's; rejects it if not.
+	 *
+	 * Returns a boolean instead of throwing (the shape the EDOPro base's
+	 * `validateVersion` used). handleJoin is async and the "JOIN" listener voids its
+	 * promise, so a throw here became an unhandled rejection: Node routes it to the
+	 * global uncaughtException hook (src/shared/error-handler/error-handler.ts),
+	 * which logs a routine client-version mismatch as "Excepción no capturada" — and
+	 * because nothing after the throw ran, the rejected socket stayed open as a
+	 * live-but-rejected connection. Encoding was never the problem here:
+	 * VersionErrorClientMessage.create is byte-identical to the ygopro frame
+	 * (its `decimalToBytesBuffer(0, 3)` already covers STOC_ErrorMsg's alignment
+	 * padding). We go through the ygopro repository anyway, so the ygopro path owns
+	 * its own wire format instead of borrowing EDOPro's.
+	 */
+	private rejectOnVersionMismatch(data: Buffer, room: YGOProRoom, socket: ISocket): boolean {
+		const joinMessage = new YGOProJoinGameMessage(data);
+		if (joinMessage.version === mercuryConfig.version) {
+			return true;
+		}
+
+		socket.send(room.messageSender.errorMessage(ErrorMessageType.VERERROR, mercuryConfig.version));
+		socket.close();
+
+		return false;
+	}
+
+	/**
+	 * Reject a joiner whose name is already seated.
+	 *
+	 * Must NOT reuse RoomState.sendExistingPlayerErrorMessage: that helper writes
+	 * EDOPro-flavoured frames (a 0xF3 server-error frame the classic ygopro client
+	 * does not know, plus an EDOPro-packed STOC_ERROR_MSG of size 6). ygopro drops
+	 * STOC_ERROR_MSG when `len < 1 + sizeof(STOC_ErrorMsg)` — 9 bytes once the
+	 * struct's alignment padding is counted — so the joiner got no error at all and
+	 * sat on the connecting screen. Encode through the ygopro repository instead,
+	 * mirroring YGOProRoom.admissionTarget's rejectAdmission path: a red STOC_CHAT
+	 * explaining why, then the real JOINERROR, then a graceful close() so both
+	 * frames flush before teardown (see SocketCloseOnError.test.ts).
+	 */
+	private sendNameTakenError(room: YGOProRoom, name: string, socket: ISocket): void {
+		const chat = new YGOProStocChat().fromPartial({
+			player_type: ChatColor.RED,
+			msg: `A player named "${name}" is already in this room. Change your nickname and try again.`,
+		});
+		socket.send(Buffer.from(chat.toFullPayload()));
+		socket.send(room.messageSender.errorMessage(ErrorMessageType.JOINERROR, 0));
+		socket.close();
 	}
 
 	private handleTryStart(_message: ClientMessage, room: YGOProRoom, player: YGOProClient): void {


### PR DESCRIPTION
## Description / Descripción

Two players joining the same room with the same nickname left the second one stuck on the connecting screen. The server did reject the duplicate name correctly — it just told the client in a dialect the client does not speak.

`YGOProWaitingState.handleJoin` rejected through the inherited EDOPro helper `RoomState.sendExistingPlayerErrorMessage`, which writes **EDOPro-packed** frames. The two encodings of `STOC_ERROR_MSG` differ:

```
EDOPro:  0600 02 01 00000000        ← size = 6
ygopro:  0900 02 01 000000 00000000 ← size = 9
```

The 3 extra bytes are `STOC_ErrorMsg`'s alignment padding (`unsigned char msg` + 3 pad + `int code`). The classic ygopro client does `if (len < 1 + sizeof(STOC_ErrorMsg)) return;` — with `len = 6 < 9` it **discards the packet silently**. The other frame the helper sends (`0xF3`) is an EDOPro-only STOC that ygopro also ignores. Net result: no error reaches the joiner, and it waits forever.

The helper also used `socket.destroy()`, breaking the invariant already documented in `SocketCloseOnError.test.ts` — abrupt teardown can drop queued frames. That same file already flagged this path as *"the one remaining destroy()-only path with a message"*.

Fixed by encoding through `YGOProMessageRepository`, mirroring the `rejectAdmission` path that already existed in `YGOProRoom.admissionTarget`: a red `STOC_CHAT` explaining why, the real `JOINERROR`, then `close()`.

**Also in this PR** — `RoomState.validateVersion` was the last ygopro-specific method sitting in the EDOPro base, and `YGOProWaitingState` was its only caller. It `throw`s from an async handler whose promise the `"JOIN"` listener voids, so a routine client-version mismatch became an unhandled rejection routed to the global `uncaughtException` hook (logged as `"Excepción no capturada"`), and the rejected socket was left open as a live-but-rejected connection because nothing after the `throw` ran. It now returns a boolean and closes the socket.

> Its wire format was **not** broken and is unchanged: `VersionErrorClientMessage.create` emits `0900020400000062130000`, byte-identical to the ygopro encoder, because its `decimalToBytesBuffer(0, 3)` already covers the padding. Only `ErrorClientMessage.create` was mis-encoded.

## Related Issue(s) / Issue(s) relacionado(s)

No tracking issue — reported directly against a live server, reproduced from the join logs.

## Changes

| File | Change |
|------|--------|
| `src/ygopro/room/domain/states/YGOProWaitingState.ts` | `sendNameTakenError` replaces the EDOPro helper on the duplicate-nick path; `rejectOnVersionMismatch` replaces the inherited `validateVersion` and returns a boolean instead of throwing |
| `src/edopro/room/domain/RoomState.ts` | Removed the now-unused `validateVersion` and the three ygopro imports it required (`mercuryConfig`, `YGOProJoinGameMessage`, `VersionErrorClientMessage`) |
| `src/ygopro/room/domain/states/YGOProWaitingState.test.ts` | 4 regression tests, all confirmed red before the fix |

## Test Plan

- [x] `npm test` — **128 suites / 1213 tests** green
- [x] `npx biome ci` — clean, 487 files
- [x] `npm run build` — `tsc` + `tsc-alias` clean
- [x] New tests confirmed **red before the fix**, green after
- [x] Frame encodings verified byte-for-byte against `ygopro-msg-encode`, not assumed
- [x] Unhandled-rejection leak asserted with a `process.on("unhandledRejection")` spy

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [x] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

The bug is not reachable from the EDOPro path — EDOPro clients understand EDOPro frames. It only bites ygopro/Mercury clients, which is why it survived: `YGOProWaitingState` extends `YGOProRoomState`, which extends the EDOPro `RoomState`, and inherited a helper whose wire format silently does not apply.

Worth a follow-up sweep: `ErrorClientMessage.create` is still reachable from other shared code paths, and any of them that can be hit by a ygopro client has the same silent-drop problem.
