### PR TITLE
feat(room): add shared duel-event vocabulary and wire decoders (duel-events 1/4)

### DIFF
--- a/src/edopro/room/domain/RoomState.ts
+++ b/src/edopro/room/domain/RoomState.ts
@@ -4,6 +4,13 @@ import { ErrorMessages } from "src/edopro/messages/server-to-client/error-messag
 import { ErrorClientMessage } from "src/edopro/messages/server-to-client/ErrorClientMessage";
 import { ServerErrorClientMessage } from "src/edopro/messages/server-to-client/ServerErrorMessageClientMessage";
 import { Team } from "src/shared/room/Team";
+import {
+	DuelEventContext,
+	decodeDamageDealt,
+	decodeLifeRecovered,
+	decodeLpCostPaid,
+	decodeTurnStarted,
+} from "src/shared/room/domain/duel-events/DuelEventDecoders";
 import WebSocketSingleton from "src/web-socket-server/WebSocketSingleton";
 import { EventEmitter } from "stream";
 
@@ -85,43 +92,45 @@ export abstract class RoomState {
 	}
 
 	protected processDuelMessage(messageType: CoreMessages, data: Buffer, room: YgoRoom): void {
+		// Wire decoding lives in the shared duel-event decoders — one per kind,
+		// shared with the ygopro pipeline. This method keeps only the room
+		// mutation + broadcast.
+		const ctx: DuelEventContext = {
+			roomId: room.id,
+			turn: room.turn,
+			resolveTeam: (player: number) => room.firstToPlay ^ player,
+		};
+
 		if (messageType === CoreMessages.MSG_DAMAGE) {
-			const team = room.firstToPlay ^ data.readUint8(1);
-			const damage = data.readUint32LE(2);
-			room.decreaseLps(team as Team, damage);
-			WebSocketSingleton.getInstance().broadcast({
-				action: "UPDATE-ROOM",
-				data: room.toRealTimePresentation(),
-			});
+			const event = decodeDamageDealt(data, ctx);
+			room.decreaseLps(event.team as Team, event.amount);
+			this.broadcastDuelRoomUpdate(room);
 		}
 
 		if (messageType === CoreMessages.MSG_RECOVER) {
-			const team = room.firstToPlay ^ data.readUint8(1);
-			const health = data.readUint32LE(2);
-			room.increaseLps(team as Team, health);
-			WebSocketSingleton.getInstance().broadcast({
-				action: "UPDATE-ROOM",
-				data: room.toRealTimePresentation(),
-			});
+			const event = decodeLifeRecovered(data, ctx);
+			room.increaseLps(event.team as Team, event.amount);
+			this.broadcastDuelRoomUpdate(room);
 		}
 
 		if (messageType === CoreMessages.MSG_PAY_LPCOST) {
-			const team = room.firstToPlay ^ data.readUint8(1);
-			const cost = data.readUint32LE(2);
-			room.decreaseLps(team as Team, cost);
-			WebSocketSingleton.getInstance().broadcast({
-				action: "UPDATE-ROOM",
-				data: room.toRealTimePresentation(),
-			});
+			const event = decodeLpCostPaid(data, ctx);
+			room.decreaseLps(event.team as Team, event.amount);
+			this.broadcastDuelRoomUpdate(room);
 		}
 
 		if (messageType === CoreMessages.MSG_NEW_TURN) {
+			decodeTurnStarted(data, ctx);
 			room.increaseTurn();
-			WebSocketSingleton.getInstance().broadcast({
-				action: "UPDATE-ROOM",
-				data: room.toRealTimePresentation(),
-			});
+			this.broadcastDuelRoomUpdate(room);
 		}
+	}
+
+	private broadcastDuelRoomUpdate(room: YgoRoom): void {
+		WebSocketSingleton.getInstance().broadcast({
+			action: "UPDATE-ROOM",
+			data: room.toRealTimePresentation(),
+		});
 	}
 
 	protected notifyDuelStart(room: YgoRoom): void {

--- a/src/edopro/room/domain/RoomStateProcessDuelMessage.test.ts
+++ b/src/edopro/room/domain/RoomStateProcessDuelMessage.test.ts
@@ -1,0 +1,120 @@
+/**
+ * RoomState.processDuelMessage behavior contract: team = firstToPlay ^ data[1],
+ * amount = data.readUint32LE(2), one UPDATE-ROOM broadcast per handled message,
+ * and unhandled message types touch nothing.
+ */
+import { EventEmitter } from "stream";
+
+import { CoreMessages } from "src/edopro/messages/domain/CoreMessages";
+
+jest.mock("../../../web-socket-server/WebSocketSingleton", () => {
+	const mockBroadcast = jest.fn();
+	return {
+		__esModule: true,
+		default: {
+			getInstance: () => ({ broadcast: mockBroadcast }),
+		},
+		mockBroadcast,
+	};
+});
+
+import { RoomState } from "./RoomState";
+import { YgoRoom } from "../../../shared/room/domain/YgoRoom";
+import WebSocketSingleton from "../../../web-socket-server/WebSocketSingleton";
+
+// jest.mock above is hoisted, so this import resolves to the mock; getInstance()
+// hands back the same broadcast spy the factory created.
+const mockBroadcast = WebSocketSingleton.getInstance().broadcast as jest.Mock;
+
+// processDuelMessage is protected; expose it for the test.
+class TestRoomState extends RoomState {
+	run(messageType: CoreMessages, data: Buffer, room: YgoRoom): void {
+		this.processDuelMessage(messageType, data, room);
+	}
+}
+
+// [type u8, player u8, amount u32le] — the layout both cores emit
+// (edo9300 operations.cpp:603/674/749, processor.cpp:3334; the classic
+// encoder produces identical bytes).
+const lpPayload = (type: number, player: number, amount: number): Buffer => {
+	const buf = Buffer.alloc(6);
+	buf.writeUint8(type, 0);
+	buf.writeUint8(player, 1);
+	buf.writeUint32LE(amount, 2);
+	return buf;
+};
+
+const makeRoom = (firstToPlay: number) =>
+	({
+		id: 7,
+		firstToPlay,
+		turn: 2,
+		decreaseLps: jest.fn(),
+		increaseLps: jest.fn(),
+		increaseTurn: jest.fn(),
+		toRealTimePresentation: jest.fn().mockReturnValue({ id: 7 }),
+	}) as unknown as YgoRoom;
+
+describe("RoomState.processDuelMessage", () => {
+	let state: TestRoomState;
+
+	beforeEach(() => {
+		mockBroadcast.mockClear();
+		state = new TestRoomState(new EventEmitter());
+	});
+
+	it("MSG_DAMAGE decreases the XOR-mapped team's LPs and broadcasts", () => {
+		const room = makeRoom(0);
+
+		state.run(CoreMessages.MSG_DAMAGE, lpPayload(CoreMessages.MSG_DAMAGE, 1, 1000), room);
+
+		expect(room.decreaseLps).toHaveBeenCalledWith(1, 1000);
+		expect(mockBroadcast).toHaveBeenCalledWith(expect.objectContaining({ action: "UPDATE-ROOM" }));
+	});
+
+	it("MSG_DAMAGE maps the team through firstToPlay (swapped first-to-play flips it)", () => {
+		const room = makeRoom(1);
+
+		state.run(CoreMessages.MSG_DAMAGE, lpPayload(CoreMessages.MSG_DAMAGE, 1, 1000), room);
+
+		expect(room.decreaseLps).toHaveBeenCalledWith(0, 1000);
+	});
+
+	it("MSG_RECOVER increases the XOR-mapped team's LPs and broadcasts", () => {
+		const room = makeRoom(0);
+
+		state.run(CoreMessages.MSG_RECOVER, lpPayload(CoreMessages.MSG_RECOVER, 0, 500), room);
+
+		expect(room.increaseLps).toHaveBeenCalledWith(0, 500);
+		expect(mockBroadcast).toHaveBeenCalledTimes(1);
+	});
+
+	it("MSG_PAY_LPCOST decreases the XOR-mapped team's LPs and broadcasts", () => {
+		const room = makeRoom(0);
+
+		state.run(CoreMessages.MSG_PAY_LPCOST, lpPayload(CoreMessages.MSG_PAY_LPCOST, 1, 800), room);
+
+		expect(room.decreaseLps).toHaveBeenCalledWith(1, 800);
+		expect(mockBroadcast).toHaveBeenCalledTimes(1);
+	});
+
+	it("MSG_NEW_TURN increases the turn and broadcasts", () => {
+		const room = makeRoom(0);
+
+		state.run(CoreMessages.MSG_NEW_TURN, Buffer.from([CoreMessages.MSG_NEW_TURN, 1]), room);
+
+		expect(room.increaseTurn).toHaveBeenCalledTimes(1);
+		expect(mockBroadcast).toHaveBeenCalledTimes(1);
+	});
+
+	it("does nothing for an unhandled message type", () => {
+		const room = makeRoom(0);
+
+		state.run(CoreMessages.MSG_DRAW, Buffer.from([CoreMessages.MSG_DRAW]), room);
+
+		expect(room.decreaseLps).not.toHaveBeenCalled();
+		expect(room.increaseLps).not.toHaveBeenCalled();
+		expect(room.increaseTurn).not.toHaveBeenCalled();
+		expect(mockBroadcast).not.toHaveBeenCalled();
+	});
+});

--- a/src/shared/room/domain/duel-events/DuelEventDecoders.test.ts
+++ b/src/shared/room/domain/duel-events/DuelEventDecoders.test.ts
@@ -1,0 +1,149 @@
+/**
+ * One decoder per DuelEventKind, shared by both pipelines.
+ *
+ * The wire layout under test holds for BOTH producers:
+ *  - classic core: payloads below are generated with ygopro-msg-encode, the same
+ *    encoder this server ships in production for the ygopro pipeline.
+ *  - EDOPro core: emission sites in edo9300/ygopro-core write the identical
+ *    layout — operations.cpp:603 (MSG_DAMAGE), :674 (MSG_RECOVER),
+ *    :749 (MSG_PAY_LPCOST): write<uint8_t>(playerid); write<uint32_t>(amount);
+ *    processor.cpp:3334 (MSG_NEW_TURN): write<uint8_t>(turn_player).
+ */
+import {
+	YGOProMsgDamage,
+	YGOProMsgNewTurn,
+	YGOProMsgPayLpCost,
+	YGOProMsgRecover,
+} from "ygopro-msg-encode";
+
+import {
+	buildDamageDealt,
+	buildLifeRecovered,
+	buildLpCostPaid,
+	buildTurnStarted,
+	decodeDamageDealt,
+	decodeLifeRecovered,
+	decodeLpCostPaid,
+	decodeTurnStarted,
+	DuelEventContext,
+} from "./DuelEventDecoders";
+import { DUEL_EVENT_KINDS } from "./DuelEvents";
+
+// EDOPro rooms resolve team as firstToPlay ^ player; ygopro rooms pass their
+// own resolveTeam. The decoders must stay pipeline-agnostic: the mapping is
+// injected, never assumed.
+const xorCtx = (firstToPlay: number): DuelEventContext => ({
+	roomId: 42,
+	turn: 3,
+	resolveTeam: (player: number) => firstToPlay ^ player,
+});
+
+const wire = {
+	damage: (player: number, amount: number): Buffer =>
+		Buffer.from(new YGOProMsgDamage().fromPartial({ player, value: amount }).toPayload()),
+	recover: (player: number, amount: number): Buffer =>
+		Buffer.from(new YGOProMsgRecover().fromPartial({ player, value: amount }).toPayload()),
+	lpCost: (player: number, cost: number): Buffer =>
+		Buffer.from(new YGOProMsgPayLpCost().fromPartial({ player, cost }).toPayload()),
+	newTurn: (player: number): Buffer =>
+		Buffer.from(new YGOProMsgNewTurn().fromPartial({ player }).toPayload()),
+};
+
+describe("DuelEvents vocabulary", () => {
+	it("names exactly the four duel-event kinds", () => {
+		expect(DUEL_EVENT_KINDS).toEqual([
+			"duel.damage",
+			"duel.recover",
+			"duel.lp-cost",
+			"duel.turn-start",
+		]);
+	});
+});
+
+describe("decodeDamageDealt", () => {
+	it("decodes a classic-encoded MSG_DAMAGE payload", () => {
+		// [0x5b, 0x01, e8 03 00 00] — player 1 takes 1000
+		const event = decodeDamageDealt(wire.damage(1, 1000), xorCtx(0));
+
+		expect(event).toEqual({ roomId: 42, team: 1, amount: 1000, turn: 3 });
+	});
+
+	it("applies the injected team mapping (firstToPlay = 1 flips the team)", () => {
+		const event = decodeDamageDealt(wire.damage(1, 1000), xorCtx(1));
+
+		expect(event.team).toBe(0);
+	});
+
+	it("rejects a buffer whose type byte is not MSG_DAMAGE", () => {
+		expect(() => decodeDamageDealt(wire.recover(0, 500), xorCtx(0))).toThrow(/91/);
+	});
+});
+
+describe("decodeLifeRecovered", () => {
+	it("decodes a classic-encoded MSG_RECOVER payload", () => {
+		const event = decodeLifeRecovered(wire.recover(0, 500), xorCtx(0));
+
+		expect(event).toEqual({ roomId: 42, team: 0, amount: 500, turn: 3 });
+	});
+
+	it("rejects a mismatched type byte", () => {
+		expect(() => decodeLifeRecovered(wire.damage(0, 500), xorCtx(0))).toThrow(/92/);
+	});
+});
+
+describe("decodeLpCostPaid", () => {
+	it("decodes a classic-encoded MSG_PAY_LPCOST payload", () => {
+		const event = decodeLpCostPaid(wire.lpCost(1, 800), xorCtx(0));
+
+		expect(event).toEqual({ roomId: 42, team: 1, amount: 800, turn: 3 });
+	});
+
+	it("rejects a mismatched type byte", () => {
+		expect(() => decodeLpCostPaid(wire.newTurn(0), xorCtx(0))).toThrow(/100/);
+	});
+});
+
+describe("decodeTurnStarted", () => {
+	it("decodes a classic-encoded MSG_NEW_TURN payload, keeping the raw turn player", () => {
+		// Both cores emit exactly one NEW_TURN per turn; player is the core turn
+		// player (0/1), never a tag partner code. Kept raw: turn-player team
+		// resolution differs per pipeline and is not this event's business.
+		const event = decodeTurnStarted(wire.newTurn(1), xorCtx(0));
+
+		expect(event).toEqual({ roomId: 42, player: 1, turn: 3 });
+	});
+
+	it("rejects a mismatched type byte", () => {
+		expect(() => decodeTurnStarted(wire.damage(0, 100), xorCtx(0))).toThrow(/40/);
+	});
+});
+
+describe("cross-pipeline equivalence (build* from typed fields === decode* from wire)", () => {
+	// The ygopro pipeline receives already-decoded messages (msg.player,
+	// msg.value); it calls build* with those fields. The EDOPro pipeline calls
+	// decode* with the raw buffer. Same logical event MUST produce the same
+	// object — this is what makes consumer data comparable across room types.
+	const ctx = xorCtx(0);
+
+	it("damage", () => {
+		expect(buildDamageDealt({ player: 1, amount: 1000 }, ctx)).toEqual(
+			decodeDamageDealt(wire.damage(1, 1000), ctx),
+		);
+	});
+
+	it("recover", () => {
+		expect(buildLifeRecovered({ player: 0, amount: 500 }, ctx)).toEqual(
+			decodeLifeRecovered(wire.recover(0, 500), ctx),
+		);
+	});
+
+	it("lp cost", () => {
+		expect(buildLpCostPaid({ player: 1, amount: 800 }, ctx)).toEqual(
+			decodeLpCostPaid(wire.lpCost(1, 800), ctx),
+		);
+	});
+
+	it("turn start", () => {
+		expect(buildTurnStarted({ player: 1 }, ctx)).toEqual(decodeTurnStarted(wire.newTurn(1), ctx));
+	});
+});

--- a/src/shared/room/domain/duel-events/DuelEventDecoders.ts
+++ b/src/shared/room/domain/duel-events/DuelEventDecoders.ts
@@ -1,0 +1,95 @@
+/**
+ * Wire decoders and event builders for the duel-event vocabulary.
+ *
+ * One decoder per DuelEventKind, shared by both pipelines:
+ *  - The EDOPro pipeline calls decode*(buffer, ctx) with the raw core message
+ *    (layout [type u8, player u8, amount u32le] — verified at the emission
+ *    sites in edo9300/ygopro-core operations.cpp:603/674/749 and
+ *    processor.cpp:3334, and byte-identical to ygopro-msg-encode's classic
+ *    payloads).
+ *  - The ygopro pipeline receives already-typed messages and calls
+ *    build*({player, amount}, ctx) with their fields.
+ *
+ * Both paths MUST produce the same object for the same logical event — that
+ * equivalence is what makes consumer data comparable across room types.
+ *
+ * Team resolution is injected via ctx.resolveTeam, never assumed: EDOPro rooms
+ * map firstToPlay ^ player, ygopro rooms use their own resolveTeam.
+ */
+import {
+	DamageDealtEvent,
+	LifeRecoveredEvent,
+	LpCostPaidEvent,
+	TurnStartedEvent,
+} from "./DuelEvents";
+
+export interface DuelEventContext {
+	readonly roomId: number;
+	readonly turn: number;
+	readonly resolveTeam: (player: number) => number;
+}
+
+const MSG_NEW_TURN = 40;
+const MSG_DAMAGE = 91;
+const MSG_RECOVER = 92;
+const MSG_PAY_LPCOST = 100;
+
+function assertType(data: Buffer, expected: number): void {
+	const actual = data.readUint8(0);
+	if (actual !== expected) {
+		throw new Error(`Expected core message type ${expected}, got ${actual}`);
+	}
+}
+
+interface LpWire {
+	readonly player: number;
+	readonly amount: number;
+}
+
+function readLpWire(data: Buffer): LpWire {
+	return { player: data.readUint8(1), amount: data.readUint32LE(2) };
+}
+
+export function buildDamageDealt(wire: LpWire, ctx: DuelEventContext): DamageDealtEvent {
+	return {
+		roomId: ctx.roomId,
+		team: ctx.resolveTeam(wire.player),
+		amount: wire.amount,
+		turn: ctx.turn,
+	};
+}
+
+export function buildLifeRecovered(wire: LpWire, ctx: DuelEventContext): LifeRecoveredEvent {
+	return buildDamageDealt(wire, ctx);
+}
+
+export function buildLpCostPaid(wire: LpWire, ctx: DuelEventContext): LpCostPaidEvent {
+	return buildDamageDealt(wire, ctx);
+}
+
+export function buildTurnStarted(
+	wire: { readonly player: number },
+	ctx: DuelEventContext,
+): TurnStartedEvent {
+	return { roomId: ctx.roomId, player: wire.player, turn: ctx.turn };
+}
+
+export function decodeDamageDealt(data: Buffer, ctx: DuelEventContext): DamageDealtEvent {
+	assertType(data, MSG_DAMAGE);
+	return buildDamageDealt(readLpWire(data), ctx);
+}
+
+export function decodeLifeRecovered(data: Buffer, ctx: DuelEventContext): LifeRecoveredEvent {
+	assertType(data, MSG_RECOVER);
+	return buildLifeRecovered(readLpWire(data), ctx);
+}
+
+export function decodeLpCostPaid(data: Buffer, ctx: DuelEventContext): LpCostPaidEvent {
+	assertType(data, MSG_PAY_LPCOST);
+	return buildLpCostPaid(readLpWire(data), ctx);
+}
+
+export function decodeTurnStarted(data: Buffer, ctx: DuelEventContext): TurnStartedEvent {
+	assertType(data, MSG_NEW_TURN);
+	return buildTurnStarted({ player: data.readUint8(1) }, ctx);
+}

--- a/src/shared/room/domain/duel-events/DuelEvents.ts
+++ b/src/shared/room/domain/duel-events/DuelEvents.ts
@@ -1,0 +1,54 @@
+/**
+ * Duel-event vocabulary. These are the only duel facts the surface names;
+ * consumers receive the payload types below — decoded domain data, never wire
+ * buffers.
+ *
+ * duel.duelist-changed is deliberately absent: duelist rotation is core-driven
+ * on the EDOPro pipeline (MSG_TAG_SWAP) but server-computed on the ygopro one,
+ * so it is not the same fact on both pipelines.
+ */
+export const DUEL_EVENT_KINDS = [
+	"duel.damage",
+	"duel.recover",
+	"duel.lp-cost",
+	"duel.turn-start",
+] as const;
+
+export type DuelEventKind = (typeof DUEL_EVENT_KINDS)[number];
+
+/** A player's team took battle or effect damage. */
+export interface DamageDealtEvent {
+	readonly roomId: number;
+	readonly team: number;
+	readonly amount: number;
+	readonly turn: number;
+}
+
+/** A player's team recovered life points. */
+export interface LifeRecoveredEvent {
+	readonly roomId: number;
+	readonly team: number;
+	readonly amount: number;
+	readonly turn: number;
+}
+
+/** A player's team paid life points as a cost. */
+export interface LpCostPaidEvent {
+	readonly roomId: number;
+	readonly team: number;
+	readonly amount: number;
+	readonly turn: number;
+}
+
+/**
+ * A new turn began. `player` is the core turn player (0/1) exactly as emitted —
+ * both cores emit exactly one MSG_NEW_TURN per turn with this byte, in single,
+ * match and tag (edo9300/ygopro-core processor.cpp:3334 is the single emission
+ * site). It is kept raw because turn-player team resolution differs per
+ * pipeline and is not this event's business.
+ */
+export interface TurnStartedEvent {
+	readonly roomId: number;
+	readonly player: number;
+	readonly turn: number;
+}

--- a/src/utils/perf/benchmark-duel-events.ts
+++ b/src/utils/perf/benchmark-duel-events.ts
@@ -1,0 +1,150 @@
+/**
+ * Measures the per-message cost of publishing duel messages as domain events,
+ * against the inline switch in processDuelMessage.
+ *
+ * Scenarios, cheapest to most expensive:
+ *   1. inline_switch          — today's baseline: offset reads + LP arithmetic
+ *   2. decode_to_domain_event — building {roomId, team, amount, turn} from the Buffer
+ *   3. publish_no_subscribers — EventBus.publish floor when nothing subscribed
+ *   4. decode_publish_1_sub   — decode + awaited publish, one no-op subscriber
+ *   5. decode_publish_3_subs  — decode + awaited publish, three no-op subscribers
+ *   6. decode_room_queue      — decode + per-room queue, drained outside the
+ *                               loop in insertion order
+ *
+ * Run: npx ts-node -r tsconfig-paths/register src/utils/perf/benchmark-duel-events.ts
+ */
+import { EventBus } from "@shared/event-bus/EventBus";
+import { LoggerMock } from "@test-support/mocks/logger/LoggerMock";
+
+const iterations = Number(process.env.BENCH_ITERATIONS ?? 100_000);
+
+// MSG_DAMAGE payload as processDuelMessage reads it: [type, player, lp x4]
+const damageBuffer = Buffer.from([0x5b, 0x01, 0xe8, 0x03, 0x00, 0x00]);
+
+interface DamageDealtEvent {
+	roomId: number;
+	team: number;
+	amount: number;
+	turn: number;
+}
+
+const fakeRoom = { firstToPlay: 0, lps: [8000, 8000], turn: 3, id: 42 };
+
+const decode = (data: Buffer): DamageDealtEvent => ({
+	roomId: fakeRoom.id,
+	team: fakeRoom.firstToPlay ^ data.readUint8(1),
+	amount: data.readUint32LE(2),
+	turn: fakeRoom.turn,
+});
+
+const measure = async (name: string, fn: () => Promise<void> | void) => {
+	const started = process.hrtime.bigint();
+	await fn();
+	const elapsed = process.hrtime.bigint() - started;
+	return {
+		name,
+		elapsedMs: Number(elapsed) / 1e6,
+		nsPerMessage: Number(elapsed) / iterations,
+		opsPerSec: iterations / (Number(elapsed) / 1e9),
+	};
+};
+
+async function main(): Promise<void> {
+	let sink = 0;
+
+	const inlineSwitch = await measure("inline_switch", () => {
+		for (let i = 0; i < iterations; i += 1) {
+			const team = fakeRoom.firstToPlay ^ damageBuffer.readUint8(1);
+			const damage = damageBuffer.readUint32LE(2);
+			fakeRoom.lps[team] -= damage;
+			sink += fakeRoom.lps[team];
+			fakeRoom.lps[team] += damage; // restore so numbers stay realistic
+		}
+	});
+
+	const decodeOnly = await measure("decode_to_domain_event", () => {
+		for (let i = 0; i < iterations; i += 1) {
+			sink += decode(damageBuffer).amount;
+		}
+	});
+
+	const emptyBus = new EventBus(new LoggerMock());
+	const publishNoSubs = await measure("publish_no_subscribers", async () => {
+		for (let i = 0; i < iterations; i += 1) {
+			await emptyBus.publish("duel.damage", decode(damageBuffer));
+		}
+	});
+
+	const makeBusWith = (count: number): EventBus => {
+		const bus = new EventBus(new LoggerMock());
+		for (let s = 0; s < count; s += 1) {
+			bus.subscribe("duel.damage", {
+				handle: (event) => {
+					sink += (event as DamageDealtEvent).amount;
+				},
+			});
+		}
+		return bus;
+	};
+
+	const oneSubBus = makeBusWith(1);
+	const publishOneSub = await measure("decode_publish_1_sub", async () => {
+		for (let i = 0; i < iterations; i += 1) {
+			await oneSubBus.publish("duel.damage", decode(damageBuffer));
+		}
+	});
+
+	const threeSubBus = makeBusWith(3);
+	const publishThreeSubs = await measure("decode_publish_3_subs", async () => {
+		for (let i = 0; i < iterations; i += 1) {
+			await threeSubBus.publish("duel.damage", decode(damageBuffer));
+		}
+	});
+
+	// Proposed design: the hot loop only decodes and pushes; a single drain
+	// outside the loop delivers to handlers in order.
+	const handler = (event: DamageDealtEvent): void => {
+		sink += event.amount;
+	};
+	const roomQueue: DamageDealtEvent[] = [];
+	const decodeRoomQueue = await measure("decode_room_queue", async () => {
+		for (let i = 0; i < iterations; i += 1) {
+			roomQueue.push(decode(damageBuffer));
+			if (roomQueue.length >= 1000) {
+				await Promise.resolve(); // yield, as the real drain would
+				for (const event of roomQueue) {
+					handler(event);
+				}
+				roomQueue.length = 0;
+			}
+		}
+		for (const event of roomQueue) {
+			handler(event);
+		}
+		roomQueue.length = 0;
+	});
+
+	if (sink === Number.MIN_SAFE_INTEGER) {
+		throw new Error("sink escaped"); // keep the JIT honest
+	}
+
+	process.stdout.write(
+		`${JSON.stringify(
+			{
+				iterations,
+				results: [
+					inlineSwitch,
+					decodeOnly,
+					publishNoSubs,
+					publishOneSub,
+					publishThreeSubs,
+					decodeRoomQueue,
+				],
+			},
+			null,
+			2,
+		)}\n`,
+	);
+}
+
+void main();


### PR DESCRIPTION
## Description / Descripción

Phase 1 of the duel-event plugin surface (**duel-events 1/4**): the plugin system activated in plugin-system 1/4–4/4 can only observe `GAME_OVER`; this series opens the duel itself — damage, life points, turns — as decoded, opt-in, observe-only events. This first slice ships the shared vocabulary and wire decoders, and makes the EDOPro pipeline consume them. Nothing publishes to plugins yet.

**New module `src/shared/room/domain/duel-events/`:**

- `DuelEvents.ts` — `DUEL_EVENT_KINDS` (`duel.damage`, `duel.recover`, `duel.lp-cost`, `duel.turn-start`) plus the four typed payloads. `duel.duelist-changed` is deliberately absent: duelist rotation is core-driven on EDOPro (`MSG_TAG_SWAP`) but server-computed on ygopro (srvpro2 formulas), so it is not the same fact on both pipelines.
- `DuelEventDecoders.ts` — one decoder per kind, shared by both pipelines: `decode*(buffer, ctx)` for the EDOPro buffer path (validates the type byte, throws on mismatch) and `build*(fields, ctx)` for the ygopro already-typed path. Team resolution is injected via `ctx.resolveTeam`, never assumed.

**`RoomState.processDuelMessage`** swaps its inline offset math for the decoders — identical behavior, wire decoding in one place. The triplicated WebSocket broadcast is extracted as `broadcastDuelRoomUpdate` (named to avoid colliding with `YGOProDuelingState`'s existing private `broadcastRoomUpdate`).

### Wire layout, verified on both producers

`[type u8, player u8, amount u32le]`, cross-checked against:

- **classic**: payloads generated by `ygopro-msg-encode`, the encoder this server ships in production (`5b01e8030000` = MSG_DAMAGE player 1, 1000);
- **EDOPro core**: emission sites in edo9300/ygopro-core — `operations.cpp:603/674/749` (`write<uint8_t>(playerid); write<uint32_t>(amount)`), `processor.cpp:3334` (MSG_NEW_TURN, `turn_player`).

Both cores emit exactly one `MSG_NEW_TURN` per turn with `player` ∈ {0,1} in single, match and tag (verified against executed replay snapshots and core source — see the proposal's *Verified* section).

### TDD sequence

1. 14 decoder tests written first → red (module didn't exist) → implementation → green.
2. 6 characterization tests for `processDuelMessage` written **before** the refactor, green against the old code → swap → still green. Same behavior, proven rather than assumed.
3. Cross-pipeline equivalence block: `build*` from typed fields ≡ `decode*` from the buffer for the same logical event — the guarantee that plugin data will be comparable across EDOPro and ygopro rooms.

Also includes `src/utils/perf/benchmark-duel-events.ts`, the measurement backing the design: decode + per-room queue costs 18 ns/msg — identical to the inline switch it replaces (1M iterations, ±2% across runs).

## Related Issue(s) / Issue(s) relacionado(s)

No tracking issue — implements phase 1 of the "Duel messages for plugins" technical proposal (reviewed in-session; measured and verified basis documented there).

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [x] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

- Full suite: **133 suites / 1244 tests** green; `tsc --noEmit` and `biome ci` clean.
- Next slices: **2/4** moves the four handlers onto the EventBus as internal subscribers (gate: byte-identical LP totals, turn counts and UPDATE-ROOM broadcasts); **3/4** adds the `duelEvents` opt-in field and the bounded per-room queue (1000-event cap + ~10 ms handle budget, both feeding one disconnect-with-loud-error consequence); **4/4** ships the first consumer plugin.
- The benchmark file documents its own run command (standalone `ts-node` is not installed; it runs via `ts-node-dev`'s nested `ts-node` in transpile-only mode).
