### PR TITLE
feat(room): dispatch duel events to synchronous internal subscribers (duel-events 2/4)

### DIFF
--- a/src/edopro/room/domain/RoomState.ts
+++ b/src/edopro/room/domain/RoomState.ts
@@ -11,6 +11,7 @@ import {
 	decodeLpCostPaid,
 	decodeTurnStarted,
 } from "src/shared/room/domain/duel-events/DuelEventDecoders";
+import { DuelEventDispatcher } from "src/shared/room/domain/duel-events/DuelEventDispatcher";
 import WebSocketSingleton from "src/web-socket-server/WebSocketSingleton";
 import { EventEmitter } from "stream";
 
@@ -38,9 +39,11 @@ import {
 
 export abstract class RoomState {
 	protected readonly eventEmitter: EventEmitter;
+	protected readonly duelEvents = new DuelEventDispatcher();
 
 	constructor(eventEmitter: EventEmitter) {
 		this.eventEmitter = eventEmitter;
+		this.registerDuelEventSubscribers();
 
 		this.eventEmitter.on(
 			Commands.CHAT as unknown as string,
@@ -92,9 +95,9 @@ export abstract class RoomState {
 	}
 
 	protected processDuelMessage(messageType: CoreMessages, data: Buffer, room: YgoRoom): void {
-		// Wire decoding lives in the shared duel-event decoders — one per kind,
-		// shared with the ygopro pipeline. This method keeps only the room
-		// mutation + broadcast.
+		// Decode the core message into a duel event and hand it to the
+		// synchronous dispatcher; the room mutation and broadcast live in the
+		// subscribers registered by registerDuelEventSubscribers.
 		const ctx: DuelEventContext = {
 			roomId: room.id,
 			turn: room.turn,
@@ -102,28 +105,42 @@ export abstract class RoomState {
 		};
 
 		if (messageType === CoreMessages.MSG_DAMAGE) {
-			const event = decodeDamageDealt(data, ctx);
-			room.decreaseLps(event.team as Team, event.amount);
-			this.broadcastDuelRoomUpdate(room);
+			this.duelEvents.dispatch("duel.damage", decodeDamageDealt(data, ctx), room);
 		}
 
 		if (messageType === CoreMessages.MSG_RECOVER) {
-			const event = decodeLifeRecovered(data, ctx);
-			room.increaseLps(event.team as Team, event.amount);
-			this.broadcastDuelRoomUpdate(room);
+			this.duelEvents.dispatch("duel.recover", decodeLifeRecovered(data, ctx), room);
 		}
 
 		if (messageType === CoreMessages.MSG_PAY_LPCOST) {
-			const event = decodeLpCostPaid(data, ctx);
-			room.decreaseLps(event.team as Team, event.amount);
-			this.broadcastDuelRoomUpdate(room);
+			this.duelEvents.dispatch("duel.lp-cost", decodeLpCostPaid(data, ctx), room);
 		}
 
 		if (messageType === CoreMessages.MSG_NEW_TURN) {
-			decodeTurnStarted(data, ctx);
+			this.duelEvents.dispatch("duel.turn-start", decodeTurnStarted(data, ctx), room);
+		}
+	}
+
+	private registerDuelEventSubscribers(): void {
+		this.duelEvents.subscribe("duel.damage", (event, room) => {
+			room.decreaseLps(event.team as Team, event.amount);
+			this.broadcastDuelRoomUpdate(room);
+		});
+
+		this.duelEvents.subscribe("duel.recover", (event, room) => {
+			room.increaseLps(event.team as Team, event.amount);
+			this.broadcastDuelRoomUpdate(room);
+		});
+
+		this.duelEvents.subscribe("duel.lp-cost", (event, room) => {
+			room.decreaseLps(event.team as Team, event.amount);
+			this.broadcastDuelRoomUpdate(room);
+		});
+
+		this.duelEvents.subscribe("duel.turn-start", (_event, room) => {
 			room.increaseTurn();
 			this.broadcastDuelRoomUpdate(room);
-		}
+		});
 	}
 
 	private broadcastDuelRoomUpdate(room: YgoRoom): void {

--- a/src/shared/room/domain/duel-events/DuelEventDispatcher.test.ts
+++ b/src/shared/room/domain/duel-events/DuelEventDispatcher.test.ts
@@ -1,0 +1,71 @@
+import { YgoRoom } from "../YgoRoom";
+import { DuelEventDispatcher } from "./DuelEventDispatcher";
+import { DamageDealtEvent, TurnStartedEvent } from "./DuelEvents";
+
+const damage: DamageDealtEvent = { roomId: 7, team: 1, amount: 1000, turn: 2 };
+const turnStart: TurnStartedEvent = { roomId: 7, player: 0, turn: 3 };
+const room = { id: 7 } as unknown as YgoRoom;
+
+describe("DuelEventDispatcher", () => {
+	let dispatcher: DuelEventDispatcher;
+
+	beforeEach(() => {
+		dispatcher = new DuelEventDispatcher();
+	});
+
+	it("delivers the event and room to a subscriber of that kind", () => {
+		const handler = jest.fn();
+		dispatcher.subscribe("duel.damage", handler);
+
+		dispatcher.dispatch("duel.damage", damage, room);
+
+		expect(handler).toHaveBeenCalledWith(damage, room);
+	});
+
+	it("does not deliver to subscribers of other kinds", () => {
+		const handler = jest.fn();
+		dispatcher.subscribe("duel.turn-start", handler);
+
+		dispatcher.dispatch("duel.damage", damage, room);
+
+		expect(handler).not.toHaveBeenCalled();
+	});
+
+	it("delivers to multiple subscribers in subscription order", () => {
+		const calls: string[] = [];
+		dispatcher.subscribe("duel.damage", () => calls.push("first"));
+		dispatcher.subscribe("duel.damage", () => calls.push("second"));
+
+		dispatcher.dispatch("duel.damage", damage, room);
+
+		expect(calls).toEqual(["first", "second"]);
+	});
+
+	// Dispatch is synchronous: room mutations must land before the message loop
+	// touches the next core message, or later messages in the same batch read
+	// stale LP/turn state.
+	it("runs subscribers synchronously, before dispatch returns", () => {
+		let ran = false;
+		dispatcher.subscribe("duel.turn-start", () => {
+			ran = true;
+		});
+
+		dispatcher.dispatch("duel.turn-start", turnStart, room);
+
+		expect(ran).toBe(true);
+	});
+
+	// Internal subscribers are first-party code: an error propagates exactly as
+	// it did when the same logic ran inline in processDuelMessage.
+	it("propagates a subscriber's error to the dispatch caller", () => {
+		dispatcher.subscribe("duel.damage", () => {
+			throw new Error("boom");
+		});
+
+		expect(() => dispatcher.dispatch("duel.damage", damage, room)).toThrow("boom");
+	});
+
+	it("dispatching a kind with no subscribers is a no-op", () => {
+		expect(() => dispatcher.dispatch("duel.recover", damage, room)).not.toThrow();
+	});
+});

--- a/src/shared/room/domain/duel-events/DuelEventDispatcher.ts
+++ b/src/shared/room/domain/duel-events/DuelEventDispatcher.ts
@@ -1,0 +1,51 @@
+/**
+ * Synchronous, ordered dispatch of duel events to internal subscribers.
+ *
+ * Deliberately NOT the async EventBus: room mutations (LPs, turn) must land
+ * before the message loop touches the next core message — an async publish
+ * would defer them to microtasks and later messages in the same batch would
+ * read stale room state. Subscribers here are first-party code, so errors
+ * propagate to the caller instead of being swallowed.
+ */
+import { YgoRoom } from "../YgoRoom";
+
+import {
+	DamageDealtEvent,
+	DuelEventKind,
+	LifeRecoveredEvent,
+	LpCostPaidEvent,
+	TurnStartedEvent,
+} from "./DuelEvents";
+
+export interface DuelEventPayloads {
+	"duel.damage": DamageDealtEvent;
+	"duel.recover": LifeRecoveredEvent;
+	"duel.lp-cost": LpCostPaidEvent;
+	"duel.turn-start": TurnStartedEvent;
+}
+
+export type DuelEventHandler<K extends DuelEventKind> = (
+	event: DuelEventPayloads[K],
+	room: YgoRoom,
+) => void;
+
+export class DuelEventDispatcher {
+	private readonly handlers = new Map<DuelEventKind, Array<DuelEventHandler<DuelEventKind>>>();
+
+	subscribe<K extends DuelEventKind>(kind: K, handler: DuelEventHandler<K>): void {
+		const existing = this.handlers.get(kind) ?? [];
+		existing.push(handler as DuelEventHandler<DuelEventKind>);
+		this.handlers.set(kind, existing);
+	}
+
+	dispatch<K extends DuelEventKind>(kind: K, event: DuelEventPayloads[K], room: YgoRoom): void {
+		const handlers = this.handlers.get(kind);
+		if (!handlers) {
+			return;
+		}
+
+		for (const handler of handlers) {
+			handler(event, room);
+		}
+	}
+}


### PR DESCRIPTION
## Description / Descripción

**duel-events 2/4** — the four duel-message handlers become subscribers, and `processDuelMessage` shrinks to decode + dispatch.

New `DuelEventDispatcher` in `src/shared/room/domain/duel-events/`: synchronous, ordered delivery of duel events to internal subscribers. This is **deliberately not the async `EventBus`**, and the reason is the gate of this slice (byte-identical behavior): `EventBus.publish` awaits `Promise.allSettled` over subscribers, so wiring LP/turn mutations through it would defer them to microtasks — and since the duel loop drains up to `MAX_MESSAGES_PER_TICK = 1000` messages synchronously, every later message in the same batch would read stale room state (`room.turn` feeds the decode context; LPs feed the real-time presentation). Synchronous dispatch preserves the exact ordering the inline code had. Subscribers are first-party code, so errors propagate exactly as they did when the same logic ran inline.

`RoomState` registers the four subscribers in its constructor (`registerDuelEventSubscribers`): `duel.damage` → `decreaseLps` + broadcast, `duel.recover` → `increaseLps` + broadcast, `duel.lp-cost` → `decreaseLps` + broadcast, `duel.turn-start` → `increaseTurn` + broadcast.

### Gate: identical behavior, proven

The 6 characterization tests from duel-events 1/4 (`RoomStateProcessDuelMessage.test.ts`) pin team mapping (`firstToPlay ^ player`), amounts, turn increments and one UPDATE-ROOM broadcast per handled message. **They were not touched by this change** and stay green — same expectations, before and after the handlers moved.

New dispatcher unit tests (6): delivery by kind, subscription order, synchronous execution before `dispatch` returns, error propagation, no-op on unsubscribed kinds.

## Related Issue(s) / Issue(s) relacionado(s)

Continues #329 (duel-events 1/4).

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [x] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

- Full suite: **134 suites / 1250 tests** green; `tsc --noEmit` and `biome ci` clean.
- Next: **3/4** adds the `duelEvents` opt-in declaration on `ServerPlugin` and the bounded per-room queue bridging this dispatcher to plugin subscribers (1000-event cap + ~10 ms handle budget → disconnect with loud error); **4/4** ships the first consumer plugin.
