### PR TITLE
feat(plugins): bridge duel events to plugins via bounded per-room queues (duel-events 3/4)

### DIFF
--- a/src/bootstrap/bootstrapPlugins.test.ts
+++ b/src/bootstrap/bootstrapPlugins.test.ts
@@ -14,6 +14,14 @@ import {
 	registerCalls,
 } from "@test-support/plugin-fixtures/kitchen-sink/valid-plugin/capture";
 
+import { DuelEventDispatcher } from "@shared/room/domain/duel-events/DuelEventDispatcher";
+import { DuelEventPluginHub } from "@shared/room/domain/duel-events/DuelEventPluginHub";
+import { YgoRoom } from "@shared/room/domain/YgoRoom";
+import {
+	receivedEvents,
+	resetReceivedEvents,
+} from "@test-support/plugin-fixtures/duel-events/subscriber/capture";
+
 import { bootstrapPlugins } from "./bootstrapPlugins";
 
 const FIXTURES_ROOT = path.join(__dirname, "..", "test-support", "plugin-fixtures");
@@ -95,5 +103,45 @@ describe("bootstrapPlugins", () => {
 
 		expect(report.loaded).toEqual(["dup-name"]);
 		expect(report.skipped).toContain("duplicate-name-b");
+	});
+
+	describe("duel-events root", () => {
+		const duelEventsRoot = path.join(FIXTURES_ROOT, "duel-events");
+		const room = { id: 7 } as unknown as YgoRoom;
+
+		beforeEach(() => {
+			DuelEventPluginHub.resetInstance();
+			resetReceivedEvents();
+		});
+
+		afterEach(() => {
+			DuelEventPluginHub.resetInstance();
+		});
+
+		it("wires a declaring plugin's subscription into the hub", async () => {
+			const report = await bootstrapPlugins(bus, deps, duelEventsRoot);
+			expect(report.loaded).toContain("subscriber");
+
+			const dispatcher = new DuelEventDispatcher();
+			DuelEventPluginHub.getInstance().attach(dispatcher);
+			dispatcher.dispatch("duel.damage", { roomId: 7, team: 0, amount: 1000, turn: 1 }, room);
+			await new Promise((resolve) => setImmediate(resolve));
+
+			expect(receivedEvents).toEqual([{ roomId: 7, team: 0, amount: 1000, turn: 1 }]);
+		});
+
+		it("fails a plugin that subscribes to a kind it did not declare", async () => {
+			const report = await bootstrapPlugins(bus, deps, duelEventsRoot);
+
+			expect(report.failed).toContain("undeclared-kind");
+			expect(report.loaded).not.toContain("undeclared-kind");
+		});
+
+		it("keeps deps identity for plugins that declare nothing", async () => {
+			const kitchenSinkRoot = path.join(FIXTURES_ROOT, "kitchen-sink");
+			await bootstrapPlugins(bus, deps, kitchenSinkRoot);
+
+			expect(registerCalls[0].deps).toBe(deps);
+		});
 	});
 });

--- a/src/bootstrap/bootstrapPlugins.ts
+++ b/src/bootstrap/bootstrapPlugins.ts
@@ -3,7 +3,8 @@ import path from "node:path";
 
 import { EventBus } from "@shared/event-bus/EventBus";
 import { isServerPlugin } from "@shared/plugin/isServerPlugin";
-import { PluginDeps } from "@shared/plugin/ServerPlugin";
+import { DuelEventSubscriptions, PluginDeps, ServerPlugin } from "@shared/plugin/ServerPlugin";
+import { DuelEventPluginHub } from "@shared/room/domain/duel-events/DuelEventPluginHub";
 
 export interface PluginBootstrapReport {
 	loaded: string[];
@@ -13,6 +14,33 @@ export interface PluginBootstrapReport {
 
 function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
 	return error instanceof Error && "code" in error;
+}
+
+// A plugin that declares duelEvents gets a subscription surface scoped to
+// exactly those kinds, wired into the DuelEventPluginHub under its own name so
+// delivery and disconnection are attributable. A plugin that declares nothing
+// receives the shared deps object untouched.
+function depsFor(plugin: ServerPlugin, deps: PluginDeps): PluginDeps {
+	if (plugin.duelEvents === undefined) {
+		return deps;
+	}
+
+	const declared = new Set(plugin.duelEvents);
+	const hub = DuelEventPluginHub.getInstance();
+	hub.initialize(deps.logger);
+
+	const duelEvents: DuelEventSubscriptions = {
+		subscribe: (kind, handler) => {
+			if (!declared.has(kind)) {
+				throw new Error(
+					`Plugin "${plugin.name}" subscribed to undeclared duel event "${kind}" — add it to duelEvents`,
+				);
+			}
+			hub.register(plugin.name, kind, handler);
+		},
+	};
+
+	return { ...deps, duelEvents };
 }
 
 // Discovers and registers plugins from pluginsRoot (D5/D8): only direct
@@ -79,7 +107,7 @@ export async function bootstrapPlugins(
 				continue;
 			}
 
-			await candidate.register(bus, deps);
+			await candidate.register(bus, depsFor(candidate, deps));
 			report.loaded.push(candidate.name);
 		} catch (error) {
 			deps.logger.error(error instanceof Error ? error : String(error), { dirName });

--- a/src/edopro/room/domain/RoomState.ts
+++ b/src/edopro/room/domain/RoomState.ts
@@ -12,6 +12,7 @@ import {
 	decodeTurnStarted,
 } from "src/shared/room/domain/duel-events/DuelEventDecoders";
 import { DuelEventDispatcher } from "src/shared/room/domain/duel-events/DuelEventDispatcher";
+import { DuelEventPluginHub } from "src/shared/room/domain/duel-events/DuelEventPluginHub";
 import WebSocketSingleton from "src/web-socket-server/WebSocketSingleton";
 import { EventEmitter } from "stream";
 
@@ -44,6 +45,10 @@ export abstract class RoomState {
 	constructor(eventEmitter: EventEmitter) {
 		this.eventEmitter = eventEmitter;
 		this.registerDuelEventSubscribers();
+		// Plugin subscribers observe the same dispatched events through the
+		// hub's bounded per-room queue; with no plugins registered this is a
+		// no-op.
+		DuelEventPluginHub.getInstance().attach(this.duelEvents);
 
 		this.eventEmitter.on(
 			Commands.CHAT as unknown as string,

--- a/src/edopro/room/domain/RoomStateProcessDuelMessage.test.ts
+++ b/src/edopro/room/domain/RoomStateProcessDuelMessage.test.ts
@@ -18,6 +18,7 @@ jest.mock("../../../web-socket-server/WebSocketSingleton", () => {
 	};
 });
 
+import { DuelEventPluginHub } from "../../../shared/room/domain/duel-events/DuelEventPluginHub";
 import { RoomState } from "./RoomState";
 import { YgoRoom } from "../../../shared/room/domain/YgoRoom";
 import WebSocketSingleton from "../../../web-socket-server/WebSocketSingleton";
@@ -116,5 +117,32 @@ describe("RoomState.processDuelMessage", () => {
 		expect(room.increaseLps).not.toHaveBeenCalled();
 		expect(room.increaseTurn).not.toHaveBeenCalled();
 		expect(mockBroadcast).not.toHaveBeenCalled();
+	});
+
+	describe("plugin delivery through the hub", () => {
+		beforeEach(() => {
+			DuelEventPluginHub.resetInstance();
+		});
+
+		afterEach(() => {
+			DuelEventPluginHub.resetInstance();
+		});
+
+		it("delivers decoded events to a hub-registered plugin handler, off the dispatch path", async () => {
+			const received: unknown[] = [];
+			DuelEventPluginHub.getInstance().register("stats", "duel.damage", (event) => {
+				received.push(event);
+			});
+			const pluginState = new TestRoomState(new EventEmitter());
+			const room = makeRoom(0);
+
+			pluginState.run(CoreMessages.MSG_DAMAGE, lpPayload(CoreMessages.MSG_DAMAGE, 1, 1000), room);
+
+			// Nothing synchronously — the queue drains on a microtask.
+			expect(received).toEqual([]);
+			await new Promise((resolve) => setImmediate(resolve));
+
+			expect(received).toEqual([{ roomId: 7, team: 1, amount: 1000, turn: 2 }]);
+		});
 	});
 });

--- a/src/shared/plugin/ServerPlugin.ts
+++ b/src/shared/plugin/ServerPlugin.ts
@@ -1,5 +1,7 @@
 import { EventBus } from "@shared/event-bus/EventBus";
 import { Logger } from "@shared/logger/domain/Logger";
+import { DuelEventPayloads } from "@shared/room/domain/duel-events/DuelEventDispatcher";
+import { DuelEventKind } from "@shared/room/domain/duel-events/DuelEvents";
 
 import { config } from "src/config";
 
@@ -7,9 +9,23 @@ import { config } from "src/config";
 // to src/config, so a plugin file never drags the real env-parsing module in.
 export type AppConfig = typeof config;
 
+/**
+ * Subscription surface for the duel events a plugin declared in `duelEvents`.
+ * Only present in the deps of a plugin that declares — the declaration is the
+ * single source of what a plugin may observe, and subscribing to an undeclared
+ * kind throws.
+ */
+export interface DuelEventSubscriptions {
+	subscribe<K extends DuelEventKind>(
+		kind: K,
+		handler: (event: DuelEventPayloads[K]) => void | Promise<void>,
+	): void;
+}
+
 export interface PluginDeps {
 	readonly logger: Logger;
 	readonly config: AppConfig;
+	readonly duelEvents?: DuelEventSubscriptions;
 }
 
 /**
@@ -22,4 +38,13 @@ export interface ServerPlugin {
 	readonly name: string;
 	enabled(config: AppConfig): boolean;
 	register(bus: EventBus, deps: PluginDeps): void | Promise<void>;
+
+	/**
+	 * Duel-event kinds this plugin observes. Omit it and the plugin sees no
+	 * duel events at all; declare it and deps.duelEvents.subscribe accepts
+	 * exactly these kinds. Delivery is observe-only, queued off the duel's
+	 * path, bounded, and disconnected per room on abuse (see
+	 * DuelEventPluginHub).
+	 */
+	readonly duelEvents?: readonly DuelEventKind[];
 }

--- a/src/shared/plugin/isServerPlugin.test.ts
+++ b/src/shared/plugin/isServerPlugin.test.ts
@@ -28,4 +28,28 @@ describe("isServerPlugin", () => {
 	it("returns true when register returns a Promise<void>", () => {
 		expect(isServerPlugin({ ...validPlugin, register: async () => undefined })).toBe(true);
 	});
+
+	describe("duelEvents declaration", () => {
+		it("returns true when duelEvents is absent", () => {
+			expect(isServerPlugin(validPlugin)).toBe(true);
+		});
+
+		it("returns true for an array of known duel-event kinds", () => {
+			expect(
+				isServerPlugin({ ...validPlugin, duelEvents: ["duel.damage", "duel.turn-start"] }),
+			).toBe(true);
+		});
+
+		it("returns true for an empty declaration", () => {
+			expect(isServerPlugin({ ...validPlugin, duelEvents: [] })).toBe(true);
+		});
+
+		it.each([
+			["not an array", "duel.damage"],
+			["an unknown kind", ["duel.damage", "duel.unknown"]],
+			["a non-string entry", [42]],
+		])("returns false when duelEvents is %s", (_description, duelEvents) => {
+			expect(isServerPlugin({ ...validPlugin, duelEvents })).toBe(false);
+		});
+	});
 });

--- a/src/shared/plugin/isServerPlugin.ts
+++ b/src/shared/plugin/isServerPlugin.ts
@@ -1,3 +1,5 @@
+import { DUEL_EVENT_KINDS } from "@shared/room/domain/duel-events/DuelEvents";
+
 import { ServerPlugin } from "./ServerPlugin";
 
 // Runtime guard used by bootstrapPlugins() to reject any dynamically-imported
@@ -12,6 +14,18 @@ export function isServerPlugin(value: unknown): value is ServerPlugin {
 	return (
 		typeof candidate.name === "string" &&
 		typeof candidate.enabled === "function" &&
-		typeof candidate.register === "function"
+		typeof candidate.register === "function" &&
+		hasValidDuelEventsDeclaration(candidate.duelEvents)
+	);
+}
+
+function hasValidDuelEventsDeclaration(duelEvents: unknown): boolean {
+	if (duelEvents === undefined) {
+		return true;
+	}
+
+	return (
+		Array.isArray(duelEvents) &&
+		duelEvents.every((kind) => (DUEL_EVENT_KINDS as readonly string[]).includes(kind as string))
 	);
 }

--- a/src/shared/room/domain/duel-events/DuelEventPluginHub.test.ts
+++ b/src/shared/room/domain/duel-events/DuelEventPluginHub.test.ts
@@ -1,0 +1,209 @@
+import { LoggerMock } from "@test-support/mocks/logger/LoggerMock";
+
+import { YgoRoom } from "../YgoRoom";
+import { DuelEventDispatcher } from "./DuelEventDispatcher";
+import { DuelEventPluginHub } from "./DuelEventPluginHub";
+import { DamageDealtEvent } from "./DuelEvents";
+
+const room = { id: 7 } as unknown as YgoRoom;
+const damage = (amount: number): DamageDealtEvent => ({ roomId: 7, team: 0, amount, turn: 1 });
+
+// Queue drains run on microtasks (and async handlers add real ticks); flush
+// both before asserting.
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+const busyWaitMs = (ms: number) => {
+	const end = Date.now() + ms;
+	while (Date.now() < end) {
+		/* burn */
+	}
+};
+
+describe("DuelEventPluginHub", () => {
+	let hub: DuelEventPluginHub;
+	let dispatcher: DuelEventDispatcher;
+	let logger: LoggerMock;
+	let errorSpy: jest.SpyInstance;
+	let warnSpy: jest.SpyInstance;
+
+	const makeHub = (options?: ConstructorParameters<typeof DuelEventPluginHub>[0]) => {
+		hub = new DuelEventPluginHub(options);
+		hub.initialize(logger);
+	};
+
+	beforeEach(() => {
+		logger = new LoggerMock();
+		errorSpy = jest.spyOn(logger, "error");
+		warnSpy = jest.spyOn(logger, "warn");
+		dispatcher = new DuelEventDispatcher();
+	});
+
+	it("delivers dispatched events to a registered plugin handler, in order", async () => {
+		makeHub();
+		const seen: number[] = [];
+		hub.register("stats", "duel.damage", async (event) => {
+			await Promise.resolve();
+			seen.push((event as DamageDealtEvent).amount);
+		});
+		hub.attach(dispatcher);
+
+		dispatcher.dispatch("duel.damage", damage(100), room);
+		dispatcher.dispatch("duel.damage", damage(200), room);
+		dispatcher.dispatch("duel.damage", damage(300), room);
+		await flush();
+
+		expect(seen).toEqual([100, 200, 300]);
+	});
+
+	it("delivers nothing for kinds no plugin registered", () => {
+		makeHub();
+		const subscribeSpy = jest.spyOn(dispatcher, "subscribe");
+
+		hub.attach(dispatcher);
+
+		expect(subscribeSpy).not.toHaveBeenCalled();
+	});
+
+	it("does not deliver synchronously inside dispatch", () => {
+		makeHub();
+		let delivered = false;
+		hub.register("stats", "duel.damage", () => {
+			delivered = true;
+		});
+		hub.attach(dispatcher);
+
+		dispatcher.dispatch("duel.damage", damage(100), room);
+
+		expect(delivered).toBe(false);
+	});
+
+	it("logs a plugin handler's error and keeps delivering", async () => {
+		makeHub();
+		const seen: number[] = [];
+		hub.register("stats", "duel.damage", (event) => {
+			if ((event as DamageDealtEvent).amount === 100) {
+				throw new Error("plugin exploded");
+			}
+			seen.push((event as DamageDealtEvent).amount);
+		});
+		hub.attach(dispatcher);
+
+		dispatcher.dispatch("duel.damage", damage(100), room);
+		dispatcher.dispatch("duel.damage", damage(200), room);
+		await flush();
+
+		expect(seen).toEqual([200]);
+		expect(errorSpy).toHaveBeenCalled();
+	});
+
+	it("disconnects a plugin from the room when its queue overflows, with a loud error", async () => {
+		makeHub({ maxQueue: 2 });
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const seen: number[] = [];
+		hub.register("slow", "duel.damage", async (event) => {
+			await gate;
+			seen.push((event as DamageDealtEvent).amount);
+		});
+		hub.attach(dispatcher);
+
+		// First event enters the drain and blocks; the queue then fills to the
+		// cap and the next enqueue overflows.
+		dispatcher.dispatch("duel.damage", damage(1), room);
+		await Promise.resolve();
+		dispatcher.dispatch("duel.damage", damage(2), room);
+		dispatcher.dispatch("duel.damage", damage(3), room);
+		dispatcher.dispatch("duel.damage", damage(4), room);
+		await flush();
+
+		expect(errorSpy).toHaveBeenCalledWith(
+			expect.stringContaining('"slow"'),
+			expect.objectContaining({ roomId: 7, reason: "queue-overflow" }),
+		);
+
+		release();
+		await flush();
+		dispatcher.dispatch("duel.damage", damage(5), room);
+		await flush();
+
+		// Only the event that was already draining survives; nothing after the
+		// disconnect is delivered.
+		expect(seen).toEqual([1]);
+	});
+
+	it("warns on a handle over budget and disconnects a repeat offender", async () => {
+		makeHub({ budgetMs: 5, maxViolations: 2 });
+		const seen: number[] = [];
+		hub.register("cpu-hog", "duel.damage", (event) => {
+			seen.push((event as DamageDealtEvent).amount);
+			busyWaitMs(8);
+		});
+		hub.attach(dispatcher);
+
+		dispatcher.dispatch("duel.damage", damage(1), room);
+		await flush();
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+
+		dispatcher.dispatch("duel.damage", damage(2), room);
+		await flush();
+		expect(errorSpy).toHaveBeenCalledWith(
+			expect.stringContaining('"cpu-hog"'),
+			expect.objectContaining({ roomId: 7, reason: "budget-exceeded" }),
+		);
+
+		dispatcher.dispatch("duel.damage", damage(3), room);
+		await flush();
+
+		expect(seen).toEqual([1, 2]);
+	});
+
+	it("keeps a healthy plugin delivering after another plugin is disconnected", async () => {
+		makeHub({ budgetMs: 5, maxViolations: 1 });
+		const healthy: number[] = [];
+		hub.register("cpu-hog", "duel.damage", () => busyWaitMs(8));
+		hub.register("healthy", "duel.damage", (event) => {
+			healthy.push((event as DamageDealtEvent).amount);
+		});
+		hub.attach(dispatcher);
+
+		dispatcher.dispatch("duel.damage", damage(1), room);
+		await flush();
+		dispatcher.dispatch("duel.damage", damage(2), room);
+		await flush();
+
+		expect(healthy).toEqual([1, 2]);
+	});
+
+	it("attachments are independent: a disconnect in one room does not affect another", async () => {
+		makeHub({ budgetMs: 5, maxViolations: 1 });
+		const otherRoom = { id: 8 } as unknown as YgoRoom;
+		const otherDispatcher = new DuelEventDispatcher();
+		const seen: number[] = [];
+		hub.register("plugin", "duel.damage", (event) => {
+			busyWaitMs((event as DamageDealtEvent).amount === 1 ? 8 : 0);
+			seen.push((event as DamageDealtEvent).amount);
+		});
+		hub.attach(dispatcher);
+		hub.attach(otherDispatcher);
+
+		// Disconnect in room 7 (over budget), then room 8 still delivers.
+		dispatcher.dispatch("duel.damage", damage(1), room);
+		await flush();
+		dispatcher.dispatch("duel.damage", damage(2), room);
+		otherDispatcher.dispatch("duel.damage", { roomId: 8, team: 0, amount: 3, turn: 1 }, otherRoom);
+		await flush();
+
+		expect(seen).toEqual([1, 3]);
+	});
+
+	it("getInstance returns a stable singleton and resetInstance clears it", () => {
+		const first = DuelEventPluginHub.getInstance();
+		expect(DuelEventPluginHub.getInstance()).toBe(first);
+
+		DuelEventPluginHub.resetInstance();
+
+		expect(DuelEventPluginHub.getInstance()).not.toBe(first);
+	});
+});

--- a/src/shared/room/domain/duel-events/DuelEventPluginHub.ts
+++ b/src/shared/room/domain/duel-events/DuelEventPluginHub.ts
@@ -1,0 +1,187 @@
+/**
+ * Bridges the synchronous DuelEventDispatcher to plugin subscribers through a
+ * bounded, ordered, per-attachment queue.
+ *
+ * Plugins are third-party observers with no veto power over a duel, so their
+ * handlers never run inside dispatch: enqueueing is the only work on the duel's
+ * path, and the queue drains on a microtask, one event at a time, preserving
+ * per-room order. Handler errors are logged, never rethrown.
+ *
+ * Two detectors feed one consequence — the plugin is disconnected from that
+ * room with a loud, named error:
+ *  - queue-overflow: the queue is bounded (maxQueue); a consumer slower than
+ *    the duel produces all-or-nothing data instead of silent gaps.
+ *  - budget-exceeded: each handle() is timed; over budgetMs logs a warning
+ *    naming the plugin, and maxViolations of them disconnect it. A sync
+ *    CPU-heavy handler blocks the whole event loop — nothing in-process can
+ *    prevent that, so the budget attributes it instead.
+ */
+import { Logger } from "@shared/logger/domain/Logger";
+
+import { YgoRoom } from "../YgoRoom";
+import { DuelEventDispatcher, DuelEventPayloads } from "./DuelEventDispatcher";
+import { DuelEventKind } from "./DuelEvents";
+
+export type PluginDuelEventHandler = (
+	event: DuelEventPayloads[DuelEventKind],
+) => void | Promise<void>;
+
+export interface DuelEventPluginHubOptions {
+	maxQueue?: number;
+	budgetMs?: number;
+	maxViolations?: number;
+}
+
+interface Registration {
+	pluginName: string;
+	kind: DuelEventKind;
+	handler: PluginDuelEventHandler;
+}
+
+interface QueuedEvent {
+	event: DuelEventPayloads[DuelEventKind];
+	room: YgoRoom;
+	handler: PluginDuelEventHandler;
+}
+
+interface PluginDeliveryState {
+	queue: QueuedEvent[];
+	draining: boolean;
+	violations: number;
+	disconnected: boolean;
+}
+
+export class DuelEventPluginHub {
+	private static instance?: DuelEventPluginHub;
+
+	private readonly maxQueue: number;
+	private readonly budgetMs: number;
+	private readonly maxViolations: number;
+	private readonly registrations: Registration[] = [];
+	private logger?: Logger;
+
+	constructor(options: DuelEventPluginHubOptions = {}) {
+		this.maxQueue = options.maxQueue ?? 1000;
+		this.budgetMs = options.budgetMs ?? 10;
+		this.maxViolations = options.maxViolations ?? 3;
+	}
+
+	static getInstance(): DuelEventPluginHub {
+		if (!DuelEventPluginHub.instance) {
+			DuelEventPluginHub.instance = new DuelEventPluginHub();
+		}
+
+		return DuelEventPluginHub.instance;
+	}
+
+	static resetInstance(): void {
+		DuelEventPluginHub.instance = undefined;
+	}
+
+	initialize(logger: Logger): void {
+		this.logger = logger;
+	}
+
+	register(pluginName: string, kind: DuelEventKind, handler: PluginDuelEventHandler): void {
+		this.registrations.push({ pluginName, kind, handler });
+	}
+
+	get registeredKinds(): readonly DuelEventKind[] {
+		return [...new Set(this.registrations.map((registration) => registration.kind))];
+	}
+
+	/**
+	 * Subscribes the registered plugin handlers to a room state's dispatcher.
+	 * Delivery state (queue, violations, disconnection) is scoped to this
+	 * attachment: a disconnect affects one plugin in one room, never the plugin
+	 * elsewhere or the room's other plugins.
+	 */
+	attach(dispatcher: DuelEventDispatcher): void {
+		const states = new Map<string, PluginDeliveryState>();
+		const stateFor = (pluginName: string): PluginDeliveryState => {
+			let state = states.get(pluginName);
+			if (!state) {
+				state = { queue: [], draining: false, violations: 0, disconnected: false };
+				states.set(pluginName, state);
+			}
+
+			return state;
+		};
+
+		for (const registration of this.registrations) {
+			dispatcher.subscribe(registration.kind, (event, room) => {
+				this.enqueue(stateFor(registration.pluginName), registration, event, room);
+			});
+		}
+	}
+
+	private enqueue(
+		state: PluginDeliveryState,
+		registration: Registration,
+		event: DuelEventPayloads[DuelEventKind],
+		room: YgoRoom,
+	): void {
+		if (state.disconnected) {
+			return;
+		}
+
+		if (state.queue.length >= this.maxQueue) {
+			this.disconnect(state, registration.pluginName, room, "queue-overflow");
+
+			return;
+		}
+
+		state.queue.push({ event, room, handler: registration.handler });
+
+		if (!state.draining) {
+			state.draining = true;
+			queueMicrotask(() => void this.drain(state, registration.pluginName));
+		}
+	}
+
+	private async drain(state: PluginDeliveryState, pluginName: string): Promise<void> {
+		while (state.queue.length > 0 && !state.disconnected) {
+			const item = state.queue.shift() as QueuedEvent;
+			const started = process.hrtime.bigint();
+
+			try {
+				await item.handler(item.event);
+			} catch (error) {
+				this.logger?.error(error instanceof Error ? error : String(error), {
+					plugin: pluginName,
+					roomId: item.room.id,
+				});
+			}
+
+			const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+			if (elapsedMs > this.budgetMs) {
+				state.violations += 1;
+				this.logger?.warn(
+					`Duel-event handler of plugin "${pluginName}" took ${elapsedMs.toFixed(1)}ms (budget ${this.budgetMs}ms, violation ${state.violations}/${this.maxViolations})`,
+					{ plugin: pluginName, roomId: item.room.id },
+				);
+
+				if (state.violations >= this.maxViolations) {
+					this.disconnect(state, pluginName, item.room, "budget-exceeded");
+				}
+			}
+		}
+
+		state.draining = false;
+	}
+
+	private disconnect(
+		state: PluginDeliveryState,
+		pluginName: string,
+		room: YgoRoom,
+		reason: "queue-overflow" | "budget-exceeded",
+	): void {
+		state.disconnected = true;
+		state.queue.length = 0;
+		this.logger?.error(`Duel-event plugin "${pluginName}" disconnected from room ${room.id}`, {
+			plugin: pluginName,
+			roomId: room.id,
+			reason,
+		});
+	}
+}

--- a/src/test-support/plugin-fixtures/duel-events/subscriber/capture.ts
+++ b/src/test-support/plugin-fixtures/duel-events/subscriber/capture.ts
@@ -1,0 +1,7 @@
+import { DamageDealtEvent } from "@shared/room/domain/duel-events/DuelEvents";
+
+export const receivedEvents: DamageDealtEvent[] = [];
+
+export function resetReceivedEvents(): void {
+	receivedEvents.length = 0;
+}

--- a/src/test-support/plugin-fixtures/duel-events/subscriber/index.ts
+++ b/src/test-support/plugin-fixtures/duel-events/subscriber/index.ts
@@ -1,0 +1,13 @@
+import { makeTestPlugin } from "../../makeTestPlugin";
+import { receivedEvents } from "./capture";
+
+// Declares duel.damage and subscribes to it through the scoped deps surface.
+export default makeTestPlugin({
+	name: "subscriber",
+	duelEvents: ["duel.damage"],
+	register: (_bus, deps) => {
+		deps.duelEvents?.subscribe("duel.damage", (event) => {
+			receivedEvents.push(event);
+		});
+	},
+});

--- a/src/test-support/plugin-fixtures/duel-events/undeclared-kind/index.ts
+++ b/src/test-support/plugin-fixtures/duel-events/undeclared-kind/index.ts
@@ -1,0 +1,12 @@
+import { makeTestPlugin } from "../../makeTestPlugin";
+
+// Declares only duel.damage but subscribes to duel.turn-start: the scoped
+// subscription surface must reject it and the loader must report the plugin
+// as failed.
+export default makeTestPlugin({
+	name: "undeclared-kind",
+	duelEvents: ["duel.damage"],
+	register: (_bus, deps) => {
+		deps.duelEvents?.subscribe("duel.turn-start", () => undefined);
+	},
+});


### PR DESCRIPTION
## Description / Descripción

**duel-events 3/4** — plugins can now observe duel events, with the isolation policy the design froze: observe-only, queued off the duel's path, bounded, and disconnected per room on abuse.

### Contract (`ServerPlugin`)

- New optional `duelEvents?: readonly DuelEventKind[]` declaration, validated by `isServerPlugin` (unknown kinds reject the module).
- A **declaring** plugin receives `deps.duelEvents.subscribe(kind, handler)`, scoped to exactly the declared kinds — subscribing to an undeclared kind throws and the loader reports the plugin as `failed`. The declaration is the single source of what a plugin may observe.
- A plugin that declares nothing keeps the shared `deps` object untouched (by identity — pinned by test) and sees no duel events at all. The four shipped plugins need no change.

### Bridge (`DuelEventPluginHub`)

Bridges the synchronous `DuelEventDispatcher` (duel-events 2/4) to plugin subscribers:

- **Enqueueing is the only work on the duel's path.** Each plugin's queue drains on a microtask, one event at a time, preserving per-room order. Handler errors are logged with the plugin's name, never rethrown.
- **Two detectors, one consequence** — the plugin is disconnected from that room with a loud, named error (`reason: queue-overflow | budget-exceeded`):
  - bounded queue (**1000** events): a consumer slower than the duel produces all-or-nothing data instead of silent gaps in someone's stats;
  - per-handle time budget (**10 ms**, warn per violation, disconnect at **3**): a sync CPU-heavy handler blocks the whole event loop — nothing in-process can prevent that (measured: 10×50 ms sync CPU handlers block a 10 ms heartbeat for 490 ms vs 2 ms for async I/O) — so the budget *attributes* it.
- A disconnect affects one plugin in one room, never the plugin elsewhere or the room's other plugins (pinned by tests).

`RoomState` attaches the hub to its dispatcher at construction; with zero declaring plugins the bridge subscribes nothing — the no-plugin path is a no-op.

### TDD

Red-first throughout: 9 hub tests (ordering, async-off-dispatch, error logging, overflow disconnect, budget disconnect, per-plugin and per-room isolation, singleton reset), 6 new `isServerPlugin` cases, 3 loader tests over new fixtures (`duel-events/subscriber`, `duel-events/undeclared-kind`), 1 end-to-end RoomState → hub delivery test. The 6 characterization tests stay untouched and green.

## Related Issue(s) / Issue(s) relacionado(s)

Continues #329 (1/4) and #331 (2/4).

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [x] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

- Full suite: **135 suites / 1269 tests** green; `tsc --noEmit` and `biome ci` clean.
- Policy constants (`maxQueue: 1000`, `budgetMs: 10`, `maxViolations: 3`) are constructor-injectable; tests use small values, production uses defaults via the singleton.
- Next: **4/4** ships the first consumer plugin, whose gate is working identically on an EDOPro room and a ygopro room — that slice wires the ygopro pipeline's typed messages into the same dispatcher (its internal LP/broadcast handlers stay in the middleware; only plugin delivery is added).
