### PR TITLE
feat(plugins): wire ygopro duel events and ship the first consumer plugin (duel-events 4/4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,4 +81,5 @@ resources.manifest.private.json.*
 # Plugins — private plugin folders are cloned in place and must stay untracked.
 src/plugins/*
 !src/plugins/basic-stats/
+!src/plugins/big-damage-log/
 !src/plugins/unranked-match/

--- a/src/bootstrap/bootstrapPlugins.realPlugins.test.ts
+++ b/src/bootstrap/bootstrapPlugins.realPlugins.test.ts
@@ -4,6 +4,8 @@ import { GameOverDomainEvent } from "@shared/room/domain/match/domain/domain-eve
 import { LoggerMock } from "@test-support/mocks/logger/LoggerMock";
 import { dataSource } from "src/evolution-types/src/data-source";
 
+import { DuelEventPluginHub } from "@shared/room/domain/duel-events/DuelEventPluginHub";
+
 import { bootstrapPlugins } from "./bootstrapPlugins";
 
 // Exercises bootstrapPlugins against the real src/plugins directory (no
@@ -20,12 +22,22 @@ function makeDeps(rankingEnabled: boolean): PluginDeps {
 }
 
 describe("bootstrapPlugins against the real src/plugins directory", () => {
+	beforeEach(() => {
+		DuelEventPluginHub.resetInstance();
+	});
+
+	afterEach(() => {
+		DuelEventPluginHub.resetInstance();
+	});
+
 	it("skips both stats plugins when ranking is disabled (zero-argument default pluginsRoot)", async () => {
 		const bus = { subscribe: jest.fn() } as unknown as EventBus;
 
 		const report = await bootstrapPlugins(bus, makeDeps(false));
 
-		expect(report.loaded).toEqual([]);
+		// big-damage-log is ranking-independent and observes duel events only,
+		// so it loads without ever touching the event bus.
+		expect(report.loaded).toEqual(["big-damage-log"]);
 		expect(report.skipped).toEqual(expect.arrayContaining(["basic-stats", "unranked-match"]));
 		expect(bus.subscribe).not.toHaveBeenCalled();
 	});
@@ -35,7 +47,9 @@ describe("bootstrapPlugins against the real src/plugins directory", () => {
 
 		const report = await bootstrapPlugins(bus, makeDeps(true));
 
-		expect(report.loaded).toEqual(expect.arrayContaining(["basic-stats", "unranked-match"]));
+		expect(report.loaded).toEqual(
+			expect.arrayContaining(["basic-stats", "big-damage-log", "unranked-match"]),
+		);
 		expect(bus.subscribe).toHaveBeenCalledTimes(2);
 	});
 

--- a/src/edopro/room/domain/RoomState.ts
+++ b/src/edopro/room/domain/RoomState.ts
@@ -122,11 +122,18 @@ export abstract class RoomState {
 		}
 
 		if (messageType === CoreMessages.MSG_NEW_TURN) {
-			this.duelEvents.dispatch("duel.turn-start", decodeTurnStarted(data, ctx), room);
+			// TurnStartedEvent.turn is the number of the turn that just started;
+			// the room counter increments in the internal subscriber, after this
+			// event is built.
+			const turnStartCtx: DuelEventContext = { ...ctx, turn: room.turn + 1 };
+			this.duelEvents.dispatch("duel.turn-start", decodeTurnStarted(data, turnStartCtx), room);
 		}
 	}
 
-	private registerDuelEventSubscribers(): void {
+	// The ygopro pipeline overrides this with a no-op: it applies LP/turn
+	// mutations in its ocgcore middleware, so its dispatcher carries plugin
+	// delivery only.
+	protected registerDuelEventSubscribers(): void {
 		this.duelEvents.subscribe("duel.damage", (event, room) => {
 			room.decreaseLps(event.team as Team, event.amount);
 			this.broadcastDuelRoomUpdate(room);

--- a/src/edopro/room/domain/RoomStateProcessDuelMessage.test.ts
+++ b/src/edopro/room/domain/RoomStateProcessDuelMessage.test.ts
@@ -144,5 +144,23 @@ describe("RoomState.processDuelMessage", () => {
 
 			expect(received).toEqual([{ roomId: 7, team: 1, amount: 1000, turn: 2 }]);
 		});
+
+		// TurnStartedEvent.turn is the number of the turn that just started. The
+		// room counter increments inside the internal subscriber, after the event
+		// is built, so the event must carry room.turn + 1 — matching the ygopro
+		// pipeline, whose counter has already incremented when it dispatches.
+		it("turn-start carries the number of the turn that just started", async () => {
+			const received: unknown[] = [];
+			DuelEventPluginHub.getInstance().register("stats", "duel.turn-start", (event) => {
+				received.push(event);
+			});
+			const pluginState = new TestRoomState(new EventEmitter());
+			const room = makeRoom(0); // room.turn = 2
+
+			pluginState.run(CoreMessages.MSG_NEW_TURN, Buffer.from([CoreMessages.MSG_NEW_TURN, 1]), room);
+			await new Promise((resolve) => setImmediate(resolve));
+
+			expect(received).toEqual([{ roomId: 7, player: 1, turn: 3 }]);
+		});
 	});
 });

--- a/src/plugins/big-damage-log/index.test.ts
+++ b/src/plugins/big-damage-log/index.test.ts
@@ -1,0 +1,68 @@
+import { EventBus } from "@shared/event-bus/EventBus";
+import { AppConfig, DuelEventSubscriptions, PluginDeps } from "@shared/plugin/ServerPlugin";
+import { DamageDealtEvent } from "@shared/room/domain/duel-events/DuelEvents";
+import { LoggerMock } from "@test-support/mocks/logger/LoggerMock";
+import { expectServerPluginContract } from "@test-support/plugin/expectServerPluginContract";
+
+import plugin, { BIG_DAMAGE_THRESHOLD } from "./index";
+
+const bus = { subscribe: jest.fn() } as unknown as EventBus;
+
+function makeDeps(): {
+	deps: PluginDeps;
+	handlers: Map<string, (event: DamageDealtEvent) => void | Promise<void>>;
+	logger: LoggerMock;
+} {
+	const handlers = new Map<string, (event: DamageDealtEvent) => void | Promise<void>>();
+	const logger = new LoggerMock();
+	const duelEvents: DuelEventSubscriptions = {
+		subscribe: (kind, handler) => {
+			handlers.set(kind, handler as (event: DamageDealtEvent) => void | Promise<void>);
+		},
+	};
+
+	return { deps: { logger, config: {} as AppConfig, duelEvents }, handlers, logger };
+}
+
+const damage = (amount: number): DamageDealtEvent => ({ roomId: 7, team: 1, amount, turn: 3 });
+
+describe("big-damage-log plugin", () => {
+	it("conforms to the ServerPlugin contract", () => {
+		expectServerPluginContract(plugin);
+	});
+
+	it("is always enabled", () => {
+		expect(plugin.enabled({} as AppConfig)).toBe(true);
+	});
+
+	it("declares exactly duel.damage", () => {
+		expect(plugin.duelEvents).toEqual(["duel.damage"]);
+	});
+
+	it("logs a damage event at or above the threshold", () => {
+		const { deps, handlers, logger } = makeDeps();
+		const infoSpy = jest.spyOn(logger, "info");
+		plugin.register(bus, deps);
+
+		handlers.get("duel.damage")?.(damage(BIG_DAMAGE_THRESHOLD));
+
+		expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining("5000"));
+	});
+
+	it("stays silent below the threshold", () => {
+		const { deps, handlers, logger } = makeDeps();
+		const infoSpy = jest.spyOn(logger, "info");
+		plugin.register(bus, deps);
+
+		handlers.get("duel.damage")?.(damage(BIG_DAMAGE_THRESHOLD - 1));
+
+		expect(infoSpy).not.toHaveBeenCalled();
+	});
+
+	it("never touches the event bus", () => {
+		const { deps } = makeDeps();
+		plugin.register(bus, deps);
+
+		expect(bus.subscribe).not.toHaveBeenCalled();
+	});
+});

--- a/src/plugins/big-damage-log/index.ts
+++ b/src/plugins/big-damage-log/index.ts
@@ -1,0 +1,24 @@
+import { ServerPlugin } from "@shared/plugin/ServerPlugin";
+
+export const BIG_DAMAGE_THRESHOLD = 5000;
+
+// Observe-only consumer of the duel-event surface: logs any single hit at or
+// above the threshold. Stateless on purpose — GameOverDomainEvent carries no
+// roomId, so per-duel aggregation has no end-of-room signal to key on yet.
+const plugin: ServerPlugin = {
+	name: "big-damage-log",
+	enabled: () => true,
+	duelEvents: ["duel.damage"],
+	register: (_bus, deps) => {
+		const logger = deps.logger.child({ file: "BigDamageLog" });
+		deps.duelEvents?.subscribe("duel.damage", (event) => {
+			if (event.amount >= BIG_DAMAGE_THRESHOLD) {
+				logger.info(
+					`Big damage: team ${event.team} took ${event.amount} LP in room ${event.roomId} (turn ${event.turn})`,
+				);
+			}
+		});
+	},
+};
+
+export default plugin;

--- a/src/ygopro/room/domain/YGOProRoomState.ts
+++ b/src/ygopro/room/domain/YGOProRoomState.ts
@@ -2,6 +2,13 @@ import { RoomState } from "@edopro/room/domain/RoomState";
 import { YGOProRoom } from "./YGOProRoom";
 
 export class YGOProRoomState extends RoomState {
+	protected override registerDuelEventSubscribers(): void {
+		// LP and turn mutations on this pipeline live in the ocgcore middleware
+		// (YGOProDuelingState / ocgcore.ts), not in dispatcher subscribers.
+		// Registering the EDOPro internal handlers here would apply every
+		// mutation twice; the dispatcher carries plugin delivery only.
+	}
+
 	protected toRPS(room: YGOProRoom): void {
 		const team0Player = room.getTeamPlayers(0)[0];
 		const team1Player = room.getTeamPlayers(1)[0];

--- a/src/ygopro/room/domain/YGOProRoomStateDuelEvents.test.ts
+++ b/src/ygopro/room/domain/YGOProRoomStateDuelEvents.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The ygopro pipeline applies LP/turn mutations in its ocgcore middleware, so
+ * its dispatcher must NOT carry the EDOPro internal subscribers — dispatching a
+ * duel event from a ygopro state would otherwise apply the mutation twice (the
+ * middleware already called decreaseLps). Plugin delivery through the hub is
+ * the only thing a ygopro dispatcher carries.
+ */
+import { EventEmitter } from "stream";
+
+jest.mock("../../../web-socket-server/WebSocketSingleton", () => {
+	const mockBroadcast = jest.fn();
+	return {
+		__esModule: true,
+		default: {
+			getInstance: () => ({ broadcast: mockBroadcast }),
+		},
+		mockBroadcast,
+	};
+});
+
+import { DuelEventPluginHub } from "@shared/room/domain/duel-events/DuelEventPluginHub";
+import { DamageDealtEvent } from "@shared/room/domain/duel-events/DuelEvents";
+import WebSocketSingleton from "../../../web-socket-server/WebSocketSingleton";
+
+import { YGOProRoom } from "./YGOProRoom";
+import { YGOProRoomState } from "./YGOProRoomState";
+
+const mockBroadcast = WebSocketSingleton.getInstance().broadcast as jest.Mock;
+
+class TestYgoState extends YGOProRoomState {
+	fire(event: DamageDealtEvent, room: YGOProRoom): void {
+		this.duelEvents.dispatch("duel.damage", event, room);
+	}
+}
+
+describe("YGOProRoomState duel-event dispatcher", () => {
+	beforeEach(() => {
+		DuelEventPluginHub.resetInstance();
+		mockBroadcast.mockClear();
+	});
+
+	afterEach(() => {
+		DuelEventPluginHub.resetInstance();
+	});
+
+	const damage: DamageDealtEvent = { roomId: 7, team: 1, amount: 1000, turn: 2 };
+
+	it("does not run the EDOPro internal subscribers (no double LP mutation, no broadcast)", () => {
+		const state = new TestYgoState(new EventEmitter());
+		const room = { id: 7, decreaseLps: jest.fn() } as unknown as YGOProRoom;
+
+		state.fire(damage, room);
+
+		expect(room.decreaseLps).not.toHaveBeenCalled();
+		expect(mockBroadcast).not.toHaveBeenCalled();
+	});
+
+	it("still delivers to hub-registered plugin handlers", async () => {
+		const received: unknown[] = [];
+		DuelEventPluginHub.getInstance().register("stats", "duel.damage", (event) => {
+			received.push(event);
+		});
+		const state = new TestYgoState(new EventEmitter());
+		const room = { id: 7, decreaseLps: jest.fn() } as unknown as YGOProRoom;
+
+		state.fire(damage, room);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(received).toEqual([damage]);
+	});
+});

--- a/src/ygopro/room/domain/states/YGOProDuelingState.ts
+++ b/src/ygopro/room/domain/states/YGOProDuelingState.ts
@@ -10,6 +10,11 @@ import { EventBus } from "@shared/event-bus/EventBus";
 import { Commands } from "@shared/messages/Commands";
 import { ClientMessage } from "@shared/messages/MessageProcessor";
 import { Logger } from "@shared/logger/domain/Logger";
+import {
+	buildDamageDealt,
+	buildTurnStarted,
+	DuelEventContext,
+} from "@shared/room/domain/duel-events/DuelEventDecoders";
 import { ISocket } from "@shared/socket/domain/ISocket";
 import { Team } from "@shared/room/Team";
 import { ReconnectionTokenIssuer } from "@shared/room/application/reconnect/ReconnectionTokenIssuer";
@@ -134,6 +139,7 @@ export class YGOProDuelingState extends RoomState {
 			if (this.room.isTag && (msg.player & 0x2) === 0) {
 				this.pendingSurrenders.clear();
 			}
+			this.publishTurnStart(msg.player);
 			this.broadcastRoomUpdate();
 			return msg;
 		});
@@ -141,6 +147,7 @@ export class YGOProDuelingState extends RoomState {
 		this.ocgCore.messageMiddleware.on(YGOProMsgDamage, (msg) => {
 			const team = this.resolveTeam(msg.player);
 			this.room.decreaseLps(team, msg.value);
+			this.publishLpEvent("duel.damage", msg.player, msg.value);
 			this.broadcastRoomUpdate();
 			return msg;
 		});
@@ -148,6 +155,7 @@ export class YGOProDuelingState extends RoomState {
 		this.ocgCore.messageMiddleware.on(YGOProMsgRecover, (msg) => {
 			const team = this.resolveTeam(msg.player);
 			this.room.increaseLps(team, msg.value);
+			this.publishLpEvent("duel.recover", msg.player, msg.value);
 			this.broadcastRoomUpdate();
 			return msg;
 		});
@@ -155,6 +163,7 @@ export class YGOProDuelingState extends RoomState {
 		this.ocgCore.messageMiddleware.on(YGOProMsgPayLpCost, (msg) => {
 			const team = this.resolveTeam(msg.player);
 			this.room.decreaseLps(team, msg.cost);
+			this.publishLpEvent("duel.lp-cost", msg.player, msg.cost);
 			this.broadcastRoomUpdate();
 			return msg;
 		});
@@ -674,6 +683,39 @@ export class YGOProDuelingState extends RoomState {
 				banListName: this.room.banListName ?? "N/A",
 				ranked: this.room.ranked,
 			}),
+		);
+	}
+
+	private duelEventContext(): DuelEventContext {
+		return {
+			roomId: this.room.id,
+			turn: this.room.turn,
+			resolveTeam: (player: number) => this.resolveTeam(player),
+		};
+	}
+
+	private publishLpEvent(
+		kind: "duel.damage" | "duel.recover" | "duel.lp-cost",
+		player: number,
+		amount: number,
+	): void {
+		this.duelEvents.dispatch(
+			kind,
+			buildDamageDealt({ player, amount }, this.duelEventContext()),
+			this.room,
+		);
+	}
+
+	/**
+	 * The room counter has already incremented when this pipeline's NEW_TURN
+	 * middleware runs (ocgcore.ts registers increaseTurn first), so the current
+	 * value is the number of the turn that just started.
+	 */
+	private publishTurnStart(player: number): void {
+		this.duelEvents.dispatch(
+			"duel.turn-start",
+			buildTurnStarted({ player }, this.duelEventContext()),
+			this.room,
 		);
 	}
 

--- a/src/ygopro/room/domain/states/YGOProDuelingStateDuelEvents.test.ts
+++ b/src/ygopro/room/domain/states/YGOProDuelingStateDuelEvents.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Exercises the real YGOProDuelingState duel-event publishers — the private
+ * helpers its ocgcore middleware handlers call to hand decoded duel facts to
+ * the dispatcher. Invoked on a prototype instance with only the fields they
+ * read injected (room, ocgCore, duelEvents), skipping the OCGCore-heavy
+ * constructor — same technique as YGOProDuelingStateEvrp.test.ts.
+ */
+import { DuelEventDispatcher } from "@shared/room/domain/duel-events/DuelEventDispatcher";
+
+import { YGOProDuelingState } from "./YGOProDuelingState";
+
+type TestableDuelingState = {
+	publishLpEvent(
+		kind: "duel.damage" | "duel.recover" | "duel.lp-cost",
+		player: number,
+		amount: number,
+	): void;
+	publishTurnStart(player: number): void;
+};
+
+function buildState(overrides: Record<string, unknown> = {}): {
+	state: TestableDuelingState;
+	dispatch: jest.Mock;
+	room: object;
+} {
+	const dispatch = jest.fn();
+	const room = { id: 7, turn: 3, isTag: false, ...overrides };
+	const state = Object.create(YGOProDuelingState.prototype) as Record<string, unknown>;
+	state.room = room;
+	// Non-tag team resolution goes through the core's side mapping.
+	state.ocgCore = { getSideTeam: (side: number) => side ^ 1 };
+	state.duelEvents = { dispatch } as unknown as DuelEventDispatcher;
+
+	return { state: state as unknown as TestableDuelingState, dispatch, room };
+}
+
+describe("YGOProDuelingState duel-event publishers", () => {
+	it("publishes an LP event with the core-resolved team and current turn", () => {
+		const { state, dispatch, room } = buildState();
+
+		state.publishLpEvent("duel.damage", 1, 1000);
+
+		expect(dispatch).toHaveBeenCalledWith(
+			"duel.damage",
+			{ roomId: 7, team: 0, amount: 1000, turn: 3 },
+			room,
+		);
+	});
+
+	it("resolves the team as the raw side in tag rooms", () => {
+		const { state, dispatch } = buildState({ isTag: true });
+
+		state.publishLpEvent("duel.lp-cost", 1, 800);
+
+		expect(dispatch).toHaveBeenCalledWith(
+			"duel.lp-cost",
+			expect.objectContaining({ team: 1, amount: 800 }),
+			expect.anything(),
+		);
+	});
+
+	// On this pipeline the room counter has already incremented when the state's
+	// NEW_TURN middleware runs, so the current value IS the started turn —
+	// matching the EDOPro pipeline's room.turn + 1.
+	it("publishes turn-start with the started turn number and raw player", () => {
+		const { state, dispatch, room } = buildState();
+
+		state.publishTurnStart(1);
+
+		expect(dispatch).toHaveBeenCalledWith(
+			"duel.turn-start",
+			{ roomId: 7, player: 1, turn: 3 },
+			room,
+		);
+	});
+});


### PR DESCRIPTION
## Description / Descripción

**duel-events 4/4** — the series closes: the ygopro pipeline publishes the same duel events as EDOPro, and the first consumer plugin ships against the surface.

### ygopro wiring

`YGOProDuelingState`'s four ocgcore middleware handlers (`NewTurn`, `Damage`, `Recover`, `PayLpCost`) now publish through the same dispatcher the EDOPro pipeline uses, via small publishers (`publishLpEvent`, `publishTurnStart`) that build events with the shared `build*` constructors and this pipeline's own team resolution (`resolveTeam`: raw side in tag, core side-mapping otherwise).

**The double-apply trap, closed:** `YGOProRoomState` overrides `registerDuelEventSubscribers` with a documented no-op. This pipeline applies LP/turn mutations in its ocgcore middleware — inheriting the EDOPro internal subscribers would apply every mutation twice and double-broadcast. Pinned by test: dispatching on a ygopro state's dispatcher calls no `decreaseLps`, no WebSocket broadcast, and still delivers to hub-registered plugins.

### Turn semantics, unified

`TurnStartedEvent.turn` = the number of the turn that just started, on both pipelines:

- EDOPro builds it as `room.turn + 1` (its counter increments in the internal subscriber, after the event is built);
- ygopro uses `room.turn` directly (its counter already incremented — `ocgcore.ts` registers `increaseTurn` first).

Both pipelines share `YgoRoom.STARTING_TURN = 0` and the same `Duel` entity, so the numbers agree. Without this, a plugin's per-turn stats would differ by one depending on room type — the exact cross-pipeline divergence this series set out to prevent.

### First consumer: `big-damage-log`

Always enabled, declares `duel.damage` only, logs any single hit of **5000+ LP** with room, team and turn — and never touches the event bus. Deliberately stateless: `GameOverDomainEvent` carries no `roomId`, so per-duel aggregation has no end-of-room signal to key on yet (noted as the natural next event if aggregation is wanted).

### Gate: identical on both room types

The plugin consumes only the unified event payloads. Equivalence is pinned in layers: `build*` ≡ `decode*` for the same logical event (1/4), team resolution injected per pipeline (1/4), turn semantics unified here, and delivery through one hub regardless of which pipeline dispatched (3/4). The ygopro publishers are tested on prototype instances (same technique as `YGOProDuelingStateEvrp.test.ts`); the middleware closures that call them are the one untested seam, noted honestly.

### TDD

Red-first: 1 turn-semantics test (EDOPro), 2 override tests (ygopro), 3 publisher tests (ygopro), 6 plugin tests. Roster test updated: with ranking disabled the loaded list is now `["big-damage-log"]`.

## Related Issue(s) / Issue(s) relacionado(s)

Closes the series: #329 (1/4), #331 (2/4), #332 (3/4).

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [x] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

- Full suite: **138 suites / 1281 tests** green; `tsc --noEmit` and `biome ci` clean.
- `.gitignore` whitelist gains `!src/plugins/big-damage-log/`.
