### PR TITLE
feat(rush): enable Rush Duel as a playable format

### DIFF
--- a/resources.manifest.json
+++ b/resources.manifest.json
@@ -147,8 +147,9 @@
 		},
 		{
 			"target": "ygopro/formats/rush/lflist.conf",
-			"from": "edopro-lflists",
-			"file": "Rush.lflist.conf"
+			"from": "evolution-assets",
+			"file": "rush/lflist.conf",
+			"comment": "Rush ban list from the mirrored pack — the ProjectIgnis Rush list targets EDOPro's native Rush with real card IDs, which do not exist in this pool"
 		},
 		{
 			"target": "ygopro/formats/goat/lflist.conf",
@@ -192,10 +193,23 @@
 			"comment": "YGOPro cards art (extended pool only)",
 			"target": "ygopro/extensions/custom-cards",
 			"from": "custom-cards"
+		},
+		{
+			"comment": "Rush Duel Lua pack — rules live in RDRule.lua, loaded via special.lua",
+			"target": "ygopro/formats/rush/script",
+			"from": "evolution-assets",
+			"dir": "rush/script"
+		},
+		{
+			"comment": "Rush card databases (RD Standard/Patch/Alternate) — rush-only pool, no base cards. Mirrored daily from code.moenext.com by evolution-assets so the image build never depends on that host being reachable.",
+			"target": "ygopro/formats/rush",
+			"from": "evolution-assets",
+			"dir": "rush",
+			"only": "*.cdb"
 		}
 	],
 	"runtime": {
-		"comment": "TS loader pool membership. standard = base + served formats (load order; base first for FIRST-occurrence dedup). extended = extra members appended after standard. Formats assembled but omitted here (goat, rush, speed, gx, mdc) are assembled-but-not-served by design.",
+		"comment": "TS loader pool membership. standard = base + served formats (load order; base first for FIRST-occurrence dedup). extended = extra members appended after standard. pools = named pools that declare their script search path and card pool separately. Formats assembled but omitted here (goat, speed, gx, mdc) are assembled-but-not-served by design.",
 		"ygopro": {
 			"standard": [
 				"base",
@@ -209,7 +223,14 @@
 				"formats/hat",
 				"formats/ocg"
 			],
-			"extended": ["extensions/prereleases", "extensions/custom-cards"]
+			"extended": ["extensions/prereleases", "extensions/custom-cards"],
+			"pools": {
+				"rush": {
+					"comment": "Base is on the script path for utility.lua/constant.lua, but its cards are not part of the format.",
+					"scripts": ["base", "formats/rush"],
+					"cards": ["formats/rush"]
+				}
+			}
 		}
 	}
 }

--- a/src/shared/ban-list/BanList.ts
+++ b/src/shared/ban-list/BanList.ts
@@ -6,6 +6,16 @@ export abstract class BanList {
 	readonly semiLimited: number[] = [];
 	readonly all: number[] = [];
 	readonly points = new Map<number, number>();
+
+	/**
+	 * Allowances shared across a group of cards, keyed by the list's own
+	 * identifier (`legend_monster`, `legend_spell`, `legend_trap` in Rush).
+	 *
+	 * Unlike forbidden/limited/semiLimited, which cap copies of ONE card, this
+	 * caps how much of a category a whole deck may spend.
+	 */
+	readonly creditLimits = new Map<string, { cap: number; cards: Map<number, number> }>();
+
 	protected _name: string | null = null;
 	protected _hash = 0x7dfcee6a;
 	private _whitelisted = false;
@@ -20,6 +30,26 @@ export abstract class BanList {
 
 	get hash(): number {
 		return this._hash;
+	}
+
+	/** Declare a category and how much of it one deck may spend. */
+	addCreditLimit(identifier: string, cap: number): void {
+		const existing = this.creditLimits.get(identifier);
+		if (existing) {
+			this.creditLimits.set(identifier, { cap, cards: existing.cards });
+			return;
+		}
+		this.creditLimits.set(identifier, { cap, cards: new Map() });
+	}
+
+	/** Tolerates arriving before its cap line — lflist order is not guaranteed. */
+	addCreditMember(identifier: string, cardId: number, credit: number): void {
+		let limit = this.creditLimits.get(identifier);
+		if (!limit) {
+			limit = { cap: 1, cards: new Map() };
+			this.creditLimits.set(identifier, limit);
+		}
+		limit.cards.set(cardId, credit);
 	}
 
 	whileListed(): void {

--- a/src/shared/deck/domain/errors/CreditLimitDeckError.ts
+++ b/src/shared/deck/domain/errors/CreditLimitDeckError.ts
@@ -1,0 +1,14 @@
+import { DeckError } from "./DeckError";
+import { DeckErrorType } from "./DeckErrorType";
+
+/**
+ * A deck spends more of a category's allowance than the list permits.
+ *
+ * Reported as CARD_BANLISTED: it is the only "this card may not be in this deck"
+ * verdict the ygopro wire protocol carries, so clients can point at the card.
+ */
+export class CreditLimitDeckError extends DeckError {
+	constructor(cardId: number, spent: number, allowed: number) {
+		super({ type: DeckErrorType.CARD_BANLISTED, code: cardId, got: spent, min: 0, max: allowed });
+	}
+}

--- a/src/shared/deck/domain/validators/CreditLimitValidationHandler.test.ts
+++ b/src/shared/deck/domain/validators/CreditLimitValidationHandler.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Rush Duel's Legend rule is a credit limit, not a copy limit: a deck may carry
+ * ONE Legend monster, ONE Legend spell and ONE Legend trap — not one copy of
+ * each Legend card. Picking Blue-Eyes spends the whole monster allowance, and
+ * the other 70 Legend monsters become unplayable in that deck.
+ *
+ * The `!RD` list expresses that with `$legend_monster 1` plus a membership line
+ * per card. `ygopro-lflist-encode` parses it into `creditLimits`, which the
+ * server used to drop on the floor — a three-Legend deck was accepted.
+ */
+
+import { BanList } from "@shared/ban-list/BanList";
+import { Deck } from "../Deck";
+import { CreditLimitDeckError } from "../errors/CreditLimitDeckError";
+import { CreditLimitValidationHandler } from "./CreditLimitValidationHandler";
+
+class TestBanList extends BanList {
+	add(cardId: number, quantity: number): void {
+		if (quantity === 0) this.forbidden.push(cardId);
+	}
+}
+
+const BLUE_EYES = 120120000;
+const DARK_MAGICIAN = 120130000;
+const TIME_WIZARD = 120102002;
+const MIRROR_FORCE = 120140001;
+const VANILLA = 120305056;
+
+function banListWithLegends(): TestBanList {
+	const list = new TestBanList();
+	list.addCreditLimit("legend_monster", 1);
+	list.addCreditLimit("legend_trap", 1);
+	for (const code of [BLUE_EYES, DARK_MAGICIAN, TIME_WIZARD]) {
+		list.addCreditMember("legend_monster", code, 1);
+	}
+	list.addCreditMember("legend_trap", MIRROR_FORCE, 1);
+	return list;
+}
+
+/** Deck stub — the handler only ever reads `allCards`. */
+function deckOf(...codes: number[]): Deck {
+	return {
+		allCards: codes.map((code) => ({ code: String(code), alias: "0" })),
+	} as unknown as Deck;
+}
+
+describe("CreditLimitValidationHandler", () => {
+	it("accepts a deck spending exactly its allowance", () => {
+		const handler = new CreditLimitValidationHandler(banListWithLegends());
+
+		expect(handler.validate(deckOf(BLUE_EYES, MIRROR_FORCE, VANILLA, VANILLA))).toBeNull();
+	});
+
+	it("rejects two different Legend monsters", () => {
+		// The rule people get wrong: these are different cards, one copy each,
+		// and the deck is still illegal.
+		const handler = new CreditLimitValidationHandler(banListWithLegends());
+
+		const error = handler.validate(deckOf(BLUE_EYES, DARK_MAGICIAN));
+
+		expect(error).toBeInstanceOf(CreditLimitDeckError);
+	});
+
+	it("rejects two copies of the same Legend monster", () => {
+		const handler = new CreditLimitValidationHandler(banListWithLegends());
+
+		expect(handler.validate(deckOf(BLUE_EYES, BLUE_EYES))).toBeInstanceOf(CreditLimitDeckError);
+	});
+
+	it("counts each category separately", () => {
+		// One monster plus one trap spends two different allowances, not one.
+		const handler = new CreditLimitValidationHandler(banListWithLegends());
+
+		expect(handler.validate(deckOf(TIME_WIZARD, MIRROR_FORCE))).toBeNull();
+	});
+
+	it("reports the offending card so the client can point at it", () => {
+		const handler = new CreditLimitValidationHandler(banListWithLegends());
+
+		const error = handler.validate(deckOf(BLUE_EYES, DARK_MAGICIAN)) as CreditLimitDeckError;
+
+		expect([BLUE_EYES, DARK_MAGICIAN]).toContain(error.code);
+	});
+
+	it("ignores cards that belong to no category", () => {
+		const handler = new CreditLimitValidationHandler(banListWithLegends());
+
+		expect(handler.validate(deckOf(VANILLA, VANILLA, VANILLA))).toBeNull();
+	});
+
+	it("passes through when the list declares no credit limits", () => {
+		// Every non-Rush format. The handler must be inert there, not a tax.
+		const handler = new CreditLimitValidationHandler(new TestBanList());
+
+		expect(handler.validate(deckOf(BLUE_EYES, DARK_MAGICIAN, TIME_WIZARD))).toBeNull();
+	});
+
+	it("delegates to the next handler when it finds nothing", () => {
+		const handler = new CreditLimitValidationHandler(banListWithLegends());
+		const next = { validate: jest.fn().mockReturnValue(null), setNextHandler: jest.fn() };
+		handler.setNextHandler(next as never);
+
+		handler.validate(deckOf(VANILLA));
+
+		expect(next.validate).toHaveBeenCalled();
+	});
+
+	it("does not reach the next handler once a deck is already illegal", () => {
+		const handler = new CreditLimitValidationHandler(banListWithLegends());
+		const next = { validate: jest.fn().mockReturnValue(null), setNextHandler: jest.fn() };
+		handler.setNextHandler(next as never);
+
+		handler.validate(deckOf(BLUE_EYES, DARK_MAGICIAN));
+
+		expect(next.validate).not.toHaveBeenCalled();
+	});
+});

--- a/src/shared/deck/domain/validators/CreditLimitValidationHandler.ts
+++ b/src/shared/deck/domain/validators/CreditLimitValidationHandler.ts
@@ -1,0 +1,54 @@
+import { BanList } from "@shared/ban-list/BanList";
+import { Deck } from "../Deck";
+import { CreditLimitDeckError } from "../errors/CreditLimitDeckError";
+import { DeckError } from "../errors/DeckError";
+import { DeckValidationHandler } from "./DeckValidationHandler";
+
+/**
+ * Enforces a list's credit limits — an allowance shared across a GROUP of cards,
+ * rather than a per-card copy cap.
+ *
+ * Rush Duel's Legend rule is the case this exists for: a deck may carry one
+ * Legend monster, one Legend spell and one Legend trap. Not one copy of each —
+ * one card out of the ~70 that carry the mark, so Blue-Eyes and Dark Magician
+ * cannot share a deck, and two copies of either are just as illegal.
+ */
+export class CreditLimitValidationHandler implements DeckValidationHandler {
+	private nextHandler: DeckValidationHandler | null = null;
+
+	constructor(private readonly banList: BanList) {}
+
+	setNextHandler(handler: DeckValidationHandler): DeckValidationHandler {
+		this.nextHandler = handler;
+
+		return handler;
+	}
+
+	validate(deck: Deck): DeckError | null {
+		for (const [, limit] of this.banList.creditLimits) {
+			let spent = 0;
+			let offender: number | null = null;
+
+			for (const card of deck.allCards) {
+				const credit = limit.cards.get(Number(card.code));
+				if (credit === undefined) continue;
+
+				spent += credit;
+				if (spent > limit.cap) {
+					offender = Number(card.code);
+					break;
+				}
+			}
+
+			if (offender !== null) {
+				return new CreditLimitDeckError(offender, spent, limit.cap);
+			}
+		}
+
+		if (this.nextHandler) {
+			return this.nextHandler.validate(deck);
+		}
+
+		return null;
+	}
+}

--- a/src/ygopro/ban-list/infrastructure/YGOProBanListLoader.ts
+++ b/src/ygopro/ban-list/infrastructure/YGOProBanListLoader.ts
@@ -106,6 +106,13 @@ export class YGOProBanListLoader {
 
 			lflist.entries.forEach((entry) => banList.add(entry.code, entry.limit));
 
+			for (const credit of lflist.creditLimits ?? []) {
+				banList.addCreditLimit(credit.identifier, credit.limit);
+				for (const member of credit.entries ?? []) {
+					banList.addCreditMember(credit.identifier, member.code, member.credit);
+				}
+			}
+
 			if (isWhitelist || banList.isGenesys()) {
 				this.parseUnrestrictedEntries(text, banList);
 			}

--- a/src/ygopro/card/infrastructure/CardYGOProRepository.ts
+++ b/src/ygopro/card/infrastructure/CardYGOProRepository.ts
@@ -2,13 +2,14 @@ import type { CardReaderFn } from "koishipro-core.js";
 import { Card } from "@shared/card/domain/Card";
 import { CardRepository } from "@shared/card/domain/CardRepository";
 import { YGOProResourceLoader } from "@ygopro/ygopro";
+import { DEFAULT_POOL } from "@ygopro/ygopro/PoolSelection";
 
 export class CardYGOProRepository implements CardRepository {
-	constructor(private readonly useExtendedCardPool: boolean = false) {}
+	constructor(private readonly cardPool: string = DEFAULT_POOL) {}
 
 	private async getCardReader(): Promise<CardReaderFn> {
 		const loader = YGOProResourceLoader.get();
-		return this.useExtendedCardPool ? loader.getExtendedCardReader() : loader.getCardReader();
+		return loader.getPoolCardReader(this.cardPool);
 	}
 
 	async findByCode(code: string): Promise<Card | null> {

--- a/src/ygopro/deck/domain/YGOProDeckValidator.ts
+++ b/src/ygopro/deck/domain/YGOProDeckValidator.ts
@@ -10,6 +10,7 @@ import { AvailableCardValidationHandler } from "@shared/deck/domain/validators/A
 import { GenesysRulesValidationHandler } from "@shared/deck/domain/validators/GenesysRulesValidationHandler";
 import { MaxCopiesValidationHandler } from "@shared/deck/domain/validators/MaxCopiesValidationHandler";
 import { EdoproBanList } from "@edopro/ban-list/domain/BanList";
+import { CreditLimitValidationHandler } from "@shared/deck/domain/validators/CreditLimitValidationHandler";
 import { CardAvailabilityValidationHandler } from "./validators/CardAvailabilityValidationHandler";
 
 /**
@@ -43,6 +44,9 @@ export class YGOProDeckValidator {
 			.setNextHandler(new ForbiddenCardValidationHandler(this.banList))
 			.setNextHandler(new SemiLimitedCardValidationHandler(this.banList))
 			.setNextHandler(new LimitedCardValidationHandler(this.banList))
+			// Rush Duel's Legend rule. Inert for every list that declares no
+			// credit limits, so it costs nothing on the other formats.
+			.setNextHandler(new CreditLimitValidationHandler(this.banList))
 			.setNextHandler(new CardAvailabilityValidationHandler(this.deckRules.rule))
 			.setNextHandler(new NoLimitedCardValidationHandler(this.banList))
 			.setNextHandler(new AvailableCardValidationHandler(this.banList));

--- a/src/ygopro/ocgcore-worker/ocgcore.ts
+++ b/src/ygopro/ocgcore-worker/ocgcore.ts
@@ -146,12 +146,8 @@ export class OCGCore {
 		];
 
 		const loader = YGOProResourceLoader.get();
-		const cardStorage = this.room.useExtendedCardPool
-			? await loader.getExtendedCardStorage()
-			: await loader.getStandardCardStorage();
-		const scriptSearchPaths = this.room.useExtendedCardPool
-			? [...loader.ygoproPaths, ...loader.extraFolderPaths]
-			: loader.ygoproPaths;
+		const cardStorage = await loader.getPoolCardStorage(this.room.cardPool);
+		const scriptSearchPaths = loader.getPoolScriptPaths(this.room.cardPool);
 		const ocgcoreWasmBinary = await loader.getOcgcoreWasmBinary();
 
 		const registry: Record<string, string> = {
@@ -167,9 +163,7 @@ export class OCGCore {
 			registry[`player_name_${index}`] = player.name;
 		});
 
-		const cardReader = this.room.useExtendedCardPool
-			? await loader.getExtendedCardReader()
-			: await loader.getCardReader();
+		const cardReader = await loader.getPoolCardReader(this.room.cardPool);
 
 		const decks = duelRecord
 			.toSwappedPlayers()

--- a/src/ygopro/room/domain/RuleMappings.test.ts
+++ b/src/ygopro/room/domain/RuleMappings.test.ts
@@ -3,7 +3,13 @@ import { GameMode } from "ygopro-msg-encode";
 import MercuryBanListMemoryRepository from "../../ban-list/infrastructure/YGOProBanListMemoryRepository";
 import { YGOProBanList } from "../../ban-list/domain/YGOProBanList";
 import LoggerFactory from "src/shared/logger/infrastructure/LoggerFactory";
-import { formatRuleMappings, isRecognizedToken, priorityRuleMappings } from "./RuleMappings";
+import {
+	formatRuleMappings,
+	isRecognizedToken,
+	priorityRuleMappings,
+	resolveCardPool,
+} from "./RuleMappings";
+import { DEFAULT_POOL, EXTENDED_POOL } from "src/ygopro/ygopro/PoolSelection";
 
 // isRecognizedToken(token) is the predicate the pairing feature uses to
 // decide whether every comma-separated token in a join command is a known
@@ -307,5 +313,42 @@ describe("jtp-2007-03 mapping (JTP Advanced March 2007)", () => {
 	it("validates only the exact token", () => {
 		expect(formatRuleMappings["jtp-2007-03"].validate("jtp-2007-03")).toBe(true);
 		expect(formatRuleMappings["jtp-2007-03"].validate("jtp")).toBe(false);
+	});
+});
+
+describe("resolveCardPool", () => {
+	it("defaults to the standard pool when no option declares one", () => {
+		expect(resolveCardPool(["edison", "casual"])).toBe(DEFAULT_POOL);
+	});
+
+	it("defaults to the standard pool for an empty option list", () => {
+		expect(resolveCardPool([])).toBe(DEFAULT_POOL);
+	});
+
+	it("selects the extended pool for prerelease and custom-art tokens", () => {
+		for (const token of ["pre", "tcgpre", "ocgpre", "tcgart", "ocgart"]) {
+			expect(resolveCardPool([token])).toBe(EXTENDED_POOL);
+		}
+	});
+
+	it("selects the rush pool for the rush token", () => {
+		// Rush cards live in their own pool: base OCG/TCG cards are not part of
+		// the format, so they are absent rather than banned.
+		expect(resolveCardPool(["rush"])).toBe("rush");
+	});
+
+	it("matches tokens case-insensitively", () => {
+		expect(resolveCardPool(["RUSH"])).toBe("rush");
+	});
+
+	it("takes the first declaring token when options disagree", () => {
+		// Deterministic instead of order-dependent-by-accident: a room asking for
+		// both rush and prereleases resolves to whichever the host typed first.
+		expect(resolveCardPool(["rush", "pre"])).toBe("rush");
+		expect(resolveCardPool(["pre", "rush"])).toBe(EXTENDED_POOL);
+	});
+
+	it("ignores non-declaring tokens while scanning", () => {
+		expect(resolveCardPool(["casual", "tm300", "rush"])).toBe("rush");
 	});
 });

--- a/src/ygopro/room/domain/RuleMappings.test.ts
+++ b/src/ygopro/room/domain/RuleMappings.test.ts
@@ -352,3 +352,19 @@ describe("resolveCardPool", () => {
 		expect(resolveCardPool(["casual", "tm300", "rush"])).toBe("rush");
 	});
 });
+
+describe("rush mapping", () => {
+	it("deals a 4-card opening hand", () => {
+		// Rush deals 4 and the draw-to-5 rule in RDRule.lua tops the turn player
+		// up during the Draw Phase. Leaving the default 5 would start every
+		// player one card ahead.
+		expect(formatRuleMappings.rush.get().start_hand).toBe(4);
+	});
+
+	it("uses the only master rule that allows Fusion Summons", () => {
+		// Verified in evolution-ygopro-core (rush-fusion-zone.integration.test.ts):
+		// under duel_rule 4 the Fusion spell never becomes activatable, because
+		// RDRule.lua disables the Extra Monster Zones and Rush has no Links.
+		expect(formatRuleMappings.rush.get().duel_rule).toBe(5);
+	});
+});

--- a/src/ygopro/room/domain/RuleMappings.ts
+++ b/src/ygopro/room/domain/RuleMappings.ts
@@ -633,7 +633,15 @@ export const formatRuleMappings: RuleMappings = {
 			return {
 				rule: 5,
 				lflist: index !== -1 ? index : 2,
-				duel_rule: 4,
+				// Must be 5. RDRule.lua disables both Extra Monster Zones, and under
+				// duel_rule 4 those are the only zones an Extra Deck monster may enter
+				// without a Link — which Rush does not have — so Fusion Summons become
+				// impossible. Lower rules would allow the summon but leave the Pendulum
+				// Zones open at S/T 6-7, outside the mask.
+				duel_rule: 5,
+				// Rush deals 4; RDRule.lua tops the turn player up to 5 during the
+				// Draw Phase via EFFECT_DRAW_COUNT.
+				start_hand: 4,
 			};
 		},
 		validate: (value) => {

--- a/src/ygopro/room/domain/RuleMappings.ts
+++ b/src/ygopro/room/domain/RuleMappings.ts
@@ -2,6 +2,7 @@ import MercuryBanListMemoryRepository from "../../ban-list/infrastructure/YGOPro
 import LoggerFactory from "src/shared/logger/infrastructure/LoggerFactory";
 import { GameMode } from "ygopro-msg-encode";
 import { HostInfo } from "./host-info/HostInfo";
+import { DEFAULT_POOL, EXTENDED_POOL, RUSH_POOL } from "src/ygopro/ygopro/PoolSelection";
 
 interface RuleMappings {
 	[key: string]: {
@@ -778,11 +779,31 @@ export function isRecognizedToken(token: string): boolean {
 	);
 }
 
-export const extendedCardPoolFormats = new Set([
-	"pre",
-	"tcgpre",
-	"ocgpre",
-	"tcgart",
-	"ocgart",
-	"rushpre",
+/**
+ * Card pool per format token. A token absent from this map plays out of the
+ * standard pool.
+ *
+ * The prerelease and art tokens widen the standard pool; `rush` replaces it,
+ * since OCG cards are absent from that format rather than banned. `rushpre` is
+ * the prerelease token, not the Rush one, so it stays on extended.
+ */
+const formatCardPools = new Map<string, string>([
+	["pre", EXTENDED_POOL],
+	["tcgpre", EXTENDED_POOL],
+	["ocgpre", EXTENDED_POOL],
+	["tcgart", EXTENDED_POOL],
+	["ocgart", EXTENDED_POOL],
+	["rushpre", EXTENDED_POOL],
+	["rush", RUSH_POOL],
 ]);
+
+/** First option declaring a pool wins, so the result never depends on map order. */
+export function resolveCardPool(options: string[]): string {
+	for (const option of options) {
+		const pool = formatCardPools.get(option.toLowerCase());
+		if (pool !== undefined) {
+			return pool;
+		}
+	}
+	return DEFAULT_POOL;
+}

--- a/src/ygopro/room/domain/YGOProRoom.test.ts
+++ b/src/ygopro/room/domain/YGOProRoom.test.ts
@@ -10,6 +10,7 @@ import { YGOProBanList } from "@ygopro/ban-list/domain/YGOProBanList";
 import BanListMemoryRepository from "@edopro/ban-list/infrastructure/BanListMemoryRepository";
 import { EdoproBanList } from "@edopro/ban-list/domain/BanList";
 import { YGOProRoom } from "./YGOProRoom";
+import { DEFAULT_POOL, EXTENDED_POOL, RUSH_POOL } from "src/ygopro/ygopro/PoolSelection";
 import { LoggerMock } from "@test-support/mocks/logger/LoggerMock";
 import { MessageRepositoryMock } from "@test-support/mocks/MessageRepositoryMock";
 
@@ -96,7 +97,7 @@ describe("YGOProRoom", () => {
 		expect(room.hostInfo.lflist).toBe(0);
 		expect(room.hostInfo.mode).toBe(GameMode.MATCH);
 		expect(room.hostInfo.start_hand).toBe(7);
-		expect(room.useExtendedCardPool).toBe(false);
+		expect(room.cardPool).toBe(DEFAULT_POOL);
 	});
 
 	it("Should create a toot room with rule 5 (all cards), TCG banlist and match mode", () => {
@@ -104,7 +105,7 @@ describe("YGOProRoom", () => {
 		expect(room.hostInfo.rule).toBe(5);
 		expect(room.hostInfo.mode).toBe(GameMode.MATCH);
 		expect(room.hostInfo.start_hand).toBe(7);
-		expect(room.useExtendedCardPool).toBe(false);
+		expect(room.cardPool).toBe(DEFAULT_POOL);
 	});
 
 	it("Should treat tt as the toot alias (rule 5, TCG banlist) — matchmaking's wire-budget token", () => {
@@ -289,7 +290,7 @@ describe("YGOProRoom", () => {
 			expect(room.hostInfo.duel_rule).toBe(1);
 			expect(room.hostInfo.time_limit).toBe(450);
 			expect(room.hostInfo.start_hand).toBe(6);
-			expect(room.useExtendedCardPool).toBe(false);
+			expect(room.cardPool).toBe(DEFAULT_POOL);
 		});
 	});
 
@@ -301,7 +302,7 @@ describe("YGOProRoom", () => {
 			expect(room.hostInfo.mode).toBe(GameMode.MATCH);
 			expect(room.hostInfo.start_hand).toBe(6);
 			expect(room.hostInfo.time_limit).toBe(400);
-			expect(room.useExtendedCardPool).toBe(false);
+			expect(room.cardPool).toBe(DEFAULT_POOL);
 		});
 	});
 
@@ -381,7 +382,20 @@ describe("YGOProRoom", () => {
 
 		it("Should use extended card pool for pre format", () => {
 			const room = YGOProRoomMother.create({ command: "pre#123" });
-			expect(room.useExtendedCardPool).toBe(true);
+			expect(room.cardPool).toBe(EXTENDED_POOL);
+		});
+
+		it("Should use the rush card pool for rush format", () => {
+			// Rush is not a widened standard pool: its cards and scripts are a
+			// separate universe, so the room must not fall back to standard.
+			const room = YGOProRoomMother.create({ command: "rush#123" });
+			expect(room.cardPool).toBe(RUSH_POOL);
+		});
+
+		it("Should keep rushpre on the extended pool, not the rush pool", () => {
+			// rushpre is the prerelease token; only `rush` selects the Rush pool.
+			const room = YGOProRoomMother.create({ command: "rushpre#123" });
+			expect(room.cardPool).toBe(EXTENDED_POOL);
 		});
 
 		it("Should create a tcgpre room with rule 5 (no scope restriction) and extended card pool", () => {
@@ -389,7 +403,7 @@ describe("YGOProRoom", () => {
 			expect(room.hostInfo.rule).toBe(5);
 			expect(room.hostInfo.duel_rule).toBe(5);
 			expect(room.hostInfo.time_limit).toBe(800);
-			expect(room.useExtendedCardPool).toBe(true);
+			expect(room.cardPool).toBe(EXTENDED_POOL);
 		});
 
 		it("Should create an ocgpre room with rule 5 (no scope restriction) and extended card pool", () => {
@@ -397,7 +411,7 @@ describe("YGOProRoom", () => {
 			expect(room.hostInfo.rule).toBe(5);
 			expect(room.hostInfo.lflist).toBe(0);
 			expect(room.hostInfo.duel_rule).toBe(5);
-			expect(room.useExtendedCardPool).toBe(true);
+			expect(room.cardPool).toBe(EXTENDED_POOL);
 		});
 
 		it("Should create a tcgart room with rule 5 (no scope restriction) and extended card pool", () => {
@@ -405,7 +419,7 @@ describe("YGOProRoom", () => {
 			expect(room.hostInfo.rule).toBe(5);
 			expect(room.hostInfo.duel_rule).toBe(5);
 			expect(room.hostInfo.time_limit).toBe(800);
-			expect(room.useExtendedCardPool).toBe(true);
+			expect(room.cardPool).toBe(EXTENDED_POOL);
 		});
 
 		it("Should create an ocgart room with rule 5 (no scope restriction) and extended card pool", () => {
@@ -413,17 +427,17 @@ describe("YGOProRoom", () => {
 			expect(room.hostInfo.rule).toBe(5);
 			expect(room.hostInfo.lflist).toBe(0);
 			expect(room.hostInfo.duel_rule).toBe(5);
-			expect(room.useExtendedCardPool).toBe(true);
+			expect(room.cardPool).toBe(EXTENDED_POOL);
 		});
 
 		it("Should NOT use extended card pool for standard formats", () => {
 			const room = YGOProRoomMother.create({ command: "m#123" });
-			expect(room.useExtendedCardPool).toBe(false);
+			expect(room.cardPool).toBe(DEFAULT_POOL);
 		});
 
 		it("Should NOT use extended card pool for ot format", () => {
 			const room = YGOProRoomMother.create({ command: "ot#123" });
-			expect(room.useExtendedCardPool).toBe(false);
+			expect(room.cardPool).toBe(DEFAULT_POOL);
 		});
 	});
 
@@ -433,7 +447,7 @@ describe("YGOProRoom", () => {
 			expect(room.hostInfo.rule).toBe(5);
 			expect(room.hostInfo.duel_rule).toBe(2);
 			expect(room.hostInfo.start_hand).toBe(5);
-			expect(room.useExtendedCardPool).toBe(false);
+			expect(room.cardPool).toBe(DEFAULT_POOL);
 		});
 	});
 
@@ -443,7 +457,7 @@ describe("YGOProRoom", () => {
 			expect(room.hostInfo.rule).toBe(5);
 			expect(room.hostInfo.duel_rule).toBe(2);
 			expect(room.hostInfo.mode).toBe(GameMode.MATCH);
-			expect(room.useExtendedCardPool).toBe(false);
+			expect(room.cardPool).toBe(DEFAULT_POOL);
 		});
 	});
 
@@ -453,7 +467,7 @@ describe("YGOProRoom", () => {
 			expect(room.hostInfo.rule).toBe(5);
 			expect(room.hostInfo.duel_rule).toBe(2);
 			expect(room.hostInfo.time_limit).toBe(450);
-			expect(room.useExtendedCardPool).toBe(false);
+			expect(room.cardPool).toBe(DEFAULT_POOL);
 		});
 	});
 
@@ -532,7 +546,7 @@ describe("YGOProRoom", () => {
 			expect(room.hostInfo.rule).toBe(5);
 			expect(room.hostInfo.duel_rule).toBe(1);
 			expect(room.hostInfo.time_limit).toBe(500);
-			expect(room.useExtendedCardPool).toBe(false);
+			expect(room.cardPool).toBe(DEFAULT_POOL);
 		});
 	});
 

--- a/src/ygopro/room/domain/YGOProRoom.ts
+++ b/src/ygopro/room/domain/YGOProRoom.ts
@@ -23,7 +23,7 @@ import { Deck } from "@shared/deck/domain/Deck";
 import MercuryBanListMemoryRepository from "../../ban-list/infrastructure/YGOProBanListMemoryRepository";
 import { YGOProClient } from "../../client/domain/YGOProClient";
 import {
-	extendedCardPoolFormats,
+	resolveCardPool,
 	formatRuleMappings,
 	priorityRuleMappings,
 	ruleMappings,
@@ -73,7 +73,7 @@ export class YGOProRoom extends YgoRoom {
 	readonly league: RoomLeague;
 	readonly createdBySocketId: string;
 	readonly banListHash: number;
-	readonly useExtendedCardPool: boolean;
+	readonly cardPool: string;
 	//TODO: compatibility with edopro list and rank;
 	private _edoBanListHash: number;
 	private _logger: Logger;
@@ -117,7 +117,7 @@ export class YGOProRoom extends YgoRoom {
 		startLp,
 		messageRepository,
 		banListHash,
-		useExtendedCardPool,
+		cardPool,
 	}: {
 		id: number;
 		password: string;
@@ -131,7 +131,7 @@ export class YGOProRoom extends YgoRoom {
 		startLp: number;
 		messageRepository: MessageRepository;
 		banListHash: number;
-		useExtendedCardPool: boolean;
+		cardPool: string;
 	}) {
 		super({
 			team0,
@@ -150,10 +150,10 @@ export class YGOProRoom extends YgoRoom {
 		this._hostInfo = hostInfo;
 		this._state = DuelState.WAITING;
 		this.banListHash = banListHash;
-		this.useExtendedCardPool = useExtendedCardPool;
+		this.cardPool = cardPool;
 		this.createdBySocketId = createdBySocketId;
 		this._messageRepository = messageRepository;
-		this._cardRepository = new CardYGOProRepository(this.useExtendedCardPool);
+		this._cardRepository = new CardYGOProRepository(this.cardPool);
 		this._deckRules = new DeckRules({
 			mainMin: 40,
 			mainMax: 60,
@@ -228,7 +228,7 @@ export class YGOProRoom extends YgoRoom {
 			rankedOverride,
 			hasPin: Boolean(playerInfo.password),
 		});
-		const useExtendedCardPool = options.some((opt) => extendedCardPoolFormats.has(opt));
+		const cardPool = resolveCardPool(options);
 		const banList = MercuryBanListMemoryRepository.findLFListByIndex(hostInfo.lflist);
 		const banListHash = banList?.hash ?? 0;
 
@@ -245,7 +245,7 @@ export class YGOProRoom extends YgoRoom {
 			startLp: hostInfo.start_lp,
 			messageRepository,
 			banListHash,
-			useExtendedCardPool,
+			cardPool,
 		});
 
 		room._logger = logger.child({ file: "MercuryRoom" });

--- a/src/ygopro/room/domain/states/YGOProSideDeckingState.test.ts
+++ b/src/ygopro/room/domain/states/YGOProSideDeckingState.test.ts
@@ -67,7 +67,7 @@ describe("YGOProSideDeckingState.handleUpdateDeck — deck error code is encoded
 			players: [], // empty → constructor schedules no side-deck timers
 			banListHash: 0,
 			hostInfo: { rule: 0 }, // referenced by the warn() log on the error paths
-			useExtendedCardPool: false,
+			cardPool: "standard",
 			shouldValidateDeck: jest.fn().mockReturnValue(true),
 			notReadyUnsafe: jest.fn(),
 			setDecksToPlayerUnsafe: jest.fn(),
@@ -167,7 +167,7 @@ describe("YGOProSideDeckingState — post-side turn choice", () => {
 			players,
 			banListHash: 0,
 			hostInfo: { rule: 0 },
-			useExtendedCardPool: false,
+			cardPool: "standard",
 			shouldValidateDeck: jest.fn().mockReturnValue(false),
 			notReadyUnsafe: jest.fn(),
 			setDecksToPlayerUnsafe: jest.fn(),

--- a/src/ygopro/room/domain/states/YGOProSideDeckingState.ts
+++ b/src/ygopro/room/domain/states/YGOProSideDeckingState.ts
@@ -243,7 +243,7 @@ export class YGOProSideDeckingState extends YGOProRoomState {
 
 		if (deckOrError instanceof DeckError) {
 			this.logger.warn(
-				`Deck build error: type=0x${deckOrError.type.toString(16)}, code=${deckOrError.code}, rule=${room.hostInfo.rule}, extendedPool=${room.useExtendedCardPool}`,
+				`Deck build error: type=0x${deckOrError.type.toString(16)}, code=${deckOrError.code}, rule=${room.hostInfo.rule}, pool=${room.cardPool}`,
 			);
 			room.notReadyUnsafe(player);
 			player.sendMessageToClient(
@@ -260,7 +260,7 @@ export class YGOProSideDeckingState extends YGOProRoomState {
 		if (hasError) {
 			const failedCard = deck.allCards.find((c) => Number(c.code) === hasError.code);
 			this.logger.warn(
-				`Deck validation error: type=0x${hasError.type.toString(16)}, code=${hasError.code}, cardOt=${failedCard?.variant ?? "N/A"}, rule=${room.hostInfo.rule}, extendedPool=${room.useExtendedCardPool}`,
+				`Deck validation error: type=0x${hasError.type.toString(16)}, code=${hasError.code}, cardOt=${failedCard?.variant ?? "N/A"}, rule=${room.hostInfo.rule}, pool=${room.cardPool}`,
 			);
 			room.notReadyUnsafe(player);
 			player.sendMessageToClient(

--- a/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
@@ -104,7 +104,7 @@ describe("YGOProWaitingState.handleUpdateDeck", () => {
 				errorMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
 			},
 			hostInfo: { rule: 0 },
-			useExtendedCardPool: false,
+			cardPool: "standard",
 		} as unknown as jest.Mocked<YGOProRoom>;
 
 		mockPlayer = {

--- a/src/ygopro/room/domain/states/YGOProWaitingState.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.ts
@@ -233,7 +233,7 @@ export class YGOProWaitingState extends YGOProRoomState {
 
 		if (deckOrError instanceof DeckError) {
 			this.logger.warn(
-				`Deck build error: type=0x${deckOrError.type.toString(16)}, code=${deckOrError.code}, rule=${room.hostInfo.rule}, extendedPool=${room.useExtendedCardPool}`,
+				`Deck build error: type=0x${deckOrError.type.toString(16)}, code=${deckOrError.code}, rule=${room.hostInfo.rule}, pool=${room.cardPool}`,
 			);
 			room.notReadyUnsafe(player);
 			player.sendMessageToClient(
@@ -258,7 +258,7 @@ export class YGOProWaitingState extends YGOProRoomState {
 		if (hasError) {
 			const failedCard = deck.allCards.find((c) => Number(c.code) === hasError.code);
 			this.logger.warn(
-				`Deck validation error: type=0x${hasError.type.toString(16)}, code=${hasError.code}, cardOt=${failedCard?.variant ?? "N/A"}, rule=${room.hostInfo.rule}, extendedPool=${room.useExtendedCardPool}`,
+				`Deck validation error: type=0x${hasError.type.toString(16)}, code=${hasError.code}, cardOt=${failedCard?.variant ?? "N/A"}, rule=${room.hostInfo.rule}, pool=${room.cardPool}`,
 			);
 			room.notReadyUnsafe(player);
 			player.sendMessageToClient(

--- a/src/ygopro/ygopro/PoolSelection.test.ts
+++ b/src/ygopro/ygopro/PoolSelection.test.ts
@@ -1,0 +1,92 @@
+import type { Logger } from "src/shared/logger/domain/Logger";
+import type { ResolvedPools } from "./ResourcePoolResolver";
+import { DEFAULT_POOL, EXTENDED_POOL, lflistScanPaths, selectPoolPaths } from "./PoolSelection";
+
+function makeLogger(): jest.Mocked<Logger> {
+	return {
+		debug: jest.fn(),
+		error: jest.fn(),
+		info: jest.fn(),
+		warn: jest.fn(),
+		child: jest.fn().mockReturnThis(),
+	};
+}
+
+const BASE = "/res/ygopro/base";
+const OCG = "/res/ygopro/formats/ocg";
+const PRERELEASES = "/res/ygopro/extensions/prereleases";
+const RUSH = "/res/ygopro/formats/rush";
+
+const POOLS: ResolvedPools = {
+	standard: [BASE, OCG],
+	extended: [BASE, OCG, PRERELEASES],
+	named: {
+		rush: { scripts: [BASE, RUSH], cards: [RUSH] },
+	},
+};
+
+describe("selectPoolPaths", () => {
+	it("maps the standard pool to the same paths for scripts and cards", () => {
+		expect(selectPoolPaths(POOLS, DEFAULT_POOL, makeLogger())).toEqual({
+			scripts: [BASE, OCG],
+			cards: [BASE, OCG],
+		});
+	});
+
+	it("maps the extended pool to standard plus the extensions delta", () => {
+		expect(selectPoolPaths(POOLS, EXTENDED_POOL, makeLogger())).toEqual({
+			scripts: [BASE, OCG, PRERELEASES],
+			cards: [BASE, OCG, PRERELEASES],
+		});
+	});
+
+	it("returns a named pool's independent script and card paths", () => {
+		// Rush is the reason scripts and cards are separate: base is on the
+		// script path for utility.lua, but its cards are not part of the format.
+		expect(selectPoolPaths(POOLS, "rush", makeLogger())).toEqual({
+			scripts: [BASE, RUSH],
+			cards: [RUSH],
+		});
+	});
+
+	it("falls back to the standard pool for an unknown name and logs an error", () => {
+		const logger = makeLogger();
+
+		const selected = selectPoolPaths(POOLS, "speed", logger);
+
+		expect(selected).toEqual({ scripts: [BASE, OCG], cards: [BASE, OCG] });
+		expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("speed"));
+	});
+
+	it("does not let an unknown name silently produce an empty pool", () => {
+		// A duel booted with no cards and no scripts would fail in the engine with
+		// an opaque error; falling back to standard keeps the room playable.
+		const selected = selectPoolPaths(POOLS, "typo", makeLogger());
+
+		expect(selected.cards.length).toBeGreaterThan(0);
+		expect(selected.scripts.length).toBeGreaterThan(0);
+	});
+});
+
+describe("lflistScanPaths", () => {
+	it("starts with the standard pool, in order", () => {
+		expect(lflistScanPaths(POOLS).slice(0, 2)).toEqual([BASE, OCG]);
+	});
+
+	it("includes named pool directories so their ban lists are discoverable", () => {
+		// A named pool sits outside the standard pool by design, so without this
+		// its lflist.conf is never scanned and the format's alias resolves to
+		// whichever list happens to sit at the fallback index.
+		expect(lflistScanPaths(POOLS)).toContain(RUSH);
+	});
+
+	it("does not scan a directory twice when a named pool reuses it", () => {
+		// The rush pool lists BASE among its scripts; scanning it again would
+		// load every base ban list a second time.
+		expect(lflistScanPaths(POOLS).filter((p) => p === BASE)).toHaveLength(1);
+	});
+
+	it("omits the extensions delta, which carries no ban lists", () => {
+		expect(lflistScanPaths(POOLS)).not.toContain(PRERELEASES);
+	});
+});

--- a/src/ygopro/ygopro/PoolSelection.ts
+++ b/src/ygopro/ygopro/PoolSelection.ts
@@ -1,0 +1,74 @@
+import type { Logger } from "src/shared/logger/domain/Logger";
+import type { ResolvedPools } from "./ResourcePoolResolver";
+
+/** Pool used by every format that does not ask for another one. */
+export const DEFAULT_POOL = "standard";
+
+/** Standard pool plus the extensions delta (prereleases, custom art). */
+export const EXTENDED_POOL = "extended";
+
+/** Must match the `runtime.ygopro.pools` key in resources.manifest.json. */
+export const RUSH_POOL = "rush";
+
+/** The script search path and card pool a duel boots with. */
+export interface SelectedPoolPaths {
+	scripts: string[];
+	cards: string[];
+}
+
+/**
+ * Directories to scan for lflist.conf files.
+ *
+ * The standard pool comes first and keeps its manifest order: ban list indices
+ * are positional and clients address lists by index. Named pools are appended,
+ * deduplicated (they usually list `base` among their scripts). The extensions
+ * delta carries cards and art, not ban lists.
+ */
+export function lflistScanPaths(pools: ResolvedPools): string[] {
+	const seen = new Set<string>(pools.standard);
+	const paths = [...pools.standard];
+
+	for (const pool of Object.values(pools.named)) {
+		for (const dir of [...pool.cards, ...pool.scripts]) {
+			if (seen.has(dir)) {
+				continue;
+			}
+			seen.add(dir);
+			paths.push(dir);
+		}
+	}
+
+	return paths;
+}
+
+/**
+ * Resolve a pool name to the paths a duel needs.
+ *
+ * An unknown name falls back to standard rather than to nothing: an empty pool
+ * boots a duel with no cards and no scripts, which surfaces as an opaque engine
+ * failure, while a room on the wrong pool is visible and recoverable.
+ */
+export function selectPoolPaths(
+	pools: ResolvedPools,
+	name: string,
+	logger: Logger,
+): SelectedPoolPaths {
+	if (name === DEFAULT_POOL) {
+		return { scripts: pools.standard, cards: pools.standard };
+	}
+
+	if (name === EXTENDED_POOL) {
+		return { scripts: pools.extended, cards: pools.extended };
+	}
+
+	const named = pools.named[name];
+	if (named) {
+		return { scripts: named.scripts, cards: named.cards };
+	}
+
+	logger.error(
+		`PoolSelection: unknown pool "${name}" — no runtime.ygopro.pools entry declares it. ` +
+			`Falling back to the "${DEFAULT_POOL}" pool.`,
+	);
+	return { scripts: pools.standard, cards: pools.standard };
+}

--- a/src/ygopro/ygopro/ResourcePoolResolver.test.ts
+++ b/src/ygopro/ygopro/ResourcePoolResolver.test.ts
@@ -509,3 +509,245 @@ describe("ResourcePoolResolver — one-shot diagnostics", () => {
 		expect(dupWarns).toHaveLength(1);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Named pools — per-format script/card path sets
+// ---------------------------------------------------------------------------
+
+describe("ResourcePoolResolver — named pools", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "named-pools-"));
+		__resetResolverWarnings();
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	/** Rush is the motivating case: base scripts, but a card pool without base. */
+	const RUSH_MANIFEST = {
+		runtime: {
+			ygopro: {
+				standard: STANDARD_LEAVES,
+				extended: EXTENDED_LEAVES,
+				pools: {
+					rush: {
+						scripts: ["base", "formats/rush"],
+						cards: ["formats/rush"],
+					},
+				},
+			},
+		},
+	};
+
+	function abs(resourcesDir: string, leaf: string): string {
+		return path.join(path.resolve(resourcesDir), "ygopro", leaf);
+	}
+
+	it("resolves a named pool's script and card paths independently", () => {
+		const manifestPath = writeManifest(tmpDir, RUSH_MANIFEST);
+		const resourcesDir = "/test/resources/current";
+
+		const { named } = resolvePools(opts({ manifestPath, resourcesDir }));
+
+		expect(named.rush).toEqual({
+			scripts: [abs(resourcesDir, "base"), abs(resourcesDir, "formats/rush")],
+			cards: [abs(resourcesDir, "formats/rush")],
+		});
+	});
+
+	it("preserves declaration order within each path set", () => {
+		const manifestPath = writeManifest(tmpDir, RUSH_MANIFEST);
+		const resourcesDir = "/test/resources/current";
+
+		const { named } = resolvePools(opts({ manifestPath, resourcesDir }));
+
+		// Base must come first: rush scripts depend on utility.lua / constant.lua.
+		expect(named.rush.scripts[0]).toBe(abs(resourcesDir, "base"));
+	});
+
+	it("leaves standard and extended untouched when named pools are present", () => {
+		const manifestPath = writeManifest(tmpDir, RUSH_MANIFEST);
+		const resourcesDir = "/test/resources/current";
+
+		const { standard, extended } = resolvePools(opts({ manifestPath, resourcesDir }));
+
+		expect(standard).toEqual(STANDARD_LEAVES.map((leaf) => abs(resourcesDir, leaf)));
+		expect(extended).toEqual(
+			[...STANDARD_LEAVES, ...EXTENDED_LEAVES].map((leaf) => abs(resourcesDir, leaf)),
+		);
+	});
+
+	it("returns an empty map when the manifest declares no pools", () => {
+		const manifestPath = writeManifest(tmpDir, VALID_MANIFEST);
+
+		const { named } = resolvePools(opts({ manifestPath, resourcesDir: "/test/resources/current" }));
+
+		expect(named).toEqual({});
+	});
+
+	it("skips a pool missing its cards list and logs an error", () => {
+		const logger = makeLogger();
+		const manifestPath = writeManifest(tmpDir, {
+			runtime: {
+				ygopro: {
+					standard: STANDARD_LEAVES,
+					pools: { rush: { scripts: ["base"] } },
+				},
+			},
+		});
+
+		const { named } = resolvePools(
+			opts({ manifestPath, resourcesDir: "/test/resources/current", logger }),
+		);
+
+		expect(named).toEqual({});
+		expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("rush"));
+	});
+
+	it("skips a pool whose entry is not an object and logs an error", () => {
+		const logger = makeLogger();
+		const manifestPath = writeManifest(tmpDir, {
+			runtime: {
+				ygopro: {
+					standard: STANDARD_LEAVES,
+					pools: { rush: "formats/rush" },
+				},
+			},
+		});
+
+		const { named } = resolvePools(
+			opts({ manifestPath, resourcesDir: "/test/resources/current", logger }),
+		);
+
+		expect(named).toEqual({});
+		expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("rush"));
+	});
+
+	it("keeps valid pools when a sibling pool is invalid", () => {
+		const logger = makeLogger();
+		const manifestPath = writeManifest(tmpDir, {
+			runtime: {
+				ygopro: {
+					standard: STANDARD_LEAVES,
+					pools: {
+						broken: { scripts: ["base"] },
+						rush: { scripts: ["base", "formats/rush"], cards: ["formats/rush"] },
+					},
+				},
+			},
+		});
+
+		const { named } = resolvePools(
+			opts({ manifestPath, resourcesDir: "/test/resources/current", logger }),
+		);
+
+		expect(Object.keys(named)).toEqual(["rush"]);
+	});
+
+	it("warns for a named pool path that does not exist on disk", () => {
+		const logger = makeLogger();
+		fs.mkdirSync(path.join(tmpDir, "ygopro", "base"), { recursive: true });
+		const manifestPath = writeManifest(tmpDir, {
+			runtime: {
+				ygopro: {
+					standard: ["base"],
+					pools: { rush: { scripts: ["base", "formats/rush"], cards: ["formats/rush"] } },
+				},
+			},
+		});
+
+		resolvePools(opts({ manifestPath, resourcesDir: tmpDir, logger }));
+
+		const missingWarns = logger.warn.mock.calls.filter((args) =>
+			String(args[0]).includes("formats/rush"),
+		);
+		expect(missingWarns.length).toBeGreaterThan(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Diagnostic 3 — a named pool whose card dirs hold no cdb
+// ---------------------------------------------------------------------------
+
+describe("ResourcePoolResolver — Diagnostic 3 (named pool with no cards)", () => {
+	let tmpDir: string;
+	let logger: jest.Mocked<Logger>;
+
+	beforeEach(() => {
+		__resetResolverWarnings();
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "rfd-dx3-"));
+		logger = makeLogger();
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function makeDir(leaf: string, files: string[] = []): void {
+		const dir = path.join(tmpDir, "ygopro", leaf);
+		fs.mkdirSync(dir, { recursive: true });
+		for (const name of files) fs.writeFileSync(path.join(dir, name), "", "utf-8");
+	}
+
+	function rushManifest(): string {
+		return writeManifest(tmpDir, {
+			runtime: {
+				ygopro: {
+					standard: ["base"],
+					pools: { rush: { scripts: ["base", "formats/rush"], cards: ["formats/rush"] } },
+				},
+			},
+		});
+	}
+
+	it("errors when a named pool's card dirs contain no cdb at all", () => {
+		// The failure this exists for: the server boots clean, and the first
+		// room on that format has an empty card pool — every deck rejected,
+		// with nothing in the logs pointing at the cause.
+		makeDir("base", ["cards.cdb"]);
+		makeDir("formats/rush"); // assembled, but the cdbs never landed
+
+		resolvePools(opts({ manifestPath: rushManifest(), resourcesDir: tmpDir, logger }));
+
+		const errors = logger.error.mock.calls.map((args) => String(args[0]));
+		expect(errors.some((line) => line.includes("rush"))).toBe(true);
+	});
+
+	it("stays quiet when the pool has at least one cdb", () => {
+		makeDir("base", ["cards.cdb"]);
+		makeDir("formats/rush", ["RD Standard.cdb"]);
+
+		resolvePools(opts({ manifestPath: rushManifest(), resourcesDir: tmpDir, logger }));
+
+		const errors = logger.error.mock.calls.map((args) => String(args[0]));
+		expect(errors.some((line) => line.includes("no card database"))).toBe(false);
+	});
+
+	it("does not double-report a pool whose dir is missing entirely", () => {
+		// warnMissingPoolDirs already names that case; two messages for one
+		// cause trains people to skim the logs.
+		makeDir("base", ["cards.cdb"]);
+
+		resolvePools(opts({ manifestPath: rushManifest(), resourcesDir: tmpDir, logger }));
+
+		const errors = logger.error.mock.calls.map((args) => String(args[0]));
+		expect(errors.filter((line) => line.includes("no card database"))).toHaveLength(0);
+	});
+
+	it("reports each empty pool once, not once per call", () => {
+		makeDir("base", ["cards.cdb"]);
+		makeDir("formats/rush");
+
+		const manifestPath = rushManifest();
+		resolvePools(opts({ manifestPath, resourcesDir: tmpDir, logger }));
+		resolvePools(opts({ manifestPath, resourcesDir: tmpDir, logger }));
+
+		const errors = logger.error.mock.calls.filter((args) =>
+			String(args[0]).includes("no card database"),
+		);
+		expect(errors).toHaveLength(1);
+	});
+});

--- a/src/ygopro/ygopro/ResourcePoolResolver.ts
+++ b/src/ygopro/ygopro/ResourcePoolResolver.ts
@@ -2,12 +2,10 @@ import fs from "node:fs";
 import path from "node:path";
 import type { Logger } from "src/shared/logger/domain/Logger";
 
-// ---------------------------------------------------------------------------
-// One-shot diagnostic dedup state
-// Keys: absPath for missing-dir warns; "dup:<basename>" for cdb-dup warns.
-// Module-level so repeated resolvePools calls within the same process stay silent
-// after the first occurrence. __resetResolverWarnings() is exported for tests only.
-// ---------------------------------------------------------------------------
+/**
+ * Diagnostics already emitted, so repeated resolvePools calls in one process
+ * report each problem once. Keys are namespaced by diagnostic kind.
+ */
 const _warnedKeys = new Set<string>();
 
 /** Test-only helper — resets one-shot warning state between test cases. */
@@ -65,11 +63,9 @@ export interface ResolvedPools {
 /**
  * Derive ordered absolute-path pools from the manifest runtime section.
  *
- * Resolution rules (per RFD-003, RFD-005):
- * 1. Derive standard pool from manifest runtime.ygopro.standard.
- * 2. Derive extended pool as standard + runtime.ygopro.extended delta.
- * 3. On any manifest read/parse error or missing standard: log error, return empty pools.
- * 4. Missing extended (but valid standard): extended falls back to standard (no error).
+ * The manifest is the sole source of pool membership: an unreadable manifest or
+ * a missing `standard` is an error and yields empty pools. A missing `extended`
+ * is not — extended then equals standard.
  */
 export function resolvePools(options: ResourcePoolResolverOptions): ResolvedPools {
 	const { manifestPath, resourcesDir, logger } = options;
@@ -77,41 +73,20 @@ export function resolvePools(options: ResourcePoolResolverOptions): ResolvedPool
 	const resolvedResourcesDir = path.resolve(resourcesDir);
 	const ygoproBase = path.join(resolvedResourcesDir, "ygopro");
 
-	// --- Parse manifest (always required; manifest is the sole source of pool membership) ---
 	const manifest = readManifest(manifestPath, logger);
-
-	// --- Standard pool ---
 	const standard = deriveStandard(manifest, ygoproBase, manifestPath, logger);
-
-	// --- Extended delta (extensions beyond standard) ---
-	const extendedDelta = deriveExtended(manifest, ygoproBase);
-
-	const extended = [...standard, ...extendedDelta];
-
-	// --- Named pools (per-format script/card path sets) ---
+	const extended = [...standard, ...deriveExtended(manifest, ygoproBase)];
 	const named = deriveNamedPools(manifest, ygoproBase, manifestPath, logger);
 
-	// --- Diagnostic 1: warn on manifest-derived paths that do not exist on disk ---
-	// All pool paths are manifest-derived; check all of them.
 	warnMissingPoolDirs(standard, logger);
 	for (const pool of Object.values(named)) {
 		warnMissingPoolDirs([...pool.scripts, ...pool.cards], logger);
 	}
-
-	// --- Diagnostic 3: a named pool that resolves but carries no cards ---
 	errorOnEmptyNamedPools(named, logger);
-
-	// --- Diagnostic 2: warn on duplicate .cdb basenames across standard pool folders ---
-	// Scanned on the standard pool (extended = standard + delta; scanning standard avoids
-	// double-counting the overlapping directories). Best-effort: unreadable dirs skipped.
 	warnDuplicateCdbBasenames(standard, logger);
 
 	return { standard, extended, named };
 }
-
-// ---------------------------------------------------------------------------
-// Internals
-// ---------------------------------------------------------------------------
 
 function readManifest(manifestPath: string, logger: Logger): Manifest | null {
 	let raw: string;
@@ -141,7 +116,7 @@ function deriveStandard(
 	logger: Logger,
 ): string[] {
 	if (manifest === null) {
-		// Error already logged in readManifest
+		// readManifest already reported why.
 		return [];
 	}
 
@@ -155,26 +130,18 @@ function deriveStandard(
 		return [];
 	}
 
-	return standardLeaves
-		.filter((leaf): leaf is string => typeof leaf === "string" && leaf.length > 0)
-		.map((leaf) => path.join(ygoproBase, leaf));
+	return toAbsoluteLeaves(standardLeaves, ygoproBase);
 }
 
+/** An absent `extended` is not an error: the empty delta leaves extended equal to standard. */
 function deriveExtended(manifest: Manifest | null, ygoproBase: string): string[] {
-	if (manifest === null) {
-		return [];
-	}
-
 	const extendedLeaves = manifest?.runtime?.ygopro?.extended;
 
 	if (!Array.isArray(extendedLeaves)) {
-		// Missing extended — fall back silently to empty delta (caller will use standard as extended)
 		return [];
 	}
 
-	return extendedLeaves
-		.filter((leaf): leaf is string => typeof leaf === "string" && leaf.length > 0)
-		.map((leaf) => path.join(ygoproBase, leaf));
+	return toAbsoluteLeaves(extendedLeaves, ygoproBase);
 }
 
 /**
@@ -234,14 +201,17 @@ function deriveNamedPools(
 	return resolved;
 }
 
+function toAbsoluteLeaves(leaves: unknown[], ygoproBase: string): string[] {
+	return leaves
+		.filter((leaf): leaf is string => typeof leaf === "string" && leaf.length > 0)
+		.map((leaf) => path.join(ygoproBase, leaf));
+}
+
 /**
- * Diagnostic 3 — a named pool whose directories exist but hold no .cdb.
- *
- * Happens when the assembly step half-runs: the directory is created, the
- * databases are not. Error rather than warn — unlike a missing folder there is
- * no benign reading, since the pool is declared.
- *
- * Pools missing outright are skipped; warnMissingPoolDirs already names those.
+ * A named pool whose directories exist but hold no .cdb — the assembly step
+ * half-ran. Error rather than warn: unlike a missing folder there is no benign
+ * reading, since the pool is declared. Pools missing outright are left to
+ * warnMissingPoolDirs.
  */
 function errorOnEmptyNamedPools(named: Record<string, NamedPool>, logger: Logger): void {
 	for (const [name, pool] of Object.entries(named)) {
@@ -277,28 +247,18 @@ function errorOnEmptyNamedPools(named: Record<string, NamedPool>, logger: Logger
 	}
 }
 
-function toAbsoluteLeaves(leaves: unknown[], ygoproBase: string): string[] {
-	return leaves
-		.filter((leaf): leaf is string => typeof leaf === "string" && leaf.length > 0)
-		.map((leaf) => path.join(ygoproBase, leaf));
-}
-
-/**
- * Diagnostic 1 — warn for each pool path that does not exist as a directory on disk.
- * All pool paths are manifest-derived. Non-fatal: the path is still returned to the caller.
- */
+/** A manifest-derived pool path that is not a directory on disk. Non-fatal: the path is still returned. */
 function warnMissingPoolDirs(pools: string[], logger: Logger): void {
 	for (const absPath of pools) {
 		if (!fs.existsSync(absPath) || !fs.statSync(absPath).isDirectory()) {
-			// One-shot: emit this warning at most once per process per missing path.
 			const key = `missing:${absPath}`;
 			if (_warnedKeys.has(key)) {
 				continue;
 			}
 			_warnedKeys.add(key);
 
-			// Derive the leaf from the path for a friendlier message.
-			// The leaf is whatever comes after /ygopro/ in the resolved path.
+			// Report the manifest leaf — whatever follows /ygopro/ — so the message
+			// names what the operator actually wrote.
 			const ygoproMarker = `${path.sep}ygopro${path.sep}`;
 			const markerIdx = absPath.indexOf(ygoproMarker);
 			const leaf = markerIdx >= 0 ? absPath.slice(markerIdx + ygoproMarker.length) : absPath;
@@ -311,18 +271,14 @@ function warnMissingPoolDirs(pools: string[], logger: Logger): void {
 }
 
 /**
- * Diagnostic 2 — warn when two or more standard pool folders contain a .cdb file with the
- * same basename. Duplicate basenames cause the databases listing to merge them into a single
- * entry (keyed by filename), making one source invisible.
+ * Two pool folders holding a .cdb of the same basename: the databases listing is
+ * keyed by filename, so they merge into one entry and one source goes invisible.
  *
- * Scan scope: top-level .cdb files in each pool directory (non-recursive). This matches how
- * the game engine reads cdbs. Best-effort: unreadable folders are silently skipped.
- *
- * Decision: scanned on the standard pool only (not extended), because extended = standard +
- * delta; scanning both would double-count the standard directories.
+ * Scans top-level .cdb files only, matching how the engine reads them, and only
+ * the standard pool — extended is standard plus a delta, so scanning both would
+ * double-count. Unreadable folders are skipped.
  */
 function warnDuplicateCdbBasenames(pools: string[], logger: Logger): void {
-	// Map: basename → list of pool dirs that contain it
 	const basenameToFolders = new Map<string, string[]>();
 
 	for (const folder of pools) {
@@ -330,7 +286,6 @@ function warnDuplicateCdbBasenames(pools: string[], logger: Logger): void {
 		try {
 			entries = fs.readdirSync(folder);
 		} catch {
-			// Unreadable — skip silently
 			continue;
 		}
 
@@ -346,7 +301,6 @@ function warnDuplicateCdbBasenames(pools: string[], logger: Logger): void {
 
 	for (const [basename, folders] of basenameToFolders) {
 		if (folders.length >= 2) {
-			// One-shot: emit this warning at most once per process per duplicate basename.
 			const key = `dup:${basename}`;
 			if (_warnedKeys.has(key)) {
 				continue;

--- a/src/ygopro/ygopro/ResourcePoolResolver.ts
+++ b/src/ygopro/ygopro/ResourcePoolResolver.ts
@@ -19,6 +19,7 @@ export function __resetResolverWarnings(): void {
 interface ManifestRuntimeYGOPro {
 	standard?: unknown;
 	extended?: unknown;
+	pools?: unknown;
 }
 
 interface ManifestRuntime {
@@ -38,11 +39,27 @@ export interface ResourcePoolResolverOptions {
 	logger: Logger;
 }
 
+/**
+ * A named pool keeps its script search path separate from its card pool.
+ *
+ * A script pack needs both to differ: Rush scripts need `base` on the search
+ * path for utility.lua and constant.lua, while its card pool must exclude base
+ * because OCG cards are not part of the format.
+ */
+export interface NamedPool {
+	/** Ordered absolute paths searched for Lua scripts. */
+	scripts: string[];
+	/** Ordered absolute paths whose .cdb files form the card pool. */
+	cards: string[];
+}
+
 export interface ResolvedPools {
 	/** Ordered absolute paths for the standard (served formats) pool. */
 	standard: string[];
 	/** Ordered absolute paths for the extended pool (standard + extensions). */
 	extended: string[];
+	/** Named pools from runtime.ygopro.pools, keyed by pool name. */
+	named: Record<string, NamedPool>;
 }
 
 /**
@@ -71,16 +88,25 @@ export function resolvePools(options: ResourcePoolResolverOptions): ResolvedPool
 
 	const extended = [...standard, ...extendedDelta];
 
+	// --- Named pools (per-format script/card path sets) ---
+	const named = deriveNamedPools(manifest, ygoproBase, manifestPath, logger);
+
 	// --- Diagnostic 1: warn on manifest-derived paths that do not exist on disk ---
 	// All pool paths are manifest-derived; check all of them.
 	warnMissingPoolDirs(standard, logger);
+	for (const pool of Object.values(named)) {
+		warnMissingPoolDirs([...pool.scripts, ...pool.cards], logger);
+	}
+
+	// --- Diagnostic 3: a named pool that resolves but carries no cards ---
+	errorOnEmptyNamedPools(named, logger);
 
 	// --- Diagnostic 2: warn on duplicate .cdb basenames across standard pool folders ---
 	// Scanned on the standard pool (extended = standard + delta; scanning standard avoids
 	// double-counting the overlapping directories). Best-effort: unreadable dirs skipped.
 	warnDuplicateCdbBasenames(standard, logger);
 
-	return { standard, extended };
+	return { standard, extended, named };
 }
 
 // ---------------------------------------------------------------------------
@@ -147,6 +173,112 @@ function deriveExtended(manifest: Manifest | null, ygoproBase: string): string[]
 	}
 
 	return extendedLeaves
+		.filter((leaf): leaf is string => typeof leaf === "string" && leaf.length > 0)
+		.map((leaf) => path.join(ygoproBase, leaf));
+}
+
+/**
+ * Derive named pools from runtime.ygopro.pools.
+ *
+ * Absent `pools` is normal. A declared but malformed entry is an error —
+ * dropping it silently would boot a server whose format looks configured and
+ * resolves to nothing. Invalid entries are skipped one by one.
+ */
+function deriveNamedPools(
+	manifest: Manifest | null,
+	ygoproBase: string,
+	manifestPath: string,
+	logger: Logger,
+): Record<string, NamedPool> {
+	const pools = manifest?.runtime?.ygopro?.pools;
+
+	if (pools === undefined || pools === null) {
+		return {};
+	}
+
+	if (typeof pools !== "object" || Array.isArray(pools)) {
+		logger.error(
+			`ResourcePoolResolver: manifest at "${manifestPath}" has runtime.ygopro.pools that is not ` +
+				`an object; ignoring all named pools.`,
+		);
+		return {};
+	}
+
+	const resolved: Record<string, NamedPool> = {};
+
+	for (const [name, entry] of Object.entries(pools as Record<string, unknown>)) {
+		if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+			logger.error(
+				`ResourcePoolResolver: named pool "${name}" in "${manifestPath}" must be an object with ` +
+					`"scripts" and "cards" arrays; skipping it.`,
+			);
+			continue;
+		}
+
+		const { scripts, cards } = entry as { scripts?: unknown; cards?: unknown };
+
+		if (!Array.isArray(scripts) || !Array.isArray(cards)) {
+			logger.error(
+				`ResourcePoolResolver: named pool "${name}" in "${manifestPath}" is missing a "scripts" or ` +
+					`"cards" array; skipping it.`,
+			);
+			continue;
+		}
+
+		resolved[name] = {
+			scripts: toAbsoluteLeaves(scripts, ygoproBase),
+			cards: toAbsoluteLeaves(cards, ygoproBase),
+		};
+	}
+
+	return resolved;
+}
+
+/**
+ * Diagnostic 3 — a named pool whose directories exist but hold no .cdb.
+ *
+ * Happens when the assembly step half-runs: the directory is created, the
+ * databases are not. Error rather than warn — unlike a missing folder there is
+ * no benign reading, since the pool is declared.
+ *
+ * Pools missing outright are skipped; warnMissingPoolDirs already names those.
+ */
+function errorOnEmptyNamedPools(named: Record<string, NamedPool>, logger: Logger): void {
+	for (const [name, pool] of Object.entries(named)) {
+		const present = pool.cards.filter(
+			(dir) => fs.existsSync(dir) && fs.statSync(dir).isDirectory(),
+		);
+		if (present.length === 0) {
+			continue;
+		}
+
+		const hasCdb = present.some((dir) => {
+			try {
+				return fs.readdirSync(dir).some((entry) => entry.toLowerCase().endsWith(".cdb"));
+			} catch {
+				return false;
+			}
+		});
+		if (hasCdb) {
+			continue;
+		}
+
+		const key = `emptypool:${name}`;
+		if (_warnedKeys.has(key)) {
+			continue;
+		}
+		_warnedKeys.add(key);
+
+		logger.error(
+			`ResourcePoolResolver: named pool "${name}" has no card database in [${present.join(", ")}]` +
+				` — rooms on this format will boot with an empty card pool and reject every deck.` +
+				` Check that the assembly step published its .cdb files.`,
+		);
+	}
+}
+
+function toAbsoluteLeaves(leaves: unknown[], ygoproBase: string): string[] {
+	return leaves
 		.filter((leaf): leaf is string => typeof leaf === "string" && leaf.length > 0)
 		.map((leaf) => path.join(ygoproBase, leaf));
 }

--- a/src/ygopro/ygopro/YGOProResourceLoader.ts
+++ b/src/ygopro/ygopro/YGOProResourceLoader.ts
@@ -10,6 +10,7 @@ import { Logger } from "src/shared/logger/domain/Logger";
 import LoggerFactory from "src/shared/logger/infrastructure/LoggerFactory";
 import { config } from "src/config";
 import { resolvePools } from "./ResourcePoolResolver";
+import { DEFAULT_POOL, EXTENDED_POOL, lflistScanPaths, selectPoolPaths } from "./PoolSelection";
 import { resolveForkCorePath } from "./ocgcoreFork";
 
 const CARD_STORAGE_RELOAD_INTERVAL_MS = 10 * 60 * 1000;
@@ -67,6 +68,11 @@ export class YGOProResourceLoader {
 	extraScriptPaths = config.resources.ygopro.extraScripts;
 
 	private loadingLock = new BetterLock();
+
+	// standard/extended keep their own fields below: the resource-version
+	// endpoint reports them and the reload timer refreshes them.
+	private readonly namedPoolStorages = new Map<string, CardStorage>();
+	private readonly namedPoolLoading = new Map<string, Promise<CardStorage>>();
 
 	private standardLoadingPromise?: Promise<CardStorage>;
 	private standardCardStorage?: CardStorage;
@@ -128,6 +134,54 @@ export class YGOProResourceLoader {
 	async getExtendedCardReader(): Promise<CardReaderFn> {
 		const storage = await this.getExtendedCardStorage();
 		return storage.toCardReader();
+	}
+
+	/** Ordered script search paths for a pool. */
+	getPoolScriptPaths(pool: string): string[] {
+		return selectPoolPaths(this.resolvedPools, pool, this.logger).scripts;
+	}
+
+	/** standard/extended delegate to their own cached loaders. */
+	async getPoolCardStorage(pool: string): Promise<CardStorage> {
+		if (pool === DEFAULT_POOL) {
+			return this.getStandardCardStorage();
+		}
+		if (pool === EXTENDED_POOL) {
+			return this.getExtendedCardStorage();
+		}
+
+		const cached = this.namedPoolStorages.get(pool);
+		if (cached) {
+			return cached;
+		}
+		const inFlight = this.namedPoolLoading.get(pool);
+		if (inFlight) {
+			return inFlight;
+		}
+		return this.loadNamedPoolCdbs(pool);
+	}
+
+	async getPoolCardReader(pool: string): Promise<CardReaderFn> {
+		const storage = await this.getPoolCardStorage(pool);
+		return storage.toCardReader();
+	}
+
+	private async loadNamedPoolCdbs(pool: string): Promise<CardStorage> {
+		const { cards } = selectPoolPaths(this.resolvedPools, pool, this.logger);
+
+		const loading = this.loadingLock.acquire(async () => {
+			const { cardStorage } = await this.loadCardStorageFromPaths(cards, pool);
+			this.namedPoolStorages.set(pool, cardStorage);
+			return cardStorage;
+		});
+		this.namedPoolLoading.set(pool, loading);
+		try {
+			return await loading;
+		} finally {
+			if (this.namedPoolLoading.get(pool) === loading) {
+				this.namedPoolLoading.delete(pool);
+			}
+		}
 	}
 
 	async getOcgcoreWasmBinary() {
@@ -279,7 +333,7 @@ export class YGOProResourceLoader {
 	}
 
 	async *getLFLists() {
-		for await (const file of searchYGOProResource(...this.ygoproPaths)) {
+		for await (const file of searchYGOProResource(...lflistScanPaths(this.resolvedPools))) {
 			const filename = path.basename(file.path);
 			if (filename !== "lflist.conf") {
 				continue;


### PR DESCRIPTION
## Description / Descripción

Enables Rush Duel as a playable format. The format needs a card universe of its
own — its scripts require `base` on the search path for `utility.lua`, while OCG
cards must be absent from its card pool, not banned — which the previous
standard/extended pool model could not express.

Four work units, each reviewable and revertable on its own:

| Commit | What it delivers |
|---|---|
| `9f23afe` | Named pools: a format declares its script paths and card paths separately |
| `00601df` | Rooms pick their pool from the format token instead of a boolean |
| `5009e95` | Rush served from its own pool, with its own ban list and `duel_rule: 5` |
| `b14fb0b` | Legend card limits enforced at deck validation |

Every rule claim was verified by driving a real duel against the engine
(`evolution-ygopro-core`, headless harness), not read from the rulebook.

## Related Issue(s) / Issue(s) relacionado(s)

_None — opened directly._

## Changes / Cambios

| File | Change |
|---|---|
| `src/ygopro/ygopro/PoolSelection.ts` | New. Resolves a pool name to its script and card paths |
| `src/ygopro/ygopro/ResourcePoolResolver.ts` | Reads `runtime.ygopro.pools`; reports a declared pool with no card database |
| `src/ygopro/ygopro/YGOProResourceLoader.ts` | Per-pool card storage; ban lists discovered across named pools |
| `src/ygopro/room/domain/YGOProRoom.ts` | `useExtendedCardPool: boolean` → `cardPool: string` |
| `src/ygopro/room/domain/RuleMappings.ts` | `resolveCardPool()`; Rush gets `duel_rule: 5`, `start_hand: 4` |
| `src/ygopro/ocgcore-worker/ocgcore.ts` | Boots a duel from the room's pool |
| `src/shared/ban-list/BanList.ts` | Carries credit limits |
| `src/shared/deck/domain/validators/CreditLimitValidationHandler.ts` | New. Enforces them |
| `resources.manifest.json` | Rush sources, assembly and pool declaration |

## Two things worth a reviewer's attention

**`duel_rule` must be 5, not 4.** Under 4, `field::get_rule_zone_fromex` returns
only the Extra Monster Zones for an Extra Deck monster. `RDRule.lua` disables
both, and Rush has no Link monsters, so the legal destination set is empty and
Fusion Summons become impossible. Verified: with both materials face-up on the
field, the Fusion spell is not even activatable under 4, and is under 5.

**Rush is deliberately NOT in the standard pool.** Its `special.lua` defines
`Auxiliary.PreloadUds`, which the core calls at the start of every duel — so
adding `formats/rush` to the standard pool would make every duel, Edison and OCG
included, play by Rush rules.

## Test Plan

- [x] `npm test` — 142 suites, 1340 tests, 0 failures
- [x] `bats test/*.bats` — 57/57
- [x] `npx tsc --noEmit` clean at **each of the four commits**, not just the tip
- [x] `biome check` clean
- [x] Server boots against real assembled resources: RD ban list loads at index 110, Mercury up on :7711, no empty-pool error
- [x] Empty-pool guard verified in both directions — silent with the cdbs present, and fires when they are moved away

## Additional Notes / Notas adicionales

**Size.** 1059 insertions across 22 files, of which ~590 are tests. Above the
400-line review guideline. The four commits are independent enough to become
chained PRs if that reads better — say the word and I will split it.

The Rush pack is sourced through `evolution-assets`, which now mirrors it daily
([workflow](https://github.com/diangogav/evolution-assets/blob/main/.github/workflows/mirror-rush-pack.yml)),
rather than cloning `code.moenext.com` at build time. `clone_repositories.sh`
runs under `set -e`, so sourcing it directly meant one unreachable third-party
host failed the entire image build.

**Known gap, not addressed here:** the Rush ban list lists four cards from an
October 2026 set the card database does not carry yet. Harmless — those codes
never match a deck — but worth knowing before someone reports it as a bug.
