### PR TITLE
feat(room): carry real match identity in GAME_OVER and persist real duelIds

### DIFF
--- a/src/bootstrap/bootstrapPlugins.realPlugins.test.ts
+++ b/src/bootstrap/bootstrapPlugins.realPlugins.test.ts
@@ -62,6 +62,9 @@ describe("bootstrapPlugins against the real src/plugins directory", () => {
 		await bus.publish(
 			GameOverDomainEvent.DOMAIN_EVENT,
 			new GameOverDomainEvent({
+				roomId: 7,
+				matchId: "match-uuid-1",
+				duelIds: ["duel-uuid-1"],
 				ranked: false,
 				players: [],
 				bestOf: 1,

--- a/src/edopro/room/application/FinishDuelHandler.test.ts
+++ b/src/edopro/room/application/FinishDuelHandler.test.ts
@@ -154,6 +154,8 @@ describe("FinishDuelHandler", () => {
 		Object.defineProperty(mockRoom, "bestOf", { value: 3 });
 		Object.defineProperty(mockRoom, "banListHash", { value: 123 });
 		Object.defineProperty(mockRoom, "ranked", { value: true });
+		Object.defineProperty(mockRoom, "matchId", { value: "match-uuid-1" });
+		Object.defineProperty(mockRoom, "duelIds", { value: ["duel-uuid-1"] });
 
 		await handler.run();
 

--- a/src/edopro/room/application/FinishDuelHandler.ts
+++ b/src/edopro/room/application/FinishDuelHandler.ts
@@ -101,6 +101,9 @@ export class FinishDuelHandler {
 			void this.eventBus.publish(
 				GameOverDomainEvent.DOMAIN_EVENT,
 				new GameOverDomainEvent({
+					roomId: this.room.id,
+					matchId: this.room.matchId,
+					duelIds: [...this.room.duelIds],
 					bestOf: this.room.bestOf,
 					players: this.room.matchPlayersHistory,
 					date: new Date(),

--- a/src/plugins/basic-stats/application/BasicStatsCalculator.test.ts
+++ b/src/plugins/basic-stats/application/BasicStatsCalculator.test.ts
@@ -136,6 +136,21 @@ describe("BasicStatsCalculator", () => {
 		expect(playerStatsRepository.save).toHaveBeenNthCalledWith(2, PlayerStats.from(opponentStats));
 	});
 
+	it("uses the event's matchId as the persisted gameId instead of inventing one", async () => {
+		const event = GameOverDomainEventMother.create({
+			players: [player.toPresentation(), opponent.toPresentation()],
+			ranked: true,
+			banListName: "N/A",
+			matchId: "match-uuid-1",
+		});
+
+		await basicStatsCalculator.handle(event);
+
+		expect(matchResumeCreator.run).toHaveBeenCalledWith(
+			expect.objectContaining({ gameId: "match-uuid-1" }),
+		);
+	});
+
 	it("Should use banListName from event data (not from hash lookup) for per-format rank", async () => {
 		const edisonBanListName = "2010.03 Edison";
 		playerStatsRepository.findByUserIdAndBanListName

--- a/src/plugins/basic-stats/application/BasicStatsCalculator.ts
+++ b/src/plugins/basic-stats/application/BasicStatsCalculator.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import { Logger } from "src/shared/logger/domain/Logger";
 import { Player } from "src/shared/player/domain/Player";
 import { UserProfileRepository } from "src/shared/user-profile/domain/UserProfileRepository";
@@ -37,7 +36,7 @@ export class BasicStatsCalculator implements DomainEventSubscriber<GameOverDomai
 		const banListName = event.data.banListName;
 		const players = event.data.players.map((item) => new Player(item));
 
-		const gameId = randomUUID();
+		const gameId = event.data.matchId;
 
 		for (const player of players) {
 			const userProfile = await this.userProfileRepository.findByUsername(player.name);

--- a/src/plugins/unranked-match/application/UnrankedMatchSaver.test.ts
+++ b/src/plugins/unranked-match/application/UnrankedMatchSaver.test.ts
@@ -5,6 +5,7 @@ import { UnrankedMatchSaver } from "./UnrankedMatchSaver";
 import { GameOverDomainEvent } from "src/shared/room/domain/match/domain/domain-events/GameOverDomainEvent";
 import { Team } from "src/shared/room/Team";
 import { PlayerMatchSummary } from "src/shared/player/domain/Player";
+import { PlayerMother } from "@test-support/mothers/player/PlayerMother";
 
 describe("UnrankedMatchSaver", () => {
 	let logger: MockProxy<Logger>;
@@ -20,6 +21,9 @@ describe("UnrankedMatchSaver", () => {
 
 	it("should NOT save if match is ranked", async () => {
 		const event = new GameOverDomainEvent({
+			roomId: 7,
+			matchId: "match-uuid-1",
+			duelIds: ["duel-uuid-1"],
 			ranked: true,
 			players: [],
 			bestOf: 1,
@@ -66,6 +70,9 @@ describe("UnrankedMatchSaver", () => {
 		};
 
 		const event = new GameOverDomainEvent({
+			roomId: 7,
+			matchId: "match-uuid-1",
+			duelIds: ["duel-uuid-1"],
 			ranked: false,
 			players: [playerTeam0, playerTeam1],
 			bestOf: 1,
@@ -105,6 +112,9 @@ describe("UnrankedMatchSaver", () => {
 		};
 
 		const event = new GameOverDomainEvent({
+			roomId: 7,
+			matchId: "match-uuid-1",
+			duelIds: ["duel-uuid-1"],
 			ranked: false,
 			players: [playerTeam0],
 			bestOf: 1,
@@ -116,5 +126,28 @@ describe("UnrankedMatchSaver", () => {
 		await unrankedMatchSaver.handle(event);
 
 		expect(unrankedMatchRepository.saveMatch).not.toHaveBeenCalled();
+	});
+
+	it("uses the event's matchId as the persisted gameId instead of inventing one", async () => {
+		const event = new GameOverDomainEvent({
+			ranked: false,
+			players: [
+				PlayerMother.create({ team: Team.PLAYER }).toPresentation(),
+				PlayerMother.create({ team: Team.OPPONENT }).toPresentation(),
+			],
+			bestOf: 1,
+			date: new Date(),
+			banListHash: 123,
+			banListName: "N/A",
+			roomId: 7,
+			matchId: "match-uuid-1",
+			duelIds: ["duel-uuid-1"],
+		});
+
+		await unrankedMatchSaver.handle(event);
+
+		expect(unrankedMatchRepository.saveMatch).toHaveBeenCalledWith(
+			expect.objectContaining({ gameId: "match-uuid-1" }),
+		);
 	});
 });

--- a/src/plugins/unranked-match/application/UnrankedMatchSaver.test.ts
+++ b/src/plugins/unranked-match/application/UnrankedMatchSaver.test.ts
@@ -6,6 +6,7 @@ import { GameOverDomainEvent } from "src/shared/room/domain/match/domain/domain-
 import { Team } from "src/shared/room/Team";
 import { PlayerMatchSummary } from "src/shared/player/domain/Player";
 import { PlayerMother } from "@test-support/mothers/player/PlayerMother";
+import { GameMother } from "@test-support/mothers/player/GameMother";
 
 describe("UnrankedMatchSaver", () => {
 	let logger: MockProxy<Logger>;
@@ -149,5 +150,66 @@ describe("UnrankedMatchSaver", () => {
 		expect(unrankedMatchRepository.saveMatch).toHaveBeenCalledWith(
 			expect.objectContaining({ gameId: "match-uuid-1" }),
 		);
+	});
+
+	it("persists each duel row under its real duelId when the event carries one per game", async () => {
+		const event = new GameOverDomainEvent({
+			ranked: false,
+			players: [
+				PlayerMother.create({
+					team: Team.PLAYER,
+					games: [GameMother.create(), GameMother.create()],
+				}).toPresentation(),
+				PlayerMother.create({ team: Team.OPPONENT }).toPresentation(),
+			],
+			bestOf: 3,
+			date: new Date(),
+			banListHash: 123,
+			banListName: "N/A",
+			roomId: 7,
+			matchId: "match-uuid-1",
+			duelIds: ["duel-uuid-1", "duel-uuid-2"],
+		});
+
+		await unrankedMatchSaver.handle(event);
+
+		expect(unrankedMatchRepository.saveDuel).toHaveBeenCalledTimes(2);
+		expect(unrankedMatchRepository.saveDuel).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({ id: "duel-uuid-1" }),
+		);
+		expect(unrankedMatchRepository.saveDuel).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({ id: "duel-uuid-2" }),
+		);
+	});
+
+	it("falls back to a random id and warns when duelIds do not match the games count", async () => {
+		const event = new GameOverDomainEvent({
+			ranked: false,
+			players: [
+				PlayerMother.create({
+					team: Team.PLAYER,
+					games: [GameMother.create(), GameMother.create()],
+				}).toPresentation(),
+				PlayerMother.create({ team: Team.OPPONENT }).toPresentation(),
+			],
+			bestOf: 3,
+			date: new Date(),
+			banListHash: 123,
+			banListName: "N/A",
+			roomId: 7,
+			matchId: "match-uuid-1",
+			duelIds: ["duel-uuid-1"],
+		});
+
+		await unrankedMatchSaver.handle(event);
+
+		expect(unrankedMatchRepository.saveDuel).toHaveBeenCalledTimes(2);
+		const savedIds = unrankedMatchRepository.saveDuel.mock.calls.map(
+			([duel]) => (duel as { id: string }).id,
+		);
+		expect(savedIds).not.toContain("duel-uuid-1");
+		expect(logger.warn).toHaveBeenCalled();
 	});
 });

--- a/src/plugins/unranked-match/application/UnrankedMatchSaver.ts
+++ b/src/plugins/unranked-match/application/UnrankedMatchSaver.ts
@@ -60,9 +60,21 @@ export class UnrankedMatchSaver implements DomainEventSubscriber<GameOverDomainE
 		await this.unrankedMatchRepository.saveMatch(unrankedMatch);
 		this.logger.info(`Unranked match saved: ${matchId}`);
 
-		for (const game of referencePlayer.games) {
+		// unranked_duels rows are one per game, so the row id IS the duel: use the
+		// real duelId when the event carries one per game. A count mismatch means
+		// the ids can no longer be matched to games by position — fall back to
+		// random ids rather than guessing, and say so.
+		const duelIds = event.data.duelIds;
+		const idsMatchGames = duelIds.length === referencePlayer.games.length;
+		if (!idsMatchGames) {
+			this.logger.warn(
+				`duelIds count (${duelIds.length}) does not match games count (${referencePlayer.games.length}) — persisting unranked duels under random ids`,
+			);
+		}
+
+		for (const [index, game] of referencePlayer.games.entries()) {
 			const unrankedDuel = UnrankedDuel.create({
-				id: randomUUID(),
+				id: idsMatchGames ? duelIds[index] : randomUUID(),
 				gameId: gameId,
 				date: event.data.date,
 				banListName,

--- a/src/plugins/unranked-match/application/UnrankedMatchSaver.ts
+++ b/src/plugins/unranked-match/application/UnrankedMatchSaver.ts
@@ -34,7 +34,7 @@ export class UnrankedMatchSaver implements DomainEventSubscriber<GameOverDomainE
 			`Processing unranked match: Team 0 (${team0Players.map((p) => p.name).join(", ")}) vs Team 1 (${team1Players.map((p) => p.name).join(", ")})`,
 		);
 
-		const gameId = randomUUID();
+		const gameId = event.data.matchId;
 		const banListName = event.data.banListName;
 		const banListHash = event.data.banListHash.toString();
 

--- a/src/shared/room/domain/YgoRoom.test.ts
+++ b/src/shared/room/domain/YgoRoom.test.ts
@@ -69,4 +69,45 @@ describe("YgoRoom", () => {
 			expect(room.players[1]).toBe(c2);
 		});
 	});
+
+	describe("match identity", () => {
+		const flushMutex = () => new Promise((resolve) => setTimeout(resolve, 10));
+
+		it("assigns a fresh matchId per match", () => {
+			const room = SimpleRoomMother.create();
+			const initial = room.matchId;
+
+			room.createMatchUnsafe();
+			const first = room.matchId;
+			room.createMatchUnsafe();
+
+			expect(first).toMatch(/^[0-9a-f-]{36}$/);
+			expect(first).not.toBe(initial);
+			expect(room.matchId).not.toBe(first);
+		});
+
+		it("accumulates the duelIds of every game in match order", async () => {
+			const room = SimpleRoomMother.create();
+			room.createMatchUnsafe();
+
+			room.createDuel(null);
+			await flushMutex();
+			const firstDuelId = room.duelId;
+			room.createDuel(null);
+			await flushMutex();
+
+			expect(room.duelIds).toEqual([firstDuelId, room.duelId]);
+		});
+
+		it("resets the duelIds when a new match starts", async () => {
+			const room = SimpleRoomMother.create();
+			room.createMatchUnsafe();
+			room.createDuel(null);
+			await flushMutex();
+
+			room.createMatchUnsafe();
+
+			expect(room.duelIds).toEqual([]);
+		});
+	});
 });

--- a/src/shared/room/domain/YgoRoom.ts
+++ b/src/shared/room/domain/YgoRoom.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import { PlayerData } from "@shared/player/domain/PlayerData";
 import { Duel } from "@shared/room/Duel";
 import { Team } from "@shared/room/Team";
@@ -81,6 +83,10 @@ export abstract class YgoRoom {
 	protected _clientWhoChoosesTurn: YgoClient;
 	protected _match: Match | null;
 	protected _firstToPlay: number;
+	// A room always has a match identity, refreshed by createMatchUnsafe; the
+	// field initializer covers rooms whose flow never calls it explicitly.
+	private _matchId: string = randomUUID();
+	private _duelIds: string[] = [];
 	protected isStart: string;
 	protected currentDuel: Duel | null = null;
 
@@ -230,6 +236,8 @@ export abstract class YgoRoom {
 
 	createMatchUnsafe(): void {
 		this._match = new Match({ bestOf: this.bestOf });
+		this._matchId = randomUUID();
+		this._duelIds = [];
 		this.initializeHistoricalData();
 	}
 
@@ -276,6 +284,7 @@ export abstract class YgoRoom {
 	createDuel(banListName: string | null): void {
 		this.mutex.runExclusive(() => {
 			this.currentDuel = new Duel(this.STARTING_TURN, [this.startLp, this.startLp], banListName);
+			this._duelIds.push(this.currentDuel.duelId);
 		});
 	}
 
@@ -306,6 +315,15 @@ export abstract class YgoRoom {
 	// Empty only outside a duel; duel events are only built mid-duel.
 	get duelId(): string {
 		return this.currentDuel?.duelId ?? "";
+	}
+
+	get matchId(): string {
+		return this._matchId;
+	}
+
+	/** duelIds of every game of the current match, in the order they were played. */
+	get duelIds(): readonly string[] {
+		return this._duelIds;
 	}
 
 	get firstToPlay(): number {

--- a/src/shared/room/domain/match/domain/domain-events/GameOverDomainEvent.ts
+++ b/src/shared/room/domain/match/domain/domain-events/GameOverDomainEvent.ts
@@ -1,6 +1,12 @@
 import { PlayerMatchSummary } from "src/shared/player/domain/Player";
 
 export type GameOverData = {
+	/** Room the match was played in. 4-digit id: unique enough to correlate logs, not to key storage. */
+	roomId: number;
+	/** Stable uuid of the match, assigned when the match is created. */
+	matchId: string;
+	/** duelIds of every game of the match, in the order they were played. */
+	duelIds: string[];
 	bestOf: number;
 	date: Date;
 	players: PlayerMatchSummary[];

--- a/src/test-support/mothers/player/GameOverDomainEventMother.ts
+++ b/src/test-support/mothers/player/GameOverDomainEventMother.ts
@@ -9,6 +9,9 @@ import { PlayerMother } from "./PlayerMother";
 export class GameOverDomainEventMother {
 	static create(params?: Partial<GameOverData>): GameOverDomainEvent {
 		return new GameOverDomainEvent({
+			roomId: faker.number.int({ min: 1000, max: 9999 }),
+			matchId: faker.string.uuid(),
+			duelIds: [faker.string.uuid()],
 			bestOf: faker.number.int({ min: 1, max: 9 }),
 			date: faker.date.past(),
 			players: [PlayerMother.create().toPresentation(), PlayerMother.create().toPresentation()],

--- a/src/ygopro/room/domain/states/YGOProDuelingState.ts
+++ b/src/ygopro/room/domain/states/YGOProDuelingState.ts
@@ -676,6 +676,9 @@ export class YGOProDuelingState extends RoomState {
 		void this.eventBus.publish(
 			GameOverDomainEvent.DOMAIN_EVENT,
 			new GameOverDomainEvent({
+				roomId: this.room.id,
+				matchId: this.room.matchId,
+				duelIds: [...this.room.duelIds],
 				bestOf: this.room.bestOf,
 				players: this.room.matchPlayersHistory,
 				date: new Date(),


### PR DESCRIPTION
## Description / Descripción

Both `GAME_OVER` consumers minted their own identity after the fact: `BasicStatsCalculator` and `UnrankedMatchSaver` each generated random `gameId`s (and a `matchId`) at stats time, so match and duel resumes could never be correlated with the room, the duels, or each other.

**The match now owns its identity:**

- `YgoRoom` assigns a `matchId` uuid when a match is created (`createMatchUnsafe`) and accumulates the `duelId` of every game in played order (`createDuel`, inside its mutex), resetting per match.
- `GameOverData` carries `roomId`, `matchId` and `duelIds`, populated by both emitters (`FinishDuelHandler`, `YGOProDuelingState`).
- Both consumers persist the event's `matchId` as their `gameId` — the invented uuids are gone.
- `unranked_duels` rows are one per game, so the row id IS the duel: each row is now persisted under the domain's real `duelId`. On a count mismatch between `duelIds` and games, positional matching is untrustworthy — the saver falls back to random ids and warns instead of guessing.

**Not covered:** the ranked `duels` table stores one row per player per game, so a domain `duelId` spans several rows and needs its own `duel_id` column — a schema migration in the `evolution-types` submodule, proposed separately.

### TDD

Red-first: 3 `YgoRoom` match-identity tests (fresh matchId per match, duelIds accumulated in order, reset on new match), 1 `BasicStatsCalculator` test (persisted `gameId` === event `matchId`), 3 `UnrankedMatchSaver` tests (gameId from event; real duelIds per row; mismatch fallback + warn). `GameOverDomainEventMother` gained defaults for the new fields, absorbing most test churn.

## Related Issue(s) / Issue(s) relacionado(s)

Builds on #334 (duelId); closes the identity chain surfaced while reviewing how events identify their room.

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [x] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

- Full suite: **138 suites / 1289 tests** green; `tsc --noEmit` and `biome ci` clean.
- No schema changes in this PR — `unranked_duels.id` was already a free-form uuid column; only its value became meaningful.
