### PR TITLE
feat(stats): persist duel resumes under their real duelId and unranked matches under their matchId

### DIFF
--- a/src/plugins/basic-stats/application/BasicStatsCalculator.test.ts
+++ b/src/plugins/basic-stats/application/BasicStatsCalculator.test.ts
@@ -151,6 +151,50 @@ describe("BasicStatsCalculator", () => {
 		);
 	});
 
+	it("persists each duel resume under its real duelId when the event carries one per game", async () => {
+		const event = GameOverDomainEventMother.create({
+			players: [player.toPresentation(), opponent.toPresentation()],
+			ranked: true,
+			banListName: "N/A",
+			matchId: "match-uuid-1",
+			duelIds: ["duel-uuid-1", "duel-uuid-2", "duel-uuid-3"],
+		});
+
+		await basicStatsCalculator.handle(event);
+
+		// Both players' rows of game i carry the SAME duelId — the cross-player
+		// correlation key.
+		const duelIdsPassed = duelResumeCreator.run.mock.calls.map(
+			([payload]) => (payload as { duelId: string | null }).duelId,
+		);
+		expect(duelIdsPassed).toEqual([
+			"duel-uuid-1",
+			"duel-uuid-2",
+			"duel-uuid-3",
+			"duel-uuid-1",
+			"duel-uuid-2",
+			"duel-uuid-3",
+		]);
+	});
+
+	it("falls back to null duelIds and warns when the count does not match the games", async () => {
+		const event = GameOverDomainEventMother.create({
+			players: [player.toPresentation(), opponent.toPresentation()],
+			ranked: true,
+			banListName: "N/A",
+			matchId: "match-uuid-1",
+			duelIds: ["duel-uuid-1"],
+		});
+
+		await basicStatsCalculator.handle(event);
+
+		const duelIdsPassed = duelResumeCreator.run.mock.calls.map(
+			([payload]) => (payload as { duelId: string | null }).duelId,
+		);
+		expect(duelIdsPassed).toEqual([null, null, null, null, null, null]);
+		expect(logger.warn).toHaveBeenCalled();
+	});
+
 	it("Should use banListName from event data (not from hash lookup) for per-format rank", async () => {
 		const edisonBanListName = "2010.03 Edison";
 		playerStatsRepository.findByUserIdAndBanListName

--- a/src/plugins/basic-stats/application/BasicStatsCalculator.ts
+++ b/src/plugins/basic-stats/application/BasicStatsCalculator.ts
@@ -97,10 +97,22 @@ export class BasicStatsCalculator implements DomainEventSubscriber<GameOverDomai
 				`Match saved with id ${matchId} for user: ${userProfile.id} with name ${player.name}`,
 			);
 
-			for (const game of player.games) {
+			// duels rows are one per player per game: both players' rows of game i
+			// carry the same duelId. A count mismatch means positional matching is
+			// untrustworthy — persist null rather than guessing, and say so.
+			const duelIds = event.data.duelIds;
+			const idsMatchGames = duelIds.length === player.games.length;
+			if (!idsMatchGames) {
+				this.logger.warn(
+					`duelIds count (${duelIds.length}) does not match games count (${player.games.length}) for ${player.name} — persisting duel resumes without duelId`,
+				);
+			}
+
+			for (const [index, game] of player.games.entries()) {
 				void this.duelResumeCreator.run({
 					userId: userProfile.id,
 					gameId,
+					duelId: idsMatchGames ? duelIds[index] : null,
 					playerNames,
 					opponentNames,
 					date: event.data.date,

--- a/src/plugins/unranked-match/application/UnrankedMatchSaver.test.ts
+++ b/src/plugins/unranked-match/application/UnrankedMatchSaver.test.ts
@@ -152,6 +152,32 @@ describe("UnrankedMatchSaver", () => {
 		);
 	});
 
+	// unranked_matches rows are one per match, so the row id IS the match:
+	// duplicate GAME_OVER publications hit the primary key instead of
+	// duplicating the row.
+	it("persists the match row under the real matchId", async () => {
+		const event = new GameOverDomainEvent({
+			ranked: false,
+			players: [
+				PlayerMother.create({ team: Team.PLAYER }).toPresentation(),
+				PlayerMother.create({ team: Team.OPPONENT }).toPresentation(),
+			],
+			bestOf: 1,
+			date: new Date(),
+			banListHash: 123,
+			banListName: "N/A",
+			roomId: 7,
+			matchId: "match-uuid-1",
+			duelIds: ["duel-uuid-1"],
+		});
+
+		await unrankedMatchSaver.handle(event);
+
+		expect(unrankedMatchRepository.saveMatch).toHaveBeenCalledWith(
+			expect.objectContaining({ id: "match-uuid-1" }),
+		);
+	});
+
 	it("persists each duel row under its real duelId when the event carries one per game", async () => {
 		const event = new GameOverDomainEvent({
 			ranked: false,

--- a/src/plugins/unranked-match/application/UnrankedMatchSaver.ts
+++ b/src/plugins/unranked-match/application/UnrankedMatchSaver.ts
@@ -40,7 +40,9 @@ export class UnrankedMatchSaver implements DomainEventSubscriber<GameOverDomainE
 
 		// Use the first player of Team 0 as reference for scores and result
 		const referencePlayer = team0Players[0];
-		const matchId = randomUUID();
+		// unranked_matches rows are one per match, so the row id IS the match:
+		// a duplicate GAME_OVER hits the primary key instead of duplicating it.
+		const matchId = event.data.matchId;
 
 		const unrankedMatch = UnrankedMatch.create({
 			id: matchId,

--- a/src/shared/stats/match-resume/duel-resume/application/DuelResumeCreator.ts
+++ b/src/shared/stats/match-resume/duel-resume/application/DuelResumeCreator.ts
@@ -17,6 +17,7 @@ export class DuelResumeCreator {
 		result: string;
 		turns: number;
 		matchId: string;
+		duelId: string | null;
 		season: number;
 		ipAddress: string | null;
 	}): Promise<{ id: string }> {

--- a/src/shared/stats/match-resume/duel-resume/domain/DuelResume.ts
+++ b/src/shared/stats/match-resume/duel-resume/domain/DuelResume.ts
@@ -10,6 +10,8 @@ export class DuelResume {
 	readonly result: string;
 	readonly turns: number;
 	readonly matchId: string;
+	/** Cross-player correlation key of the game; null when the emitter could not provide one. */
+	readonly duelId: string | null;
 	readonly season: number;
 	readonly ipAddress: string | null;
 
@@ -25,6 +27,7 @@ export class DuelResume {
 		result,
 		turns,
 		matchId,
+		duelId,
 		season,
 		ipAddress,
 	}: {
@@ -39,6 +42,7 @@ export class DuelResume {
 		result: string;
 		turns: number;
 		matchId: string;
+		duelId: string | null;
 		season: number;
 		ipAddress: string | null;
 	}) {
@@ -53,6 +57,7 @@ export class DuelResume {
 		this.result = result;
 		this.turns = turns;
 		this.matchId = matchId;
+		this.duelId = duelId;
 		this.season = season;
 		this.ipAddress = ipAddress;
 	}
@@ -69,6 +74,7 @@ export class DuelResume {
 		result,
 		turns,
 		matchId,
+		duelId,
 		season,
 		ipAddress,
 	}: {
@@ -83,6 +89,7 @@ export class DuelResume {
 		result: string;
 		turns: number;
 		matchId: string;
+		duelId: string | null;
 		season: number;
 		ipAddress: string | null;
 	}): DuelResume {
@@ -98,6 +105,7 @@ export class DuelResume {
 			result,
 			turns,
 			matchId,
+			duelId,
 			season,
 			ipAddress,
 		});
@@ -115,6 +123,7 @@ export class DuelResume {
 		result: string;
 		turns: number;
 		matchId: string;
+		duelId: string | null;
 		season: number;
 		ipAddress: string | null;
 	}): DuelResume {

--- a/src/shared/stats/match-resume/infrastructure/postgres/MatchResumePostgresRepository.ts
+++ b/src/shared/stats/match-resume/infrastructure/postgres/MatchResumePostgresRepository.ts
@@ -43,6 +43,7 @@ export class MatchResumePostgresRepository implements MatchResumeRepository {
 			result: duelResume.result,
 			turns: duelResume.turns,
 			matchId: duelResume.matchId,
+			duelId: duelResume.duelId,
 			season: duelResume.season,
 			ipAddress: duelResume.ipAddress,
 		});

--- a/src/utils/migrate-user-from-redis-to-postgres.ts
+++ b/src/utils/migrate-user-from-redis-to-postgres.ts
@@ -136,6 +136,7 @@ async function run() {
 							result: game.result,
 							turns: game.turns,
 							matchId,
+							duelId: null, // legacy data predates duel identity
 							season: 3,
 							ipAddress: null,
 						});


### PR DESCRIPTION
## Description / Descripción

Final link of the identity chain: the `duelId` born at duel creation (#334), carried by every duel event and by `GAME_OVER` (#335), now reaches the database.

### `duels.duel_id` populated end to end

The column added by evolution-types#4 (nullable `uuid` + index) is now written through the whole chain: `DuelResume` domain object → `DuelResumeCreator` payload → Postgres repository mapping. `BasicStatsCalculator` maps `player.games[i]` to `GAME_OVER`'s `duelIds[i]`, so **both players' rows of the same game carry the same `duel_id`** — the cross-player correlation key that makes duel-event data joinable with stats. On a count mismatch, positional matching is untrustworthy: rows are persisted with `null` and a warning, never a guess (same guard the unranked saver ships since #335). The legacy redis→postgres migration util passes `duelId: null` explicitly — its data predates duel identity, and the null *means* that.

### `unranked_matches.id` = real `matchId`

Rows are one per match, so the row id IS the match. Side effect, pinned by test: a duplicate `GAME_OVER` publication now hits the primary key instead of silently duplicating the row — idempotency for free.

### Submodule bump

`src/evolution-types` moves to `91be314` — the merge commit of evolution-types#4 on its main.

### TDD

Red-first: 2 `BasicStatsCalculator` tests (same duelId on both players' rows per game, in order; mismatch → all-null + warn) and 1 `UnrankedMatchSaver` test (row id = event matchId). `tsc` caught the two call sites the sweep missed (`DuelResume.create`'s inner literal, the legacy migration util).

## Related Issue(s) / Issue(s) relacionado(s)

Closes the identity chain: #334 → #335 → evolution-types#4 → this.

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [x] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

- Full suite: **138 suites / 1292 tests** green; `tsc --noEmit` and `biome ci` clean.
- Deploy order note: the migration must be applied before this deploys (already done locally); the column being nullable means either order is survivable, but this order avoids insert failures.
- Observed while editing, left untouched: `DuelResume` repeats its 13-field shape four times (props, constructor, `create`, `from`) — adding one field means six edit points. Worth a refactor pass someday.
