### PR TITLE
refactor(stats): declare each resume shape once behind a data field

### DIFF
--- a/src/plugins/unranked-match/application/UnrankedMatchSaver.test.ts
+++ b/src/plugins/unranked-match/application/UnrankedMatchSaver.test.ts
@@ -88,18 +88,18 @@ describe("UnrankedMatchSaver", () => {
 		expect(unrankedMatchRepository.saveDuel).toHaveBeenCalledTimes(1);
 
 		const capturedMatch = unrankedMatchRepository.saveMatch.mock.calls[0][0];
-		expect(capturedMatch.team0Score).toBe(1);
-		expect(capturedMatch.team1Score).toBe(0);
-		expect(capturedMatch.winnerTeam).toBe(0);
-		expect(capturedMatch.playerNames).toContain("Player0");
-		expect(capturedMatch.opponentNames).toContain("Player1");
-		expect(capturedMatch.banListName).toBe("2010.03 Edison");
+		expect(capturedMatch.data.team0Score).toBe(1);
+		expect(capturedMatch.data.team1Score).toBe(0);
+		expect(capturedMatch.data.winnerTeam).toBe(0);
+		expect(capturedMatch.data.playerNames).toContain("Player0");
+		expect(capturedMatch.data.opponentNames).toContain("Player1");
+		expect(capturedMatch.data.banListName).toBe("2010.03 Edison");
 
 		const capturedDuel = unrankedMatchRepository.saveDuel.mock.calls[0][0];
-		expect(capturedDuel.team0Score).toBe(1);
-		expect(capturedDuel.team1Score).toBe(0);
-		expect(capturedDuel.winnerTeam).toBe(0);
-		expect(capturedDuel.banListName).toBe("2010.03 Edison");
+		expect(capturedDuel.data.team0Score).toBe(1);
+		expect(capturedDuel.data.team1Score).toBe(0);
+		expect(capturedDuel.data.winnerTeam).toBe(0);
+		expect(capturedDuel.data.banListName).toBe("2010.03 Edison");
 	});
 
 	it("should NOT save if players are missing from one team", async () => {
@@ -148,7 +148,7 @@ describe("UnrankedMatchSaver", () => {
 		await unrankedMatchSaver.handle(event);
 
 		expect(unrankedMatchRepository.saveMatch).toHaveBeenCalledWith(
-			expect.objectContaining({ gameId: "match-uuid-1" }),
+			expect.objectContaining({ data: expect.objectContaining({ gameId: "match-uuid-1" }) }),
 		);
 	});
 
@@ -174,7 +174,7 @@ describe("UnrankedMatchSaver", () => {
 		await unrankedMatchSaver.handle(event);
 
 		expect(unrankedMatchRepository.saveMatch).toHaveBeenCalledWith(
-			expect.objectContaining({ id: "match-uuid-1" }),
+			expect.objectContaining({ data: expect.objectContaining({ id: "match-uuid-1" }) }),
 		);
 	});
 
@@ -202,11 +202,11 @@ describe("UnrankedMatchSaver", () => {
 		expect(unrankedMatchRepository.saveDuel).toHaveBeenCalledTimes(2);
 		expect(unrankedMatchRepository.saveDuel).toHaveBeenNthCalledWith(
 			1,
-			expect.objectContaining({ id: "duel-uuid-1" }),
+			expect.objectContaining({ data: expect.objectContaining({ id: "duel-uuid-1" }) }),
 		);
 		expect(unrankedMatchRepository.saveDuel).toHaveBeenNthCalledWith(
 			2,
-			expect.objectContaining({ id: "duel-uuid-2" }),
+			expect.objectContaining({ data: expect.objectContaining({ id: "duel-uuid-2" }) }),
 		);
 	});
 
@@ -233,7 +233,7 @@ describe("UnrankedMatchSaver", () => {
 
 		expect(unrankedMatchRepository.saveDuel).toHaveBeenCalledTimes(2);
 		const savedIds = unrankedMatchRepository.saveDuel.mock.calls.map(
-			([duel]) => (duel as { id: string }).id,
+			([duel]) => (duel as { data: { id: string } }).data.id,
 		);
 		expect(savedIds).not.toContain("duel-uuid-1");
 		expect(logger.warn).toHaveBeenCalled();

--- a/src/plugins/unranked-match/domain/UnrankedDuel.ts
+++ b/src/plugins/unranked-match/domain/UnrankedDuel.ts
@@ -1,4 +1,4 @@
-export class UnrankedDuel {
+export interface UnrankedDuelData {
 	readonly id: string;
 	readonly gameId: string;
 	readonly date: Date;
@@ -11,49 +11,12 @@ export class UnrankedDuel {
 	readonly matchId: string;
 	readonly season: number;
 	readonly ipAddress: string | null;
+}
 
-	private constructor(data: {
-		id: string;
-		gameId: string;
-		date: Date;
-		banListName: string;
-		banListHash: string;
-		team0Score: number;
-		team1Score: number;
-		winnerTeam: number;
-		turns: number;
-		matchId: string;
-		season: number;
-		ipAddress: string | null;
-	}) {
-		this.id = data.id;
-		this.gameId = data.gameId;
-		this.date = data.date;
-		this.banListName = data.banListName;
-		this.banListHash = data.banListHash;
-		this.team0Score = data.team0Score;
-		this.team1Score = data.team1Score;
-		this.winnerTeam = data.winnerTeam;
-		this.turns = data.turns;
-		this.matchId = data.matchId;
-		this.season = data.season;
-		this.ipAddress = data.ipAddress;
-	}
+export class UnrankedDuel {
+	private constructor(readonly data: UnrankedDuelData) {}
 
-	static create(data: {
-		id: string;
-		gameId: string;
-		date: Date;
-		banListName: string;
-		banListHash: string;
-		team0Score: number;
-		team1Score: number;
-		winnerTeam: number;
-		turns: number;
-		matchId: string;
-		season: number;
-		ipAddress: string | null;
-	}): UnrankedDuel {
+	static create(data: UnrankedDuelData): UnrankedDuel {
 		return new UnrankedDuel(data);
 	}
 }

--- a/src/plugins/unranked-match/domain/UnrankedMatch.ts
+++ b/src/plugins/unranked-match/domain/UnrankedMatch.ts
@@ -1,4 +1,4 @@
-export class UnrankedMatch {
+export interface UnrankedMatchData {
 	readonly id: string;
 	readonly gameId: string;
 	readonly bestOf: number;
@@ -11,62 +11,12 @@ export class UnrankedMatch {
 	readonly team1Score: number;
 	readonly winnerTeam: number;
 	readonly season: number;
+}
 
-	private constructor({
-		id,
-		gameId,
-		bestOf,
-		playerNames,
-		opponentNames,
-		date,
-		banListName,
-		banListHash,
-		team0Score,
-		team1Score,
-		winnerTeam,
-		season,
-	}: {
-		id: string;
-		gameId: string;
-		bestOf: number;
-		playerNames: string[];
-		opponentNames: string[];
-		date: Date;
-		banListName: string;
-		banListHash: string;
-		team0Score: number;
-		team1Score: number;
-		winnerTeam: number;
-		season: number;
-	}) {
-		this.id = id;
-		this.gameId = gameId;
-		this.bestOf = bestOf;
-		this.playerNames = playerNames;
-		this.opponentNames = opponentNames;
-		this.date = date;
-		this.banListName = banListName;
-		this.banListHash = banListHash;
-		this.team0Score = team0Score;
-		this.team1Score = team1Score;
-		this.winnerTeam = winnerTeam;
-		this.season = season;
-	}
+export class UnrankedMatch {
+	private constructor(readonly data: UnrankedMatchData) {}
 
-	static create(data: {
-		id: string;
-		gameId: string;
-		bestOf: number;
-		playerNames: string[];
-		opponentNames: string[];
-		date: Date;
-		banListName: string;
-		banListHash: string;
-		team0Score: number;
-		team1Score: number;
-		winnerTeam: number;
-		season: number;
-	}): UnrankedMatch {
+	static create(data: UnrankedMatchData): UnrankedMatch {
 		return new UnrankedMatch(data);
 	}
 }

--- a/src/plugins/unranked-match/infrastructure/postgres/UnrankedMatchPostgresRepository.ts
+++ b/src/plugins/unranked-match/infrastructure/postgres/UnrankedMatchPostgresRepository.ts
@@ -9,18 +9,18 @@ export class UnrankedMatchPostgresRepository implements UnrankedMatchRepository 
 	async saveMatch(unrankedMatch: UnrankedMatch): Promise<void> {
 		const repository = dataSource.getRepository(UnrankedMatchEntity);
 		const entity = repository.create({
-			id: unrankedMatch.id,
-			gameId: unrankedMatch.gameId,
-			bestOf: unrankedMatch.bestOf,
-			playerNames: unrankedMatch.playerNames,
-			opponentNames: unrankedMatch.opponentNames,
-			date: unrankedMatch.date,
-			banListName: unrankedMatch.banListName,
-			banListHash: unrankedMatch.banListHash,
-			team0Score: unrankedMatch.team0Score,
-			team1Score: unrankedMatch.team1Score,
-			winnerTeam: unrankedMatch.winnerTeam,
-			season: unrankedMatch.season,
+			id: unrankedMatch.data.id,
+			gameId: unrankedMatch.data.gameId,
+			bestOf: unrankedMatch.data.bestOf,
+			playerNames: unrankedMatch.data.playerNames,
+			opponentNames: unrankedMatch.data.opponentNames,
+			date: unrankedMatch.data.date,
+			banListName: unrankedMatch.data.banListName,
+			banListHash: unrankedMatch.data.banListHash,
+			team0Score: unrankedMatch.data.team0Score,
+			team1Score: unrankedMatch.data.team1Score,
+			winnerTeam: unrankedMatch.data.winnerTeam,
+			season: unrankedMatch.data.season,
 		});
 		await repository.save(entity);
 	}
@@ -28,18 +28,18 @@ export class UnrankedMatchPostgresRepository implements UnrankedMatchRepository 
 	async saveDuel(unrankedDuel: UnrankedDuel): Promise<void> {
 		const repository = dataSource.getRepository(UnrankedDuelEntity);
 		const entity = repository.create({
-			id: unrankedDuel.id,
-			gameId: unrankedDuel.gameId,
-			date: unrankedDuel.date,
-			banListName: unrankedDuel.banListName,
-			banListHash: unrankedDuel.banListHash,
-			team0Score: unrankedDuel.team0Score,
-			team1Score: unrankedDuel.team1Score,
-			winnerTeam: unrankedDuel.winnerTeam,
-			turns: unrankedDuel.turns,
-			matchId: unrankedDuel.matchId,
-			season: unrankedDuel.season,
-			ipAddress: unrankedDuel.ipAddress,
+			id: unrankedDuel.data.id,
+			gameId: unrankedDuel.data.gameId,
+			date: unrankedDuel.data.date,
+			banListName: unrankedDuel.data.banListName,
+			banListHash: unrankedDuel.data.banListHash,
+			team0Score: unrankedDuel.data.team0Score,
+			team1Score: unrankedDuel.data.team1Score,
+			winnerTeam: unrankedDuel.data.winnerTeam,
+			turns: unrankedDuel.data.turns,
+			matchId: unrankedDuel.data.matchId,
+			season: unrankedDuel.data.season,
+			ipAddress: unrankedDuel.data.ipAddress,
 		});
 		await repository.save(entity);
 	}

--- a/src/shared/stats/match-resume/application/MatchResumeCreator.ts
+++ b/src/shared/stats/match-resume/application/MatchResumeCreator.ts
@@ -1,28 +1,12 @@
 import { randomUUID } from "crypto";
 
-import { MatchResume } from "../domain/MatchResume";
+import { MatchResume, MatchResumeData } from "../domain/MatchResume";
 import { MatchResumeRepository } from "../domain/MatchResumeRepository";
 
 export class MatchResumeCreator {
 	constructor(private readonly matchResumeRepository: MatchResumeRepository) {}
 
-	async run(payload: {
-		userId: string;
-		gameId: string;
-		bestOf: number;
-		playerNames: string[];
-		opponentNames: string[];
-		playerIds: string[];
-		opponentIds: string[];
-		date: Date;
-		banListName: string;
-		banListHash: string;
-		playerScore: number;
-		opponentScore: number;
-		winner: boolean;
-		season: number;
-		points: number;
-	}): Promise<{ id: string }> {
+	async run(payload: Omit<MatchResumeData, "id">): Promise<{ id: string }> {
 		const id = randomUUID();
 		const matchResume = MatchResume.create({ id, ...payload });
 		await this.matchResumeRepository.create(matchResume);

--- a/src/shared/stats/match-resume/domain/MatchResume.test.ts
+++ b/src/shared/stats/match-resume/domain/MatchResume.test.ts
@@ -1,0 +1,26 @@
+import { MatchResume } from "./MatchResume";
+
+describe("MatchResume", () => {
+	it("exposes exactly the data it was created with", () => {
+		const data = {
+			id: "match-resume-1",
+			userId: "user-1",
+			gameId: "match-uuid-1",
+			bestOf: 3,
+			playerNames: ["Jaden"],
+			opponentNames: ["Chazz"],
+			playerIds: ["u1"],
+			opponentIds: ["u2"],
+			date: new Date("2026-08-25"),
+			banListName: "Global",
+			banListHash: "123",
+			playerScore: 2,
+			opponentScore: 1,
+			winner: true,
+			season: 3,
+			points: 7,
+		};
+
+		expect(MatchResume.create(data).data).toEqual(data);
+	});
+});

--- a/src/shared/stats/match-resume/domain/MatchResume.ts
+++ b/src/shared/stats/match-resume/domain/MatchResume.ts
@@ -1,4 +1,4 @@
-export class MatchResume {
+export interface MatchResumeData {
 	readonly id: string;
 	readonly userId: string;
 	readonly gameId: string;
@@ -15,133 +15,12 @@ export class MatchResume {
 	readonly winner: boolean;
 	readonly season: number;
 	readonly points: number;
+}
 
-	private constructor({
-		id,
-		userId,
-		gameId,
-		bestOf,
-		playerNames,
-		opponentNames,
-		date,
-		banListName,
-		banListHash,
-		playerScore,
-		opponentScore,
-		winner,
-		season,
-		points,
-		playerIds,
-		opponentIds,
-	}: {
-		id: string;
-		userId: string;
-		gameId: string;
-		bestOf: number;
-		playerNames: string[];
-		opponentNames: string[];
-		date: Date;
-		banListName: string;
-		banListHash: string;
-		playerScore: number;
-		opponentScore: number;
-		winner: boolean;
-		season: number;
-		points: number;
-		playerIds: string[];
-		opponentIds: string[];
-	}) {
-		this.id = id;
-		this.userId = userId;
-		this.gameId = gameId;
-		this.bestOf = bestOf;
-		this.playerNames = playerNames;
-		this.opponentNames = opponentNames;
-		this.date = date;
-		this.banListName = banListName;
-		this.banListHash = banListHash;
-		this.playerScore = playerScore;
-		this.opponentScore = opponentScore;
-		this.winner = winner;
-		this.season = season;
-		this.points = points;
-		this.playerIds = playerIds;
-		this.opponentIds = opponentIds;
-	}
+export class MatchResume {
+	private constructor(readonly data: MatchResumeData) {}
 
-	static create({
-		id,
-		userId,
-		gameId,
-		bestOf,
-		playerNames,
-		opponentNames,
-		date,
-		banListName,
-		banListHash,
-		playerScore,
-		opponentScore,
-		winner,
-		season,
-		points,
-		playerIds,
-		opponentIds,
-	}: {
-		id: string;
-		userId: string;
-		gameId: string;
-		bestOf: number;
-		playerNames: string[];
-		opponentNames: string[];
-		date: Date;
-		banListName: string;
-		banListHash: string;
-		playerScore: number;
-		opponentScore: number;
-		winner: boolean;
-		season: number;
-		points: number;
-		playerIds: string[];
-		opponentIds: string[];
-	}): MatchResume {
-		return new MatchResume({
-			id,
-			userId,
-			gameId,
-			bestOf,
-			playerNames,
-			opponentNames,
-			date,
-			banListName,
-			banListHash,
-			playerScore,
-			opponentScore,
-			winner,
-			season,
-			points,
-			playerIds,
-			opponentIds,
-		});
-	}
-
-	static from(data: {
-		id: string;
-		userId: string;
-		gameId: string;
-		bestOf: number;
-		playerNames: string[];
-		opponentNames: string[];
-		date: Date;
-		banListName: string;
-		banListHash: string;
-		playerScore: number;
-		opponentScore: number;
-		winner: boolean;
-		season: number;
-		points: number;
-		playerIds: string[];
-		opponentIds: string[];
-	}): MatchResume {
+	static create(data: MatchResumeData): MatchResume {
 		return new MatchResume(data);
 	}
 }

--- a/src/shared/stats/match-resume/duel-resume/application/DuelResumeCreator.ts
+++ b/src/shared/stats/match-resume/duel-resume/application/DuelResumeCreator.ts
@@ -1,26 +1,12 @@
 import { randomUUID } from "crypto";
 
 import { MatchResumeRepository } from "../../domain/MatchResumeRepository";
-import { DuelResume } from "../domain/DuelResume";
+import { DuelResume, DuelResumeData } from "../domain/DuelResume";
 
 export class DuelResumeCreator {
 	constructor(private readonly matchResumeRepository: MatchResumeRepository) {}
 
-	async run(payload: {
-		userId: string;
-		gameId: string;
-		playerNames: string[];
-		opponentNames: string[];
-		date: Date;
-		banListName: string;
-		banListHash: string;
-		result: string;
-		turns: number;
-		matchId: string;
-		duelId: string | null;
-		season: number;
-		ipAddress: string | null;
-	}): Promise<{ id: string }> {
+	async run(payload: Omit<DuelResumeData, "id">): Promise<{ id: string }> {
 		const id = randomUUID();
 		const duelResume = DuelResume.create({ id, ...payload });
 		await this.matchResumeRepository.createDuelResume(duelResume);

--- a/src/shared/stats/match-resume/duel-resume/domain/DuelResume.test.ts
+++ b/src/shared/stats/match-resume/duel-resume/domain/DuelResume.test.ts
@@ -1,0 +1,24 @@
+import { DuelResume } from "./DuelResume";
+
+describe("DuelResume", () => {
+	it("exposes exactly the data it was created with", () => {
+		const data = {
+			id: "duel-resume-1",
+			userId: "user-1",
+			gameId: "match-uuid-1",
+			playerNames: ["Jaden"],
+			opponentNames: ["Chazz"],
+			date: new Date("2026-08-25"),
+			banListName: "Global",
+			banListHash: "123",
+			result: "winner",
+			turns: 9,
+			matchId: "match-row-1",
+			duelId: "duel-uuid-1",
+			season: 3,
+			ipAddress: null,
+		};
+
+		expect(DuelResume.create(data).data).toEqual(data);
+	});
+});

--- a/src/shared/stats/match-resume/duel-resume/domain/DuelResume.ts
+++ b/src/shared/stats/match-resume/duel-resume/domain/DuelResume.ts
@@ -1,4 +1,4 @@
-export class DuelResume {
+export interface DuelResumeData {
 	readonly id: string;
 	readonly userId: string;
 	readonly gameId: string;
@@ -14,119 +14,12 @@ export class DuelResume {
 	readonly duelId: string | null;
 	readonly season: number;
 	readonly ipAddress: string | null;
+}
 
-	private constructor({
-		id,
-		userId,
-		gameId,
-		playerNames,
-		opponentNames,
-		date,
-		banListName,
-		banListHash,
-		result,
-		turns,
-		matchId,
-		duelId,
-		season,
-		ipAddress,
-	}: {
-		id: string;
-		userId: string;
-		gameId: string;
-		playerNames: string[];
-		opponentNames: string[];
-		date: Date;
-		banListName: string;
-		banListHash: string;
-		result: string;
-		turns: number;
-		matchId: string;
-		duelId: string | null;
-		season: number;
-		ipAddress: string | null;
-	}) {
-		this.id = id;
-		this.userId = userId;
-		this.gameId = gameId;
-		this.playerNames = playerNames;
-		this.opponentNames = opponentNames;
-		this.date = date;
-		this.banListName = banListName;
-		this.banListHash = banListHash;
-		this.result = result;
-		this.turns = turns;
-		this.matchId = matchId;
-		this.duelId = duelId;
-		this.season = season;
-		this.ipAddress = ipAddress;
-	}
+export class DuelResume {
+	private constructor(readonly data: DuelResumeData) {}
 
-	static create({
-		id,
-		userId,
-		gameId,
-		playerNames,
-		opponentNames,
-		date,
-		banListName,
-		banListHash,
-		result,
-		turns,
-		matchId,
-		duelId,
-		season,
-		ipAddress,
-	}: {
-		id: string;
-		userId: string;
-		gameId: string;
-		playerNames: string[];
-		opponentNames: string[];
-		date: Date;
-		banListName: string;
-		banListHash: string;
-		result: string;
-		turns: number;
-		matchId: string;
-		duelId: string | null;
-		season: number;
-		ipAddress: string | null;
-	}): DuelResume {
-		return new DuelResume({
-			id,
-			userId,
-			gameId,
-			playerNames,
-			opponentNames,
-			date,
-			banListName,
-			banListHash,
-			result,
-			turns,
-			matchId,
-			duelId,
-			season,
-			ipAddress,
-		});
-	}
-
-	static from(data: {
-		id: string;
-		userId: string;
-		gameId: string;
-		playerNames: string[];
-		opponentNames: string[];
-		date: Date;
-		banListName: string;
-		banListHash: string;
-		result: string;
-		turns: number;
-		matchId: string;
-		duelId: string | null;
-		season: number;
-		ipAddress: string | null;
-	}): DuelResume {
+	static create(data: DuelResumeData): DuelResume {
 		return new DuelResume(data);
 	}
 }

--- a/src/shared/stats/match-resume/infrastructure/postgres/MatchResumePostgresRepository.ts
+++ b/src/shared/stats/match-resume/infrastructure/postgres/MatchResumePostgresRepository.ts
@@ -9,22 +9,22 @@ export class MatchResumePostgresRepository implements MatchResumeRepository {
 	async create(matchResume: MatchResume): Promise<void> {
 		const repository = dataSource.getRepository(MatchResumeEntity);
 		const matchResumeEntity = repository.create({
-			id: matchResume.id,
-			userId: matchResume.userId,
-			gameId: matchResume.gameId,
-			bestOf: matchResume.bestOf,
-			playerNames: matchResume.playerNames,
-			opponentNames: matchResume.opponentNames,
-			playerIds: matchResume.playerIds,
-			opponentIds: matchResume.opponentIds,
-			date: matchResume.date,
-			banListName: matchResume.banListName,
-			banListHash: matchResume.banListHash,
-			playerScore: matchResume.playerScore,
-			opponentScore: matchResume.opponentScore,
-			winner: matchResume.winner,
-			season: matchResume.season,
-			points: matchResume.points,
+			id: matchResume.data.id,
+			userId: matchResume.data.userId,
+			gameId: matchResume.data.gameId,
+			bestOf: matchResume.data.bestOf,
+			playerNames: matchResume.data.playerNames,
+			opponentNames: matchResume.data.opponentNames,
+			playerIds: matchResume.data.playerIds,
+			opponentIds: matchResume.data.opponentIds,
+			date: matchResume.data.date,
+			banListName: matchResume.data.banListName,
+			banListHash: matchResume.data.banListHash,
+			playerScore: matchResume.data.playerScore,
+			opponentScore: matchResume.data.opponentScore,
+			winner: matchResume.data.winner,
+			season: matchResume.data.season,
+			points: matchResume.data.points,
 		});
 		await repository.save(matchResumeEntity);
 	}
@@ -32,20 +32,20 @@ export class MatchResumePostgresRepository implements MatchResumeRepository {
 	async createDuelResume(duelResume: DuelResume): Promise<void> {
 		const repository = dataSource.getRepository(DuelResumeEntity);
 		const duelResumeEntity = repository.create({
-			id: duelResume.id,
-			userId: duelResume.userId,
-			gameId: duelResume.gameId,
-			playerNames: duelResume.playerNames,
-			opponentNames: duelResume.opponentNames,
-			date: duelResume.date,
-			banListName: duelResume.banListName,
-			banListHash: duelResume.banListHash,
-			result: duelResume.result,
-			turns: duelResume.turns,
-			matchId: duelResume.matchId,
-			duelId: duelResume.duelId,
-			season: duelResume.season,
-			ipAddress: duelResume.ipAddress,
+			id: duelResume.data.id,
+			userId: duelResume.data.userId,
+			gameId: duelResume.data.gameId,
+			playerNames: duelResume.data.playerNames,
+			opponentNames: duelResume.data.opponentNames,
+			date: duelResume.data.date,
+			banListName: duelResume.data.banListName,
+			banListHash: duelResume.data.banListHash,
+			result: duelResume.data.result,
+			turns: duelResume.data.turns,
+			matchId: duelResume.data.matchId,
+			duelId: duelResume.data.duelId,
+			season: duelResume.data.season,
+			ipAddress: duelResume.data.ipAddress,
 		});
 		await repository.save(duelResumeEntity);
 	}


### PR DESCRIPTION
## Description / Descripción

The refactor flagged in #336: `MatchResume`, `DuelResume`, `UnrankedMatch` and `UnrankedDuel` each declared their full field shape **four times** — readonly properties, constructor destructuring, the `create()` parameter type and the `from()` parameter type. Worst case (`MatchResume`): 16 fields quadruplicated; adding one field meant six edit points plus call sites — exactly what adding `duelId` cost in #336, where `tsc` had to catch the two spots the sweep missed.

**Each class now declares its shape once**, as an exported `Data` interface held behind a `readonly data` field:

```typescript
export interface DuelResumeData { /* the shape, once */ }

export class DuelResume {
	private constructor(readonly data: DuelResumeData) {}

	static create(data: DuelResumeData): DuelResume {
		return new DuelResume(data);
	}
}
```

Choices, and why:

- **Composition over declaration merging**: the `class` + `interface` merging idiom would keep flat fields but is banned here (`noUnsafeDeclarationMerging: "error"` in biome). Composition with `.data` is also the pattern the codebase already uses — `GameOverDomainEvent` has held `readonly data: GameOverData` all along.
- **`from()` deleted, not migrated**: a survey found zero callers of any of the four `from()` statics — dead code shrinks, it doesn't get refactored.
- **Creator payloads reuse the interfaces**: `MatchResumeCreator`/`DuelResumeCreator` now take `Omit<XData, "id">` instead of re-declaring the shape inline — the same duplication, killed in the same pass.
- **Repositories read through `.data`** with explicit field-by-field mapping kept — the domain→entity seam stays visible rather than collapsing into a spread.

Net: **−438/+143 lines**, and the survey scope is pinned: no field reader existed outside the creators and repositories, so no other call sites change.

### TDD

Two new shape tests (`DuelResume`, `MatchResume`) written red-first against the new `.data` API; `UnrankedMatchSaver`'s existing assertions updated to reach through `.data`. Full suite green.

## Related Issue(s) / Issue(s) relacionado(s)

Follow-up flagged in #336's notes.

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [x] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

- Full suite: **140 suites / 1294 tests** green; `tsc --noEmit` and `biome ci` clean.
- Pure refactor: no behavior, wire format, or schema change — the Postgres mappings produce identical entities.
