### PR TITLE
fix(room): stop ygopro duel events from applying LP and turn mutations twice

### DIFF
--- a/src/ygopro/room/domain/YGOProRoomStateDuelEvents.test.ts
+++ b/src/ygopro/room/domain/YGOProRoomStateDuelEvents.test.ts
@@ -24,6 +24,11 @@ import WebSocketSingleton from "../../../web-socket-server/WebSocketSingleton";
 
 import { YGOProRoom } from "./YGOProRoom";
 import { YGOProRoomState } from "./YGOProRoomState";
+import { YGOProChoosingOrderState } from "./states/YGOProChoosingOrderState";
+import { YGOProDuelingState } from "./states/YGOProDuelingState";
+import { YGOProRockPaperScissorState } from "./states/YGOProRockPaperScissorState";
+import { YGOProSideDeckingState } from "./states/YGOProSideDeckingState";
+import { YGOProWaitingState } from "./states/YGOProWaitingState";
 
 const mockBroadcast = WebSocketSingleton.getInstance().broadcast as jest.Mock;
 
@@ -67,5 +72,29 @@ describe("YGOProRoomState duel-event dispatcher", () => {
 		await new Promise((resolve) => setImmediate(resolve));
 
 		expect(received).toEqual([damage]);
+	});
+
+	// Every ygopro state must resolve registerDuelEventSubscribers to the
+	// YGOProRoomState no-op. A state extending RoomState directly inherits the
+	// EDOPro internal subscribers instead, and every dispatched duel event then
+	// applies its LP/turn mutation a second time — damage counted twice, turns
+	// advancing by two (only in the room's bookkeeping; clients receive their
+	// frames once through routeGameMsg, so the game itself looks fine).
+	describe("every ygopro state inherits the no-op internal registration", () => {
+		const noOp = (YGOProRoomState.prototype as unknown as Record<string, unknown>)
+			.registerDuelEventSubscribers;
+
+		it.each([
+			["YGOProWaitingState", YGOProWaitingState],
+			["YGOProRockPaperScissorState", YGOProRockPaperScissorState],
+			["YGOProChoosingOrderState", YGOProChoosingOrderState],
+			["YGOProDuelingState", YGOProDuelingState],
+			["YGOProSideDeckingState", YGOProSideDeckingState],
+		])("%s", (_name, stateClass) => {
+			const resolved = (stateClass.prototype as unknown as Record<string, unknown>)
+				.registerDuelEventSubscribers;
+
+			expect(resolved).toBe(noOp);
+		});
 	});
 });

--- a/src/ygopro/room/domain/states/YGOProChoosingOrderState.ts
+++ b/src/ygopro/room/domain/states/YGOProChoosingOrderState.ts
@@ -3,7 +3,7 @@ import EventEmitter from "events";
 import { PlayerInfoMessage } from "../../../../edopro/messages/client-to-server/PlayerInfoMessage";
 import { Commands } from "../../../../shared/messages/Commands";
 import { ClientMessage } from "../../../../shared/messages/MessageProcessor";
-import { RoomState } from "../../../../edopro/room/domain/RoomState";
+import { YGOProRoomState } from "../YGOProRoomState";
 import { Logger } from "../../../../shared/logger/domain/Logger";
 import { ISocket } from "../../../../shared/socket/domain/ISocket";
 import { YGOProClient } from "../../../client/domain/YGOProClient";
@@ -13,7 +13,7 @@ import { TurnPlayerResult, YGOProCtosTpResult, YGOProStocDuelStart } from "ygopr
 import { ReconnectionTokenIssuer } from "@shared/room/application/reconnect/ReconnectionTokenIssuer";
 import { ReconnectionAckMessage } from "@shared/messages/server-to-client/ReconnectionAckMessage";
 
-export class YGOProChoosingOrderState extends RoomState {
+export class YGOProChoosingOrderState extends YGOProRoomState {
 	constructor(
 		eventEmitter: EventEmitter,
 		private readonly logger: Logger,

--- a/src/ygopro/room/domain/states/YGOProDuelingState.ts
+++ b/src/ygopro/room/domain/states/YGOProDuelingState.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "events";
 
 import { PlayerInfoMessage } from "@edopro/messages/client-to-server/PlayerInfoMessage";
-import { RoomState } from "@edopro/room/domain/RoomState";
+import { YGOProRoomState } from "../YGOProRoomState";
 
 import { OCGCore } from "@ygopro/ocgcore-worker/ocgcore";
 
@@ -48,7 +48,7 @@ import { EvrpSerializer } from "../replay/EvrpSerializer";
 import { GameOverDomainEvent } from "@shared/room/domain/match/domain/domain-events/GameOverDomainEvent";
 import WebSocketSingleton from "src/web-socket-server/WebSocketSingleton";
 
-export class YGOProDuelingState extends RoomState {
+export class YGOProDuelingState extends YGOProRoomState {
 	private readonly eventBus: EventBus;
 	private readonly ocgCore: OCGCore;
 	private readonly pendingSurrenders = new Set<number>();


### PR DESCRIPTION
## Description / Descripción

Live testing on a ygopro room surfaced double-applied duel-event mutations, visible only in the WebSocket real-time feed: a 1900 attack showed as −3800 LP, the turn counter advanced by two per turn, and every `UPDATE-ROOM` broadcast arrived twice — while the game itself stayed correct (clients receive their frames once through `routeGameMsg`).

**Root cause:** `YGOProDuelingState` and `YGOProChoosingOrderState` extended `RoomState` directly instead of `YGOProRoomState`, bypassing the no-op override of `registerDuelEventSubscribers` introduced in duel-events 4/4 (#333). Their dispatchers therefore carried the EDOPro internal subscribers, so every duel event the dueling state published re-applied its mutation on top of the middleware's own:

```
MSG_DAMAGE → middleware: decreaseLps (1st) + broadcast (1st)
           → publishLpEvent → dispatch("duel.damage")
           → EDOPro internal subscriber (wrongly inherited): decreaseLps (2nd) + broadcast (2nd)
```

Same for `MSG_NEW_TURN`: `increaseTurn` in `ocgcore.ts` (1st) + the wrongly-inherited subscriber (2nd) → turn advancing by two.

**Why the 4/4 test missed it:** it asserted the no-op behavior on a synthetic `TestYgoState extends YGOProRoomState` — a hierarchy `YGOProDuelingState` never had. The test was green while production double-applied. The replacement pins the invariant on the **real classes**: every ygopro state must resolve `registerDuelEventSubscribers` to the `YGOProRoomState` no-op (red on both offending states before the fix).

**Fix:** both states now extend `YGOProRoomState`.

## Related Issue(s) / Issue(s) relacionado(s)

Regression introduced by #333 (duel-events 4/4); found during live WebSocket verification. Not in any cut release — main only.

## Checklist

- [x] My code follows the project style and guidelines / Mi código sigue el estilo y las guías del proyecto
- [x] I have added tests or examples if needed / He agregado tests o ejemplos si es necesario
- [x] I have updated documentation if needed / He actualizado la documentación si es necesario
- [x] The PR title is descriptive / El título del PR es descriptivo

## Additional Notes / Notas adicionales

- Full suite: **140 suites / 1299 tests** green; `tsc --noEmit` and `biome ci` clean.
- After merging, the live check is the same one that caught it: WS feed should show turn +1 per turn, exact damage amounts, and a single `UPDATE-ROOM` per event.
