### PR TITLE
feat(room): give every duel a stable uuid identity carried by duel events

### DIFF
--- a/src/bootstrap/bootstrapPlugins.test.ts
+++ b/src/bootstrap/bootstrapPlugins.test.ts
@@ -124,10 +124,16 @@ describe("bootstrapPlugins", () => {
 
 			const dispatcher = new DuelEventDispatcher();
 			DuelEventPluginHub.getInstance().attach(dispatcher);
-			dispatcher.dispatch("duel.damage", { roomId: 7, team: 0, amount: 1000, turn: 1 }, room);
+			dispatcher.dispatch(
+				"duel.damage",
+				{ roomId: 7, duelId: "d-1", team: 0, amount: 1000, turn: 1 },
+				room,
+			);
 			await new Promise((resolve) => setImmediate(resolve));
 
-			expect(receivedEvents).toEqual([{ roomId: 7, team: 0, amount: 1000, turn: 1 }]);
+			expect(receivedEvents).toEqual([
+				{ roomId: 7, duelId: "d-1", team: 0, amount: 1000, turn: 1 },
+			]);
 		});
 
 		it("fails a plugin that subscribes to a kind it did not declare", async () => {

--- a/src/edopro/room/domain/RoomState.ts
+++ b/src/edopro/room/domain/RoomState.ts
@@ -105,6 +105,7 @@ export abstract class RoomState {
 		// subscribers registered by registerDuelEventSubscribers.
 		const ctx: DuelEventContext = {
 			roomId: room.id,
+			duelId: room.duelId,
 			turn: room.turn,
 			resolveTeam: (player: number) => room.firstToPlay ^ player,
 		};

--- a/src/edopro/room/domain/RoomStateProcessDuelMessage.test.ts
+++ b/src/edopro/room/domain/RoomStateProcessDuelMessage.test.ts
@@ -48,6 +48,7 @@ const lpPayload = (type: number, player: number, amount: number): Buffer => {
 const makeRoom = (firstToPlay: number) =>
 	({
 		id: 7,
+		duelId: "duel-uuid-1",
 		firstToPlay,
 		turn: 2,
 		decreaseLps: jest.fn(),
@@ -142,7 +143,9 @@ describe("RoomState.processDuelMessage", () => {
 			expect(received).toEqual([]);
 			await new Promise((resolve) => setImmediate(resolve));
 
-			expect(received).toEqual([{ roomId: 7, team: 1, amount: 1000, turn: 2 }]);
+			expect(received).toEqual([
+				{ roomId: 7, duelId: "duel-uuid-1", team: 1, amount: 1000, turn: 2 },
+			]);
 		});
 
 		// TurnStartedEvent.turn is the number of the turn that just started. The
@@ -160,7 +163,7 @@ describe("RoomState.processDuelMessage", () => {
 			pluginState.run(CoreMessages.MSG_NEW_TURN, Buffer.from([CoreMessages.MSG_NEW_TURN, 1]), room);
 			await new Promise((resolve) => setImmediate(resolve));
 
-			expect(received).toEqual([{ roomId: 7, player: 1, turn: 3 }]);
+			expect(received).toEqual([{ roomId: 7, duelId: "duel-uuid-1", player: 1, turn: 3 }]);
 		});
 	});
 });

--- a/src/plugins/big-damage-log/index.test.ts
+++ b/src/plugins/big-damage-log/index.test.ts
@@ -24,7 +24,13 @@ function makeDeps(): {
 	return { deps: { logger, config: {} as AppConfig, duelEvents }, handlers, logger };
 }
 
-const damage = (amount: number): DamageDealtEvent => ({ roomId: 7, team: 1, amount, turn: 3 });
+const damage = (amount: number): DamageDealtEvent => ({
+	roomId: 7,
+	duelId: "d-1",
+	team: 1,
+	amount,
+	turn: 3,
+});
 
 describe("big-damage-log plugin", () => {
 	it("conforms to the ServerPlugin contract", () => {

--- a/src/shared/room/Duel.test.ts
+++ b/src/shared/room/Duel.test.ts
@@ -14,6 +14,16 @@ describe("Duel", () => {
 			expect(duel.isFinished).toBe(false);
 		});
 
+		it("assigns each duel a unique uuid identity", () => {
+			const first = new Duel(0, [8000, 8000], null);
+			const second = new Duel(0, [8000, 8000], null);
+
+			expect(first.duelId).toMatch(
+				/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+			);
+			expect(second.duelId).not.toBe(first.duelId);
+		});
+
 		it("should handle null ban list name", () => {
 			duel = new Duel(1, [8000, 8000], null);
 

--- a/src/shared/room/Duel.ts
+++ b/src/shared/room/Duel.ts
@@ -1,6 +1,16 @@
+import { randomUUID } from "crypto";
+
 import { Team } from "./Team";
 
 export class Duel {
+	/**
+	 * Stable identity of this single game. Room ids are 4-digit randoms that
+	 * collide and get reused, and the turn counter resets per game — so
+	 * (duelId, turn) is the only unambiguous key for anything that happens
+	 * inside a duel.
+	 */
+	readonly duelId: string = randomUUID();
+
 	private _turn: number;
 	private readonly _lps: [number, number];
 	private readonly _banListName: string;

--- a/src/shared/room/domain/YgoRoom.ts
+++ b/src/shared/room/domain/YgoRoom.ts
@@ -303,6 +303,11 @@ export abstract class YgoRoom {
 		return this.currentDuel?.turn ?? 0;
 	}
 
+	// Empty only outside a duel; duel events are only built mid-duel.
+	get duelId(): string {
+		return this.currentDuel?.duelId ?? "";
+	}
+
 	get firstToPlay(): number {
 		return this._firstToPlay;
 	}

--- a/src/shared/room/domain/duel-events/DuelEventDecoders.test.ts
+++ b/src/shared/room/domain/duel-events/DuelEventDecoders.test.ts
@@ -34,6 +34,7 @@ import { DUEL_EVENT_KINDS } from "./DuelEvents";
 // injected, never assumed.
 const xorCtx = (firstToPlay: number): DuelEventContext => ({
 	roomId: 42,
+	duelId: "duel-uuid-1",
 	turn: 3,
 	resolveTeam: (player: number) => firstToPlay ^ player,
 });
@@ -65,7 +66,7 @@ describe("decodeDamageDealt", () => {
 		// [0x5b, 0x01, e8 03 00 00] — player 1 takes 1000
 		const event = decodeDamageDealt(wire.damage(1, 1000), xorCtx(0));
 
-		expect(event).toEqual({ roomId: 42, team: 1, amount: 1000, turn: 3 });
+		expect(event).toEqual({ roomId: 42, duelId: "duel-uuid-1", team: 1, amount: 1000, turn: 3 });
 	});
 
 	it("applies the injected team mapping (firstToPlay = 1 flips the team)", () => {
@@ -83,7 +84,7 @@ describe("decodeLifeRecovered", () => {
 	it("decodes a classic-encoded MSG_RECOVER payload", () => {
 		const event = decodeLifeRecovered(wire.recover(0, 500), xorCtx(0));
 
-		expect(event).toEqual({ roomId: 42, team: 0, amount: 500, turn: 3 });
+		expect(event).toEqual({ roomId: 42, duelId: "duel-uuid-1", team: 0, amount: 500, turn: 3 });
 	});
 
 	it("rejects a mismatched type byte", () => {
@@ -95,7 +96,7 @@ describe("decodeLpCostPaid", () => {
 	it("decodes a classic-encoded MSG_PAY_LPCOST payload", () => {
 		const event = decodeLpCostPaid(wire.lpCost(1, 800), xorCtx(0));
 
-		expect(event).toEqual({ roomId: 42, team: 1, amount: 800, turn: 3 });
+		expect(event).toEqual({ roomId: 42, duelId: "duel-uuid-1", team: 1, amount: 800, turn: 3 });
 	});
 
 	it("rejects a mismatched type byte", () => {
@@ -110,7 +111,7 @@ describe("decodeTurnStarted", () => {
 		// resolution differs per pipeline and is not this event's business.
 		const event = decodeTurnStarted(wire.newTurn(1), xorCtx(0));
 
-		expect(event).toEqual({ roomId: 42, player: 1, turn: 3 });
+		expect(event).toEqual({ roomId: 42, duelId: "duel-uuid-1", player: 1, turn: 3 });
 	});
 
 	it("rejects a mismatched type byte", () => {

--- a/src/shared/room/domain/duel-events/DuelEventDecoders.ts
+++ b/src/shared/room/domain/duel-events/DuelEventDecoders.ts
@@ -25,6 +25,7 @@ import {
 
 export interface DuelEventContext {
 	readonly roomId: number;
+	readonly duelId: string;
 	readonly turn: number;
 	readonly resolveTeam: (player: number) => number;
 }
@@ -53,6 +54,7 @@ function readLpWire(data: Buffer): LpWire {
 export function buildDamageDealt(wire: LpWire, ctx: DuelEventContext): DamageDealtEvent {
 	return {
 		roomId: ctx.roomId,
+		duelId: ctx.duelId,
 		team: ctx.resolveTeam(wire.player),
 		amount: wire.amount,
 		turn: ctx.turn,
@@ -71,7 +73,7 @@ export function buildTurnStarted(
 	wire: { readonly player: number },
 	ctx: DuelEventContext,
 ): TurnStartedEvent {
-	return { roomId: ctx.roomId, player: wire.player, turn: ctx.turn };
+	return { roomId: ctx.roomId, duelId: ctx.duelId, player: wire.player, turn: ctx.turn };
 }
 
 export function decodeDamageDealt(data: Buffer, ctx: DuelEventContext): DamageDealtEvent {

--- a/src/shared/room/domain/duel-events/DuelEventDispatcher.test.ts
+++ b/src/shared/room/domain/duel-events/DuelEventDispatcher.test.ts
@@ -2,8 +2,8 @@ import { YgoRoom } from "../YgoRoom";
 import { DuelEventDispatcher } from "./DuelEventDispatcher";
 import { DamageDealtEvent, TurnStartedEvent } from "./DuelEvents";
 
-const damage: DamageDealtEvent = { roomId: 7, team: 1, amount: 1000, turn: 2 };
-const turnStart: TurnStartedEvent = { roomId: 7, player: 0, turn: 3 };
+const damage: DamageDealtEvent = { roomId: 7, duelId: "d-1", team: 1, amount: 1000, turn: 2 };
+const turnStart: TurnStartedEvent = { roomId: 7, duelId: "d-1", player: 0, turn: 3 };
 const room = { id: 7 } as unknown as YgoRoom;
 
 describe("DuelEventDispatcher", () => {

--- a/src/shared/room/domain/duel-events/DuelEventPluginHub.test.ts
+++ b/src/shared/room/domain/duel-events/DuelEventPluginHub.test.ts
@@ -6,7 +6,13 @@ import { DuelEventPluginHub } from "./DuelEventPluginHub";
 import { DamageDealtEvent } from "./DuelEvents";
 
 const room = { id: 7 } as unknown as YgoRoom;
-const damage = (amount: number): DamageDealtEvent => ({ roomId: 7, team: 0, amount, turn: 1 });
+const damage = (amount: number): DamageDealtEvent => ({
+	roomId: 7,
+	duelId: "d-1",
+	team: 0,
+	amount,
+	turn: 1,
+});
 
 // Queue drains run on microtasks (and async handlers add real ticks); flush
 // both before asserting.
@@ -192,7 +198,11 @@ describe("DuelEventPluginHub", () => {
 		dispatcher.dispatch("duel.damage", damage(1), room);
 		await flush();
 		dispatcher.dispatch("duel.damage", damage(2), room);
-		otherDispatcher.dispatch("duel.damage", { roomId: 8, team: 0, amount: 3, turn: 1 }, otherRoom);
+		otherDispatcher.dispatch(
+			"duel.damage",
+			{ roomId: 8, duelId: "d-2", team: 0, amount: 3, turn: 1 },
+			otherRoom,
+		);
 		await flush();
 
 		expect(seen).toEqual([1, 3]);

--- a/src/shared/room/domain/duel-events/DuelEvents.ts
+++ b/src/shared/room/domain/duel-events/DuelEvents.ts
@@ -19,6 +19,8 @@ export type DuelEventKind = (typeof DUEL_EVENT_KINDS)[number];
 /** A player's team took battle or effect damage. */
 export interface DamageDealtEvent {
 	readonly roomId: number;
+	/** Stable uuid of the single game this happened in — see Duel.duelId. */
+	readonly duelId: string;
 	readonly team: number;
 	readonly amount: number;
 	readonly turn: number;
@@ -27,6 +29,8 @@ export interface DamageDealtEvent {
 /** A player's team recovered life points. */
 export interface LifeRecoveredEvent {
 	readonly roomId: number;
+	/** Stable uuid of the single game this happened in — see Duel.duelId. */
+	readonly duelId: string;
 	readonly team: number;
 	readonly amount: number;
 	readonly turn: number;
@@ -35,6 +39,8 @@ export interface LifeRecoveredEvent {
 /** A player's team paid life points as a cost. */
 export interface LpCostPaidEvent {
 	readonly roomId: number;
+	/** Stable uuid of the single game this happened in — see Duel.duelId. */
+	readonly duelId: string;
 	readonly team: number;
 	readonly amount: number;
 	readonly turn: number;
@@ -49,6 +55,8 @@ export interface LpCostPaidEvent {
  */
 export interface TurnStartedEvent {
 	readonly roomId: number;
+	/** Stable uuid of the single game this happened in — see Duel.duelId. */
+	readonly duelId: string;
 	readonly player: number;
 	readonly turn: number;
 }

--- a/src/ygopro/room/domain/YGOProRoomStateDuelEvents.test.ts
+++ b/src/ygopro/room/domain/YGOProRoomStateDuelEvents.test.ts
@@ -43,7 +43,7 @@ describe("YGOProRoomState duel-event dispatcher", () => {
 		DuelEventPluginHub.resetInstance();
 	});
 
-	const damage: DamageDealtEvent = { roomId: 7, team: 1, amount: 1000, turn: 2 };
+	const damage: DamageDealtEvent = { roomId: 7, duelId: "d-1", team: 1, amount: 1000, turn: 2 };
 
 	it("does not run the EDOPro internal subscribers (no double LP mutation, no broadcast)", () => {
 		const state = new TestYgoState(new EventEmitter());

--- a/src/ygopro/room/domain/states/YGOProDuelingState.ts
+++ b/src/ygopro/room/domain/states/YGOProDuelingState.ts
@@ -689,6 +689,7 @@ export class YGOProDuelingState extends RoomState {
 	private duelEventContext(): DuelEventContext {
 		return {
 			roomId: this.room.id,
+			duelId: this.room.duelId,
 			turn: this.room.turn,
 			resolveTeam: (player: number) => this.resolveTeam(player),
 		};

--- a/src/ygopro/room/domain/states/YGOProDuelingStateDuelEvents.test.ts
+++ b/src/ygopro/room/domain/states/YGOProDuelingStateDuelEvents.test.ts
@@ -24,7 +24,7 @@ function buildState(overrides: Record<string, unknown> = {}): {
 	room: object;
 } {
 	const dispatch = jest.fn();
-	const room = { id: 7, turn: 3, isTag: false, ...overrides };
+	const room = { id: 7, duelId: "duel-uuid-1", turn: 3, isTag: false, ...overrides };
 	const state = Object.create(YGOProDuelingState.prototype) as Record<string, unknown>;
 	state.room = room;
 	// Non-tag team resolution goes through the core's side mapping.
@@ -42,7 +42,7 @@ describe("YGOProDuelingState duel-event publishers", () => {
 
 		expect(dispatch).toHaveBeenCalledWith(
 			"duel.damage",
-			{ roomId: 7, team: 0, amount: 1000, turn: 3 },
+			{ roomId: 7, duelId: "duel-uuid-1", team: 0, amount: 1000, turn: 3 },
 			room,
 		);
 	});
@@ -69,7 +69,7 @@ describe("YGOProDuelingState duel-event publishers", () => {
 
 		expect(dispatch).toHaveBeenCalledWith(
 			"duel.turn-start",
-			{ roomId: 7, player: 1, turn: 3 },
+			{ roomId: 7, duelId: "duel-uuid-1", player: 1, turn: 3 },
 			room,
 		);
 	});


### PR DESCRIPTION
## Description / Descripción

Every duel now has a stable uuid identity, and every duel event carries it.

**The problem:** `roomId` — the only identity duel events carried — comes from `generateUniqueId()`, a 4-digit `randomInt(1000, 9999)` with no liveness check. It can collide across concurrent rooms (~5% at 30 live rooms, ~50% at ~112) and is guaranteed to be reused within a day. On top of that, the turn counter resets per game, so `(roomId, turn)` repeats inside a best-of-3: turn 4 of game 1 and turn 4 of game 3 are indistinguishable.

**The change:**

- `Duel` assigns itself a `duelId` (`crypto.randomUUID()`) at construction — one birth site, shared by both pipelines, one uuid per game of a match.
- `YgoRoom.duelId` exposes the current duel's id (empty only outside a duel; duel events are only built mid-duel).
- `DuelEventContext` and all four event payloads gain `duelId`. Both context sites (EDOPro `RoomState.processDuelMessage`, ygopro `YGOProDuelingState.duelEventContext`) read it from the room.

`(duelId, turn)` is now the first unambiguous key for anything that happens inside a duel. The field is additive — `big-damage-log` needs no logic change.

**Deliberately out of scope:** an end-of-duel signal (`duel.finished`, or `GameOverDomainEvent` enriched with `roomId`/`duelIds`). `duelId` gives aggregating consumers the correct key; the flush signal is a separate slice, worth building when a consumer actually aggregates.

### Test honesty note

Several existing tests matched event payloads without `duelId` and kept passing after the field was added — `toEqual` ignores `undefined` properties, so a room mock without `duelId` produced events whose missing field matched silently. Those assertions now pin `duelId` explicitly.

## Related Issue(s) / Issue(s) relacionado(s)

Follow-up to the duel-events series (#329, #331, #332, #333); addresses the room-id weakness surfaced while reviewing how events identify their room.

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [x] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

- Full suite: **138 suites / 1282 tests** green; `tsc --noEmit` and `biome ci` clean.
- `generateUniqueId()` itself is left untouched: fixing room-id collisions is a separate concern (liveness check against the room lists), and duel events no longer depend on it for identity.
