### PR TITLE
feat(matchmaking): harden the queue surface and reserve match seats

### DIFF
--- a/src/bootstrap/bootstrapMatchmaking.ts
+++ b/src/bootstrap/bootstrapMatchmaking.ts
@@ -35,12 +35,13 @@ export function bootstrapMatchmaking(logger: Logger): void {
 	MatchmakingQueue.init({
 		now: () => Date.now(),
 
-		createRankedRoom: (format: MatchmakingFormat) => {
+		createRankedRoom: (format: MatchmakingFormat, reservedUserIds: readonly [string, string]) => {
 			const { room, roomPassword } = createMatchmakingRoom({
 				format,
 				// Ranked human pairs play best-of-3 (MATCH room with side-decking).
 				matchMode: true,
 				rankedOverride: true,
+				reservedUserIds,
 				logger: mmLogger,
 				emitter: new EventEmitter(),
 				onRoomCreated: (room) => reaper.track(room),
@@ -48,13 +49,16 @@ export function bootstrapMatchmaking(logger: Logger): void {
 			return { roomId: room.id, roomPassword };
 		},
 
-		createBotRoom: (format: MatchmakingFormat) => {
+		createBotRoom: (format: MatchmakingFormat, reservedUserId: string) => {
 			const { room, roomPassword } = createMatchmakingRoom({
 				format,
 				// Bot fallback stays best-of-1: windbot has no side-deck support,
 				// so a MATCH room would stall in side-decking until the timeout.
 				matchMode: false,
 				rankedOverride: false,
+				// Only the human is reserved: the windbot enters through its
+				// one-shot AIJOIN token, which marks its socket internal.
+				reservedUserIds: [reservedUserId],
 				logger: mmLogger,
 				emitter: new EventEmitter(),
 				onRoomCreated: (room) => reaper.track(room),

--- a/src/edopro/room/application/JoinHandler.test.ts
+++ b/src/edopro/room/application/JoinHandler.test.ts
@@ -1,0 +1,122 @@
+import { EventEmitter } from "stream";
+
+import { Logger } from "@shared/logger/domain/Logger";
+import { Commands } from "@shared/messages/Commands";
+import { ClientMessage } from "@shared/messages/MessageProcessor";
+import { ISocket } from "@shared/socket/domain/ISocket";
+import { CheckIfUseCanJoin } from "@shared/user-auth/application/CheckIfUserCanJoin";
+
+import { createMatchmakingRoom } from "@ygopro/matchmaking/application/MatchmakingRoomFactory";
+import YGOProRoomList from "@ygopro/room/infrastructure/YGOProRoomList";
+
+import { ChatColor, ErrorMessageType, YGOProStocChat } from "ygopro-msg-encode";
+
+import { JoinHandler } from "./JoinHandler";
+
+const makeLogger = (): jest.Mocked<Logger> =>
+	({
+		child: jest.fn().mockReturnThis(),
+		info: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+		debug: jest.fn(),
+	}) as unknown as jest.Mocked<Logger>;
+
+const makeSocket = (): jest.Mocked<ISocket> =>
+	({
+		id: "sock-edopro",
+		remoteAddress: "10.0.0.9",
+		closed: false,
+		send: jest.fn(),
+		close: jest.fn(),
+		destroy: jest.fn(),
+		onMessage: jest.fn(),
+		removeAllListeners: jest.fn(),
+	}) as unknown as jest.Mocked<ISocket>;
+
+// CTOS_JOIN_GAME as the edopro flavor parses it (JoinGameMessage): version at
+// 0-2, room id at 4-8, password utf16 at 8-48. The version doubles as the
+// ygopro YGOProJoinGameMessage.version once the JOIN is forwarded into the
+// room's state machine, so it carries mercuryConfig.version (4962) to get past
+// the version gate and reach the reservation gate under test.
+const makeJoinGameData = (roomId: number, password: string): Buffer => {
+	const data = Buffer.alloc(50);
+	data.writeUInt16LE(4962, 0);
+	data.writeUInt32LE(roomId, 4);
+	data.write(password, 8, "utf16le");
+	return data;
+};
+
+// "Mallory" in UTF-16LE, no PIN separator (the edopro PlayerInfo frame).
+const makePlayerInfoData = (): Buffer => {
+	const data = Buffer.alloc(40);
+	data.write("Mallory", 0, "utf16le");
+	return data;
+};
+
+const makeJoinMessage = (roomId: number, password: string): ClientMessage =>
+	({
+		data: makeJoinGameData(roomId, password),
+		previousMessage: makePlayerInfoData(),
+	}) as unknown as ClientMessage;
+
+const clearRooms = () => {
+	const rooms = YGOProRoomList.getRooms();
+	while (rooms.length) {
+		YGOProRoomList.deleteRoom(rooms[0]);
+	}
+};
+
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+describe("JoinHandler — cross-flavor join into a reserved ygopro matchmaking room", () => {
+	beforeEach(clearRooms);
+	afterEach(clearRooms);
+
+	// The edopro JoinHandler resolves ygopro rooms by id too, so an edopro
+	// client holding the leaked join credentials can knock on a matchmaking
+	// room's door. Its socket never went through the ticket handshake — no
+	// resolvedUserId — so the reservation gate must turn it away entirely:
+	// not seated, not spectator.
+	it("rejects an edopro-flavor socket presenting the correct password (no ticket identity)", async () => {
+		const { room, roomPassword } = createMatchmakingRoom({
+			rankedOverride: true,
+			matchMode: true,
+			reservedUserIds: ["u-a", "u-b"],
+			logger: makeLogger(),
+			emitter: new EventEmitter(),
+		});
+		const password = roomPassword.split("#")[1];
+
+		const emitter = new EventEmitter();
+		const socket = makeSocket();
+		const checkIfUseCanJoin = {
+			check: jest.fn().mockResolvedValue(true),
+		} as unknown as CheckIfUseCanJoin;
+		new JoinHandler(emitter, makeLogger(), socket, checkIfUseCanJoin);
+
+		emitter.emit(Commands.JOIN_GAME as unknown as string, makeJoinMessage(room.id, password));
+		await flush();
+
+		// Turned away at the reservation gate with the ygopro reject sequence.
+		const sentBuffers = (socket.send as jest.Mock).mock.calls.map(([buf]) => buf as Buffer);
+		const expectedChat = Buffer.from(
+			new YGOProStocChat()
+				.fromPartial({
+					player_type: ChatColor.RED,
+					msg: "This room is reserved for its matched players.",
+				})
+				.toFullPayload(),
+		);
+		expect(sentBuffers.some((buf) => buf.equals(expectedChat))).toBe(true);
+		expect(sentBuffers).toContainEqual(
+			room.messageSender.errorMessage(ErrorMessageType.JOINERROR, 0),
+		);
+		expect(socket.close).toHaveBeenCalled();
+
+		// Not seated, not spectator; the room survives untouched for its pair.
+		expect(room.playersCount).toBe(0);
+		expect(room.spectators).toHaveLength(0);
+		expect(YGOProRoomList.findById(room.id)).toBe(room);
+	});
+});

--- a/src/http-server/controllers/EnqueueMatchmakingController.test.ts
+++ b/src/http-server/controllers/EnqueueMatchmakingController.test.ts
@@ -4,6 +4,8 @@ import { TicketRepository } from "@shared/ticket/domain/TicketRepository";
 
 import { MatchmakingQueue } from "@ygopro/matchmaking/domain/MatchmakingQueue";
 
+import { DisplayNameResolver } from "@ygopro/matchmaking/domain/DisplayNameResolver";
+
 import { EnqueueMatchmakingController } from "./EnqueueMatchmakingController";
 
 const makeLogger = () =>
@@ -51,9 +53,20 @@ describe("EnqueueMatchmakingController", () => {
 		MatchmakingQueue.resetForTests();
 	});
 
-	const run = async (body: unknown, tickets: TicketRepository) => {
+	const makeResolver = (name: string | null): DisplayNameResolver => ({
+		resolve: jest.fn().mockResolvedValue(name),
+	});
+
+	const run = async (
+		body: unknown,
+		tickets: TicketRepository,
+		displayNames: DisplayNameResolver = makeResolver(null),
+	) => {
 		const out = fakeResponse();
-		await new EnqueueMatchmakingController(makeLogger(), tickets).run({ body } as Request, out.res);
+		await new EnqueueMatchmakingController(makeLogger(), tickets, displayNames).run(
+			{ body } as Request,
+			out.res,
+		);
 		return out;
 	};
 
@@ -118,6 +131,47 @@ describe("EnqueueMatchmakingController", () => {
 		expect(out.status()).toBe(401);
 	});
 
+	it("resolves the user's display name at enqueue and stores it on the entry", async () => {
+		const resolver = makeResolver("Yugi");
+		const out = await run(
+			{ format: "tcg", queue: "ranked", ticket: "the-ticket" },
+			makeTickets("user-1"),
+			resolver,
+		);
+
+		expect(out.status()).toBe(200);
+		expect(resolver.resolve).toHaveBeenCalledWith("user-1");
+		const body = out.body() as { ticketId: string };
+		expect(MatchmakingQueue.getInstance().get(body.ticketId)?.displayName).toBe("Yugi");
+	});
+
+	it("stores a null display name when the resolver finds none", async () => {
+		const out = await run(
+			{ format: "tcg", queue: "ranked", ticket: "the-ticket" },
+			makeTickets("user-1"),
+			makeResolver(null),
+		);
+
+		expect(out.status()).toBe(200);
+		const body = out.body() as { ticketId: string };
+		expect(MatchmakingQueue.getInstance().get(body.ticketId)?.displayName).toBeNull();
+	});
+
+	it("still enqueues (200) with a null display name when resolution fails", async () => {
+		const resolver: DisplayNameResolver = {
+			resolve: jest.fn().mockRejectedValue(new Error("db down")),
+		};
+		const out = await run(
+			{ format: "tcg", queue: "ranked", ticket: "the-ticket" },
+			makeTickets("user-1"),
+			resolver,
+		);
+
+		expect(out.status()).toBe(200);
+		const body = out.body() as { ticketId: string };
+		expect(MatchmakingQueue.getInstance().get(body.ticketId)?.displayName).toBeNull();
+	});
+
 	it("returns the existing ticketId when the same user enqueues twice (409-safe idempotency)", async () => {
 		const tickets = makeTickets("user-1");
 		const first = await run({ format: "tcg", queue: "ranked", ticket: "t-a" }, tickets);
@@ -125,5 +179,17 @@ describe("EnqueueMatchmakingController", () => {
 
 		expect(first.status()).toBe(200);
 		expect(second.status()).toBe(409);
+	});
+
+	it("answers a duplicate enqueue (409) without resolving a display name", async () => {
+		const tickets = makeTickets("user-1");
+		await run({ format: "tcg", queue: "ranked", ticket: "t-a" }, tickets);
+
+		const resolver = makeResolver("Yugi");
+		const second = await run({ format: "tcg", queue: "ranked", ticket: "t-b" }, tickets, resolver);
+
+		expect(second.status()).toBe(409);
+		expect(second.body()).toEqual({ success: false, error: "Already in queue" });
+		expect(resolver.resolve).not.toHaveBeenCalled();
 	});
 });

--- a/src/http-server/controllers/EnqueueMatchmakingController.ts
+++ b/src/http-server/controllers/EnqueueMatchmakingController.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { Logger } from "@shared/logger/domain/Logger";
 import { TicketRepository } from "@shared/ticket/domain/TicketRepository";
 
+import { DisplayNameResolver } from "@ygopro/matchmaking/domain/DisplayNameResolver";
 import {
 	DuplicateQueueEntryError,
 	MatchmakingQueue,
@@ -30,6 +31,7 @@ export class EnqueueMatchmakingController {
 	constructor(
 		private readonly logger: Logger,
 		private readonly tickets: TicketRepository,
+		private readonly displayNames: DisplayNameResolver,
 	) {}
 
 	async run(req: Request, res: Response): Promise<void> {
@@ -45,12 +47,35 @@ export class EnqueueMatchmakingController {
 			return;
 		}
 
+		// Cheap synchronous pre-check: a user already in the pool never needs the
+		// display-name round-trip below. The guard inside enqueue() remains the
+		// atomic authority for the race between this check and insertion.
+		if (MatchmakingQueue.getInstance().isUserQueued(userId)) {
+			res.status(409).json({ success: false, error: "Already in queue" });
+			return;
+		}
+
+		// Resolved here, at the async HTTP boundary, so the synchronous pairing tick
+		// never touches the database. A failed lookup degrades to a null name — the
+		// matched payload must carry a public name or nothing, never the userId.
+		let displayName: string | null = null;
+		try {
+			displayName = await this.displayNames.resolve(userId);
+		} catch (error) {
+			this.logger.error(
+				`Matchmaking display-name resolution failed: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+		}
+
 		const ticketId = randomUUID();
 		try {
 			MatchmakingQueue.getInstance().enqueue({
 				ticketId,
 				userId,
 				format: validation.data.format,
+				displayName,
 			});
 		} catch (error) {
 			if (error instanceof DuplicateQueueEntryError) {

--- a/src/http-server/controllers/MatchmakingStatusController.test.ts
+++ b/src/http-server/controllers/MatchmakingStatusController.test.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from "express";
 
 import { MatchmakingQueue } from "@ygopro/matchmaking/domain/MatchmakingQueue";
+import { BOT_FALLBACK_MS, QUEUE_TTL_MS } from "@ygopro/matchmaking/domain/QueueEntry";
 
 import { MatchmakingStatusController } from "./MatchmakingStatusController";
 
@@ -74,5 +75,36 @@ describe("MatchmakingStatusController", () => {
 			opponentType: "human",
 			rated: true,
 		});
+	});
+
+	it("serializes the opponent's display name on the matched payload", () => {
+		const q = MatchmakingQueue.getInstance();
+		q.enqueue({ ticketId: "t1", userId: "user-1", format: "tcg", displayName: "Yugi" });
+		q.enqueue({ ticketId: "t2", userId: "user-2", format: "tcg", displayName: "Kaiba" });
+
+		const body = run({ ticketId: "t1" }).body() as Record<string, unknown>;
+		expect(body).toMatchObject({ state: "matched", opponentName: "Kaiba" });
+	});
+
+	it("serializes an explicit null opponentName for a bot match", () => {
+		const clock = { t: 0 };
+		MatchmakingQueue.resetForTests();
+		MatchmakingQueue.init({ ...makeDeps(), now: () => clock.t });
+		const q = MatchmakingQueue.getInstance();
+		q.enqueue({ ticketId: "t1", userId: "user-1", format: "tcg" });
+
+		// Heartbeat inside the TTL window so the entry survives to the bot fallback.
+		clock.t = QUEUE_TTL_MS - 1;
+		q.poll("t1");
+		clock.t = BOT_FALLBACK_MS + 1;
+		q.tick();
+
+		const out = run({ ticketId: "t1" });
+		expect(out.status()).toBe(200);
+		const body = out.body() as Record<string, unknown>;
+		expect(body).toMatchObject({ state: "matched", opponentType: "bot" });
+		// The key must be present on the wire with an explicit null, not absent.
+		expect("opponentName" in body).toBe(true);
+		expect(body.opponentName).toBeNull();
 	});
 });

--- a/src/http-server/middlewares/RateLimitMiddleware.test.ts
+++ b/src/http-server/middlewares/RateLimitMiddleware.test.ts
@@ -1,4 +1,14 @@
-import { isRateLimited, RateLimitStore } from "./RateLimitMiddleware";
+import type { NextFunction, Request, Response } from "express";
+
+import { Redis } from "@shared/db/redis/infrastructure/Redis";
+import { config } from "src/config";
+
+import {
+	EnqueueRateLimitMiddleware,
+	isRateLimited,
+	RateLimitMiddleware,
+	RateLimitStore,
+} from "./RateLimitMiddleware";
 
 class FakeRedis implements RateLimitStore {
 	private counters = new Map<string, number>();
@@ -15,6 +25,10 @@ class FakeRedis implements RateLimitStore {
 		this.expireCalls.push({ key, seconds });
 
 		return 1;
+	}
+
+	count(key: string): number {
+		return this.counters.get(key) ?? 0;
 	}
 }
 
@@ -46,5 +60,86 @@ describe("isRateLimited", () => {
 		const firstForSecondIp = await isRateLimited(redis, "rate-limit:inspect:2.2.2.2", 1, 60);
 
 		expect(firstForSecondIp).toBe(false);
+	});
+});
+
+describe("scoped rate-limit buckets", () => {
+	type Middleware = (req: Request, res: Response, next: NextFunction) => Promise<void>;
+
+	let store: FakeRedis;
+	let enabledBefore: boolean;
+
+	beforeEach(() => {
+		store = new FakeRedis();
+		jest
+			.spyOn(Redis, "getInstance")
+			.mockReturnValue(store as unknown as ReturnType<typeof Redis.getInstance>);
+		enabledBefore = config.rateLimit.enabled;
+		config.rateLimit.enabled = true;
+	});
+
+	afterEach(() => {
+		config.rateLimit.enabled = enabledBefore;
+		jest.restoreAllMocks();
+	});
+
+	const call = async (middleware: Middleware, ip: string) => {
+		let statusCode = 0;
+		const res = {
+			status(code: number) {
+				statusCode = code;
+				return this;
+			},
+			json() {
+				return this;
+			},
+		} as unknown as Response;
+		const next = jest.fn();
+		await middleware({ ip } as Request, res, next);
+
+		return { status: statusCode, nexted: next.mock.calls.length > 0 };
+	};
+
+	/** Drives a middleware until it answers 429; fails the test if it never does. */
+	const exhaust = async (middleware: Middleware, ip: string): Promise<number> => {
+		for (let i = 1; i <= 1_000; i++) {
+			const { status } = await call(middleware, ip);
+			if (status === 429) {
+				return i;
+			}
+		}
+		throw new Error("middleware never rate-limited");
+	};
+
+	it("keeps the shared inspect bucket on its deployed key and 60 req/min budget", async () => {
+		const calls = await exhaust(RateLimitMiddleware, "9.9.9.9");
+
+		expect(calls).toBe(61);
+		expect(store.expireCalls).toEqual([{ key: "rate-limit:inspect:9.9.9.9", seconds: 60 }]);
+	});
+
+	it("gives the enqueue route its own key so it never shares the inspect bucket", async () => {
+		await exhaust(EnqueueRateLimitMiddleware, "9.9.9.9");
+
+		expect(store.count("rate-limit:enqueue:9.9.9.9")).toBeGreaterThan(0);
+		expect(store.count("rate-limit:inspect:9.9.9.9")).toBe(0);
+	});
+
+	it("an exhausted enqueue bucket does not consume the inspect bucket", async () => {
+		await exhaust(EnqueueRateLimitMiddleware, "1.1.1.1");
+
+		const inspect = await call(RateLimitMiddleware, "1.1.1.1");
+
+		expect(inspect.status).not.toBe(429);
+		expect(inspect.nexted).toBe(true);
+	});
+
+	it("an exhausted inspect bucket does not consume the enqueue bucket", async () => {
+		await exhaust(RateLimitMiddleware, "1.1.1.1");
+
+		const enqueue = await call(EnqueueRateLimitMiddleware, "1.1.1.1");
+
+		expect(enqueue.status).not.toBe(429);
+		expect(enqueue.nexted).toBe(true);
 	});
 });

--- a/src/http-server/middlewares/RateLimitMiddleware.ts
+++ b/src/http-server/middlewares/RateLimitMiddleware.ts
@@ -5,6 +5,10 @@ import { config } from "src/config";
 
 const WINDOW_SECONDS = 60;
 const MAX_REQUESTS = 60;
+// Entering the queue is a rare, deliberate action (one POST per match attempt),
+// so its budget can be far smaller than the read/poll budget while still
+// covering several players behind one shared NAT IP.
+const ENQUEUE_MAX_REQUESTS = 20;
 
 export interface RateLimitStore {
 	incr(key: string): Promise<number>;
@@ -25,35 +29,62 @@ export async function isRateLimited(
 	return attempts > max;
 }
 
-export async function RateLimitMiddleware(
+export type RateLimitMiddlewareFn = (
 	request: Request,
 	response: Response,
 	next: NextFunction,
-): Promise<void> {
-	const redis = Redis.getInstance();
-	const ip = request.ip;
+) => Promise<void>;
 
-	if (!config.rateLimit.enabled || !redis || !ip) {
-		next();
+/**
+ * Builds a per-IP fixed-window limiter over its own Redis bucket
+ * (`rate-limit:<scope>:<ip>`). Separate scopes keep budgets independent: a
+ * client saturating one scope's bucket cannot 429 another scope's traffic.
+ */
+export function createRateLimitMiddleware(
+	scope: string,
+	max: number,
+	windowSeconds: number = WINDOW_SECONDS,
+): RateLimitMiddlewareFn {
+	return async function rateLimit(
+		request: Request,
+		response: Response,
+		next: NextFunction,
+	): Promise<void> {
+		const redis = Redis.getInstance();
+		const ip = request.ip;
 
-		return;
-	}
-
-	try {
-		const limited = await isRateLimited(
-			redis,
-			`rate-limit:inspect:${ip}`,
-			MAX_REQUESTS,
-			WINDOW_SECONDS,
-		);
-		if (limited) {
-			response.status(429).json({ error: "Too many requests. Please slow down." });
+		if (!config.rateLimit.enabled || !redis || !ip) {
+			next();
 
 			return;
 		}
-	} catch {
-		// Fail-open: a limiter error must never take down a public read-only page.
-	}
 
-	next();
+		try {
+			const limited = await isRateLimited(redis, `rate-limit:${scope}:${ip}`, max, windowSeconds);
+			if (limited) {
+				response.status(429).json({ error: "Too many requests. Please slow down." });
+
+				return;
+			}
+		} catch {
+			// Fail-open: a limiter error must never take down a public read-only page.
+		}
+
+		next();
+	};
 }
+
+/**
+ * Shared bucket for read/poll style routes. The "inspect" key segment is live
+ * deployed Redis state (and ops tooling may match on it) — keep it stable.
+ */
+export const RateLimitMiddleware = createRateLimitMiddleware("inspect", MAX_REQUESTS);
+
+/**
+ * Dedicated bucket for POST /api/matchmaking/queue so status-poll traffic from
+ * other clients behind the same IP can never starve a player's enqueue.
+ */
+export const EnqueueRateLimitMiddleware = createRateLimitMiddleware(
+	"enqueue",
+	ENQUEUE_MAX_REQUESTS,
+);

--- a/src/http-server/routes/index.test.ts
+++ b/src/http-server/routes/index.test.ts
@@ -1,0 +1,77 @@
+import type { Express } from "express";
+
+import { TicketRepository } from "@shared/ticket/domain/TicketRepository";
+
+import {
+	EnqueueRateLimitMiddleware,
+	RateLimitMiddleware,
+} from "../middlewares/RateLimitMiddleware";
+import { loadRoutes } from "./index";
+
+const makeLogger = () =>
+	({
+		child: jest.fn().mockReturnThis(),
+		info: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+		debug: jest.fn(),
+	}) as never;
+
+const makeTickets = (): TicketRepository => ({
+	consume: jest.fn().mockResolvedValue(null),
+});
+
+type RouteCall = [path: string, ...handlers: unknown[]];
+
+function makeApp(): {
+	app: Express;
+	calls: { get: RouteCall[]; post: RouteCall[]; delete: RouteCall[] };
+} {
+	const calls = { get: [] as RouteCall[], post: [] as RouteCall[], delete: [] as RouteCall[] };
+	const app = {
+		get: (...args: RouteCall) => calls.get.push(args),
+		post: (...args: RouteCall) => calls.post.push(args),
+		delete: (...args: RouteCall) => calls.delete.push(args),
+		use: jest.fn(),
+	} as unknown as Express;
+	return { app, calls };
+}
+
+const findRoute = (routes: RouteCall[], path: string): RouteCall | undefined =>
+	routes.find(([routePath]) => routePath === path);
+
+describe("loadRoutes — matchmaking rate limiting", () => {
+	/** The limiter only protects the route when it runs BEFORE the handler. */
+	const expectLimiterBeforeHandler = (route: RouteCall | undefined, middleware: unknown) => {
+		expect(route).toBeDefined();
+		const handlers = (route as RouteCall).slice(1);
+		expect(handlers.indexOf(middleware)).toBe(0);
+		expect(handlers.length).toBeGreaterThan(1);
+	};
+
+	it("wires the enqueue-scoped rate limiter before the POST /api/matchmaking/queue handler", () => {
+		const { app, calls } = makeApp();
+
+		loadRoutes(app, makeLogger(), makeTickets());
+
+		const route = findRoute(calls.post, "/api/matchmaking/queue");
+		expectLimiterBeforeHandler(route, EnqueueRateLimitMiddleware);
+		// The enqueue budget must be independent: the shared inspect limiter stays off this route.
+		expect(route).not.toContain(RateLimitMiddleware);
+	});
+
+	it("keeps the shared inspect limiter before the handler on the sibling matchmaking routes", () => {
+		const { app, calls } = makeApp();
+
+		loadRoutes(app, makeLogger(), makeTickets());
+
+		expectLimiterBeforeHandler(
+			findRoute(calls.get, "/api/matchmaking/status"),
+			RateLimitMiddleware,
+		);
+		expectLimiterBeforeHandler(
+			findRoute(calls.delete, "/api/matchmaking/queue"),
+			RateLimitMiddleware,
+		);
+	});
+});

--- a/src/http-server/routes/index.ts
+++ b/src/http-server/routes/index.ts
@@ -2,6 +2,8 @@ import { Express } from "express";
 
 import { TicketRepository } from "../../shared/ticket/domain/TicketRepository";
 import { Logger } from "../../shared/logger/domain/Logger";
+import { UserProfilePostgresRepository } from "../../shared/user-profile/infrastructure/postgres/UserProfilePostgresRepository";
+import { UserProfileDisplayNameResolver } from "../../ygopro/matchmaking/infrastructure/UserProfileDisplayNameResolver";
 import { CancelMatchmakingController } from "../controllers/CancelMatchmakingController";
 import { CreateRoomController } from "../controllers/CreateRoomController";
 import { EnqueueMatchmakingController } from "../controllers/EnqueueMatchmakingController";
@@ -17,15 +19,22 @@ import { RoomListController } from "../controllers/RoomListController";
 import { SearchCardsController } from "../controllers/SearchCardsController";
 import { ServerMessagesController } from "../controllers/ServerMessagesController";
 import { AuthAdminMiddleware } from "../middlewares/AuthAdminMiddleware";
-import { RateLimitMiddleware } from "../middlewares/RateLimitMiddleware";
+import {
+	EnqueueRateLimitMiddleware,
+	RateLimitMiddleware,
+} from "../middlewares/RateLimitMiddleware";
 
 export function loadRoutes(app: Express, logger: Logger, tickets: TicketRepository): void {
 	app.get("/", (req, res) => new InspectPageController().run(req, res));
 
 	app.get("/api/getrooms", (req, res) => new GetRoomListController().run(req, res));
 
-	app.post("/api/matchmaking/queue", (req, res) =>
-		new EnqueueMatchmakingController(logger, tickets).run(req, res),
+	const matchmakingDisplayNames = new UserProfileDisplayNameResolver(
+		new UserProfilePostgresRepository(),
+	);
+
+	app.post("/api/matchmaking/queue", EnqueueRateLimitMiddleware, (req, res) =>
+		new EnqueueMatchmakingController(logger, tickets, matchmakingDisplayNames).run(req, res),
 	);
 
 	app.get("/api/matchmaking/status", RateLimitMiddleware, (req, res) =>

--- a/src/shared/socket/domain/ISocket.ts
+++ b/src/shared/socket/domain/ISocket.ts
@@ -2,6 +2,12 @@ export interface ISocket {
 	id?: string;
 	roomId?: number;
 	resolvedUserId?: string;
+	/** Set on a server-driven bot connection whose one-shot, room-bound join
+	 * token was already consumed and validated — such a socket carries no user
+	 * identity but is pre-authorized for EXACTLY the room the token named.
+	 * Holds that room's id so the authorization cannot leak to another room
+	 * over the socket's lifetime. */
+	internalForRoomId?: number;
 	send(message: Buffer): void;
 	onMessage(callback: (message: Buffer) => void): void;
 	onClose(callback: () => void): void;

--- a/src/ygopro/matchmaking/application/MatchmakingRoomFactory.test.ts
+++ b/src/ygopro/matchmaking/application/MatchmakingRoomFactory.test.ts
@@ -2,6 +2,8 @@ import { EventEmitter } from "stream";
 
 import { RoomLeague } from "@shared/room/admission/domain/RoomLeague";
 
+import { ErrorMessageType } from "ygopro-msg-encode";
+
 import { MATCHMAKING_FORMATS } from "../domain/QueueEntry";
 import YGOProRoomList from "../../room/infrastructure/YGOProRoomList";
 import {
@@ -32,6 +34,7 @@ describe("createMatchmakingRoom", () => {
 
 	it("creates a ranked (Verified) TCG room and registers it in the room list", () => {
 		const { room, roomPassword } = createMatchmakingRoom({
+			reservedUserIds: ["u-a", "u-b"],
 			rankedOverride: true,
 			logger: makeLogger(),
 			emitter: new EventEmitter(),
@@ -48,6 +51,7 @@ describe("createMatchmakingRoom", () => {
 
 	it("creates an unrated (Casual) room for bot games when rankedOverride is false", () => {
 		const { room } = createMatchmakingRoom({
+			reservedUserIds: ["u-a", "u-b"],
 			rankedOverride: false,
 			logger: makeLogger(),
 			emitter: new EventEmitter(),
@@ -59,6 +63,7 @@ describe("createMatchmakingRoom", () => {
 
 	it("creates a best-of-3 MATCH room for ranked human pairs (matchMode)", () => {
 		const { room } = createMatchmakingRoom({
+			reservedUserIds: ["u-a", "u-b"],
 			rankedOverride: true,
 			matchMode: true,
 			logger: makeLogger(),
@@ -74,6 +79,7 @@ describe("createMatchmakingRoom", () => {
 
 	it('uses the "jm" token for jtp MATCH rooms (jtp rules + best-of-3)', () => {
 		const { room } = createMatchmakingRoom({
+			reservedUserIds: ["u-a", "u-b"],
 			format: "jtp",
 			rankedOverride: true,
 			matchMode: true,
@@ -89,6 +95,7 @@ describe("createMatchmakingRoom", () => {
 
 	it('uses the "ed" token for edison single rooms (MR1 + edison banlist)', () => {
 		const { room } = createMatchmakingRoom({
+			reservedUserIds: ["u-a", "u-b"],
 			format: "edison",
 			rankedOverride: false,
 			logger: makeLogger(),
@@ -104,6 +111,7 @@ describe("createMatchmakingRoom", () => {
 
 	it('uses the "edm" token for edison MATCH rooms (edison rules + best-of-3)', () => {
 		const { room } = createMatchmakingRoom({
+			reservedUserIds: ["u-a", "u-b"],
 			format: "edison",
 			rankedOverride: true,
 			matchMode: true,
@@ -119,6 +127,7 @@ describe("createMatchmakingRoom", () => {
 
 	it("keeps rooms best-of-1 when matchMode is omitted (bot fallback — windbot cannot side-deck)", () => {
 		const { room } = createMatchmakingRoom({
+			reservedUserIds: ["u-a", "u-b"],
 			rankedOverride: false,
 			logger: makeLogger(),
 			emitter: new EventEmitter(),
@@ -131,6 +140,7 @@ describe("createMatchmakingRoom", () => {
 
 	it("returns roomPassword as the exact command#password join string", () => {
 		const { room, roomPassword } = createMatchmakingRoom({
+			reservedUserIds: ["u-a", "u-b"],
 			rankedOverride: true,
 			logger: makeLogger(),
 			emitter: new EventEmitter(),
@@ -159,6 +169,7 @@ describe("createMatchmakingRoom", () => {
 	)("produces a join string that fits the CTOS_JOIN_GAME pass field (<= 19 chars) for format %s", (format) => {
 		for (let i = 0; i < 500; i++) {
 			const { roomPassword } = createMatchmakingRoom({
+				reservedUserIds: ["u-a", "u-b"],
 				format,
 				rankedOverride: true,
 				logger: makeLogger(),
@@ -176,6 +187,7 @@ describe("createMatchmakingRoom", () => {
 	)("produces a join string that fits the pass field (<= 19 chars) for MATCH rooms, format %s", (format) => {
 		for (let i = 0; i < 500; i++) {
 			const { roomPassword } = createMatchmakingRoom({
+				reservedUserIds: ["u-a", "u-b"],
 				format,
 				rankedOverride: true,
 				matchMode: true,
@@ -189,6 +201,7 @@ describe("createMatchmakingRoom", () => {
 
 	it("keeps a non-empty TCG name prefix and a non-empty password segment", () => {
 		const { roomPassword } = createMatchmakingRoom({
+			reservedUserIds: ["u-a", "u-b"],
 			rankedOverride: true,
 			logger: makeLogger(),
 			emitter: new EventEmitter(),
@@ -207,6 +220,7 @@ describe("createMatchmakingRoom", () => {
 		// Matchmaking hands the SAME join string to both matched players. Each
 		// sends it in CTOS_JOIN_GAME { pass }; both must land in this one room.
 		const { room, roomPassword } = createMatchmakingRoom({
+			reservedUserIds: ["u-a", "u-b"],
 			rankedOverride: true,
 			logger: makeLogger(),
 			emitter: new EventEmitter(),
@@ -227,11 +241,13 @@ describe("createMatchmakingRoom", () => {
 
 	it("generates a unique room name/password per pair (no collision across calls)", () => {
 		const a = createMatchmakingRoom({
+			reservedUserIds: ["u-a", "u-b"],
 			rankedOverride: true,
 			logger: makeLogger(),
 			emitter: new EventEmitter(),
 		});
 		const b = createMatchmakingRoom({
+			reservedUserIds: ["u-a", "u-b"],
 			rankedOverride: true,
 			logger: makeLogger(),
 			emitter: new EventEmitter(),
@@ -241,10 +257,159 @@ describe("createMatchmakingRoom", () => {
 		expect(a.room.name).not.toBe(b.room.name);
 	});
 
+	it("stamps the matched pair's userIds as the room's seat reservation", () => {
+		const { room } = createMatchmakingRoom({
+			rankedOverride: true,
+			matchMode: true,
+			reservedUserIds: ["u-a", "u-b"],
+			logger: makeLogger(),
+			emitter: new EventEmitter(),
+		});
+
+		expect(room.reservedUserIds).toEqual(["u-a", "u-b"]);
+		expect(room.reservationAdmits({ resolvedUserId: "u-a" } as never)).toBe(true);
+		expect(room.reservationAdmits({ resolvedUserId: "u-intruder" } as never)).toBe(false);
+	});
+
+	it("reserves only the human's userId for a bot-fallback room, keeping the bot's token path open", () => {
+		const { room } = createMatchmakingRoom({
+			rankedOverride: false,
+			reservedUserIds: ["u-human"],
+			logger: makeLogger(),
+			emitter: new EventEmitter(),
+		});
+
+		expect(room.reservedUserIds).toEqual(["u-human"]);
+		// The windbot authenticates with a one-shot room-bound token, not a user
+		// ticket — its socket is marked internal and must stay admissible.
+		expect(room.reservationAdmits({ internalForRoomId: room.id } as never)).toBe(true);
+	});
+
+	describe("reserved-room JOIN pipeline (real waiting state)", () => {
+		// mercuryConfig.version = 4962, little-endian at offset 0 of CTOS_JOIN_GAME.
+		const makeJoinMessage = () => {
+			const data = Buffer.alloc(48);
+			data.writeUInt16LE(4962, 0);
+			// "Mallory" in UTF-16LE, no PIN separator.
+			const previousMessage = Buffer.from("Mallory", "utf16le");
+			return { data, previousMessage } as never;
+		};
+
+		const makeSocket = (resolvedUserId?: string) =>
+			({
+				id: "sock-stranger",
+				resolvedUserId,
+				remoteAddress: "10.0.0.9",
+				closed: false,
+				send: jest.fn(),
+				close: jest.fn(),
+				destroy: jest.fn(),
+				onMessage: jest.fn(),
+				removeAllListeners: jest.fn(),
+			}) as never;
+
+		const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+		it.each([
+			["a ticketed stranger", "u-intruder"],
+			["an anonymous socket", undefined],
+		])("rejects %s presenting the exact join string, leaving the room untouched", async (_, userId) => {
+			const { room } = createMatchmakingRoom({
+				rankedOverride: true,
+				matchMode: true,
+				reservedUserIds: ["u-a", "u-b"],
+				logger: makeLogger(),
+				emitter: new EventEmitter(),
+			});
+			const socket = makeSocket(userId as string | undefined);
+
+			room.emit("JOIN", makeJoinMessage(), socket);
+			await flush();
+
+			const sentBuffers = ((socket as { send: jest.Mock }).send as jest.Mock).mock.calls.map(
+				([buf]) => buf as Buffer,
+			);
+			expect(sentBuffers).toContainEqual(
+				room.messageSender.errorMessage(ErrorMessageType.JOINERROR, 0),
+			);
+			expect((socket as { close: jest.Mock }).close).toHaveBeenCalled();
+			expect(room.playersCount).toBe(0);
+			expect(room.spectators).toHaveLength(0);
+			expect(YGOProRoomList.findById(room.id)).toBe(room);
+		});
+
+		it("rejects a reserved player's SECOND concurrent join, leaving their live seat intact", async () => {
+			const { room } = createMatchmakingRoom({
+				rankedOverride: true,
+				matchMode: true,
+				reservedUserIds: ["u-a", "u-b"],
+				logger: makeLogger(),
+				emitter: new EventEmitter(),
+			});
+			// Player A already holds a seat over a live socket.
+			room.players.push({ id: "u-a", socket: { closed: false } } as never);
+
+			// A second connection with the same reserved identity and a fresh
+			// ticket (different wire name is irrelevant — the gate reads identity).
+			const secondSocket = makeSocket("u-a");
+			room.emit("JOIN", makeJoinMessage(), secondSocket);
+			await flush();
+
+			const sentBuffers = ((secondSocket as { send: jest.Mock }).send as jest.Mock).mock.calls.map(
+				([buf]) => buf as Buffer,
+			);
+			expect(sentBuffers).toContainEqual(
+				room.messageSender.errorMessage(ErrorMessageType.JOINERROR, 0),
+			);
+			expect((secondSocket as { close: jest.Mock }).close).toHaveBeenCalled();
+			// The first seat is untouched and the opponent's seat stays free.
+			expect(room.playersCount).toBe(1);
+			expect(room.spectators).toHaveLength(0);
+		});
+	});
+
+	describe("reservation is mandatory", () => {
+		it("throws on an empty reservation list instead of creating an unguarded room", () => {
+			expect(() =>
+				createMatchmakingRoom({
+					reservedUserIds: [],
+					rankedOverride: true,
+					logger: makeLogger(),
+					emitter: new EventEmitter(),
+				}),
+			).toThrow();
+			// Nothing half-created: the loud failure must not leak a room.
+			expect(YGOProRoomList.getRooms()).toHaveLength(0);
+		});
+
+		it("still creates a ranked room for a two-id human pair", () => {
+			const { room } = createMatchmakingRoom({
+				reservedUserIds: ["u-a", "u-b"],
+				rankedOverride: true,
+				logger: makeLogger(),
+				emitter: new EventEmitter(),
+			});
+
+			expect(room.reservedUserIds).toEqual(["u-a", "u-b"]);
+		});
+
+		it("still creates a bot-fallback room for a single reserved human", () => {
+			const { room } = createMatchmakingRoom({
+				reservedUserIds: ["u-human"],
+				rankedOverride: false,
+				logger: makeLogger(),
+				emitter: new EventEmitter(),
+			});
+
+			expect(room.reservedUserIds).toEqual(["u-human"]);
+		});
+	});
+
 	it("builds the room without any client PlayerInfo wire bytes (additive path)", () => {
 		// Must not throw despite no connected client / PlayerInfoMessage.
 		expect(() =>
 			createMatchmakingRoom({
+				reservedUserIds: ["u-a", "u-b"],
 				rankedOverride: true,
 				logger: makeLogger(),
 				emitter: new EventEmitter(),

--- a/src/ygopro/matchmaking/application/MatchmakingRoomFactory.ts
+++ b/src/ygopro/matchmaking/application/MatchmakingRoomFactory.ts
@@ -55,6 +55,13 @@ export interface CreateMatchmakingRoomInput {
 	matchMode?: boolean;
 	/** true → ranked (Verified) human pair; false → unrated (Casual) bot game. */
 	rankedOverride: boolean;
+	/**
+	 * The userIds allowed through the room's JOIN door: both matched players
+	 * for a human pair, only the human for a bot-fallback room (the windbot
+	 * enters through its one-shot AIJOIN token, not a user ticket). Required —
+	 * the join string alone must never be enough to enter a matchmaking room.
+	 */
+	reservedUserIds: readonly string[];
 	logger: Logger;
 	emitter: EventEmitter;
 	/**
@@ -123,6 +130,14 @@ function randomBase36(length: number): string {
 }
 
 export function createMatchmakingRoom(input: CreateMatchmakingRoomInput): MatchmakingRoomHandle {
+	// A matchmaking room without a reservation would admit anyone holding the
+	// join string (reservationAdmits treats an empty set as "no reservation").
+	// Every caller knows its matched identities up front, so an empty list is a
+	// programming error — fail loudly before any room is created.
+	if (input.reservedUserIds.length === 0) {
+		throw new Error("createMatchmakingRoom requires at least one reserved userId");
+	}
+
 	const tokens = input.matchMode ? FORMAT_ROOM_TOKEN_MATCH : FORMAT_ROOM_TOKEN;
 	const token = tokens[input.format ?? "tcg"];
 
@@ -156,6 +171,7 @@ export function createMatchmakingRoom(input: CreateMatchmakingRoomInput): Matchm
 
 	YGOProRoomList.addRoom(room);
 	room.isMatchmaking = true;
+	room.reservedUserIds = input.reservedUserIds;
 	room.waiting();
 
 	// Register with the empty-room reaper (if wired) so an unjoined room does not

--- a/src/ygopro/matchmaking/domain/DisplayNameResolver.ts
+++ b/src/ygopro/matchmaking/domain/DisplayNameResolver.ts
@@ -1,0 +1,11 @@
+/**
+ * Port that maps an internal userId to a public display name.
+ *
+ * Matchmaking payloads must never expose internal ids: the queue stores the
+ * resolved name at enqueue time (the only async boundary in the flow) so the
+ * synchronous pairing tick can read it without blocking on I/O. A null result
+ * means "no public name" and the matched payload carries null.
+ */
+export interface DisplayNameResolver {
+	resolve(userId: string): Promise<string | null>;
+}

--- a/src/ygopro/matchmaking/domain/MatchmakingQueue.test.ts
+++ b/src/ygopro/matchmaking/domain/MatchmakingQueue.test.ts
@@ -57,6 +57,20 @@ describe("MatchmakingQueue", () => {
 		});
 	});
 
+	describe("isUserQueued", () => {
+		it("reports true only while the user has an active entry", () => {
+			const queue = MatchmakingQueue.createForTests(makeDeps());
+
+			expect(queue.isUserQueued("user-1")).toBe(false);
+
+			enqueue(queue, "t1", "user-1");
+			expect(queue.isUserQueued("user-1")).toBe(true);
+
+			queue.cancel("t1");
+			expect(queue.isUserQueued("user-1")).toBe(false);
+		});
+	});
+
 	describe("poll", () => {
 		it("returns searching state with elapsed waitedMs and refreshes lastPollAt", () => {
 			const clock = { t: 0 };
@@ -90,6 +104,36 @@ describe("MatchmakingQueue", () => {
 			tickSpy.mockRestore();
 		});
 
+		it("hands both matched userIds to the ranked-room port so the room can reserve its seats", () => {
+			const createRankedRoom = jest
+				.fn()
+				.mockReturnValue({ roomId: 1, roomPassword: "to,mmabcde#pw" });
+			const queue = MatchmakingQueue.createForTests(makeDeps({ createRankedRoom }));
+			enqueue(queue, "t1", "user-1");
+			enqueue(queue, "t2", "user-2");
+
+			queue.tick();
+
+			expect(createRankedRoom).toHaveBeenCalledWith("tcg", ["user-1", "user-2"]);
+		});
+
+		it("hands the lone human's userId to the bot-room port so the room can reserve its seat", () => {
+			const clock = { t: 0 };
+			const createBotRoom = jest.fn().mockReturnValue({ roomId: 2, roomPassword: "to,mmfghij#pw" });
+			const queue = MatchmakingQueue.createForTests(
+				makeDeps({ now: () => clock.t, createBotRoom }),
+			);
+			enqueue(queue, "t1", "user-1");
+
+			// Keep the entry alive across the TTL window; the fallback fires later.
+			clock.t = QUEUE_TTL_MS - 1;
+			queue.poll("t1");
+			clock.t = BOT_FALLBACK_MS + 1;
+			queue.tick();
+
+			expect(createBotRoom).toHaveBeenCalledWith("tcg", "user-1");
+		});
+
 		it("returns the matched payload once paired", () => {
 			const clock = { t: 0 };
 			const queue = MatchmakingQueue.createForTests(makeDeps({ now: () => clock.t }));
@@ -106,6 +150,90 @@ describe("MatchmakingQueue", () => {
 			expect((s1 as { roomPassword: string }).roomPassword).toBe(
 				(s2 as { roomPassword: string }).roomPassword,
 			);
+		});
+	});
+
+	describe("poll — pure read + heartbeat", () => {
+		it("does not pair two waiting compatible players; the sweep does on its next tick", () => {
+			// Both enqueue-time pair attempts fail, leaving two compatible entries
+			// searching. A poll must not retry the pairing — only the sweep may.
+			const createRankedRoom = jest
+				.fn()
+				.mockImplementationOnce(() => {
+					throw new Error("room not ready yet");
+				})
+				.mockReturnValue({ roomId: 1, roomPassword: "to,mm-r1#pw1" });
+			const queue = MatchmakingQueue.createForTests(
+				makeDeps({ createRankedRoom, onRoomCreationError: jest.fn() }),
+			);
+			enqueue(queue, "t1", "user-1");
+			enqueue(queue, "t2", "user-2");
+			expect(queue.get("t1")?.state).toBe("searching");
+			expect(queue.get("t2")?.state).toBe("searching");
+			const callsAfterEnqueue = createRankedRoom.mock.calls.length;
+
+			expect(queue.poll("t1")).toMatchObject({ state: "searching" });
+
+			expect(createRankedRoom.mock.calls.length).toBe(callsAfterEnqueue);
+			expect(queue.get("t1")?.state).toBe("searching");
+			expect(queue.get("t2")?.state).toBe("searching");
+
+			queue.tick();
+			expect(queue.get("t1")?.state).toBe("matched");
+			expect(queue.get("t2")?.state).toBe("matched");
+		});
+
+		it("does not trigger bot fallback; the sweep does on its next tick", () => {
+			const clock = { t: 0 };
+			const createBotRoom = jest
+				.fn()
+				.mockReturnValue({ roomPassword: "to,mm-b1#pw1", roomId: 4242 });
+			const queue = MatchmakingQueue.createForTests(
+				makeDeps({ now: () => clock.t, createBotRoom }),
+			);
+			enqueue(queue, "t1", "user-1");
+
+			clock.t = QUEUE_TTL_MS - 1;
+			queue.poll("t1");
+			clock.t = BOT_FALLBACK_MS + 1;
+
+			expect(queue.poll("t1")).toMatchObject({ state: "searching" });
+			expect(createBotRoom).not.toHaveBeenCalled();
+			expect(queue.get("t1")?.state).toBe("searching");
+
+			queue.tick();
+			expect(queue.get("t1")?.state).toBe("matched");
+			expect(queue.get("t1")?.opponentType).toBe("bot");
+		});
+
+		it("does not run the expiry sweep; a stale peer survives until the interval tick", () => {
+			// Cross-format entries: user-2 goes stale while user-1 keeps polling.
+			// user-1's polls must not reap user-2 — only the sweep may.
+			const clock = { t: 0 };
+			const queue = MatchmakingQueue.createForTests(makeDeps({ now: () => clock.t }));
+			queue.enqueue({ ticketId: "t1", userId: "user-1", format: "tcg" });
+			queue.enqueue({ ticketId: "t2", userId: "user-2", format: "jtp" });
+
+			clock.t = QUEUE_TTL_MS + 1;
+			queue.poll("t1");
+
+			expect(queue.get("t2")).toBeDefined();
+
+			queue.tick();
+			expect(queue.get("t2")).toBeUndefined();
+		});
+
+		it("still refreshes the heartbeat so a polling entry survives the sweep", () => {
+			const clock = { t: 0 };
+			const queue = MatchmakingQueue.createForTests(makeDeps({ now: () => clock.t }));
+			enqueue(queue, "t1", "user-1");
+
+			clock.t = QUEUE_TTL_MS - 1;
+			queue.poll("t1");
+			clock.t = QUEUE_TTL_MS + 1;
+			queue.tick();
+
+			expect(queue.get("t1")).toBeDefined();
 		});
 	});
 
@@ -211,6 +339,51 @@ describe("MatchmakingQueue", () => {
 			expect(createRankedRoom).not.toHaveBeenCalled();
 			expect(queue.get("t1")?.state).toBe("searching");
 			expect(queue.get("t2")?.state).toBe("searching");
+		});
+	});
+
+	describe("matched payload — opponent display name", () => {
+		it("exposes the partner's display name, never the raw userId", () => {
+			const queue = MatchmakingQueue.createForTests(makeDeps());
+			queue.enqueue({ ticketId: "t1", userId: "user-1", format: "tcg", displayName: "Kaiba" });
+			queue.enqueue({ ticketId: "t2", userId: "user-2", format: "tcg", displayName: "Yugi" });
+
+			queue.tick();
+
+			const s1 = queue.poll("t1");
+			const s2 = queue.poll("t2");
+			expect(s1).toMatchObject({ state: "matched", opponentName: "Yugi" });
+			expect(s2).toMatchObject({ state: "matched", opponentName: "Kaiba" });
+			// The internal userId must never leave the server in the matched payload.
+			expect(JSON.stringify(s1)).not.toContain("user-2");
+			expect(JSON.stringify(s2)).not.toContain("user-1");
+		});
+
+		it("falls back to null (not the userId) when the partner has no display name", () => {
+			const queue = MatchmakingQueue.createForTests(makeDeps());
+			enqueue(queue, "t1", "user-1");
+			enqueue(queue, "t2", "user-2");
+
+			queue.tick();
+
+			const s1 = queue.poll("t1");
+			expect(s1).toMatchObject({ state: "matched", opponentName: null });
+			expect(JSON.stringify(s1)).not.toContain("user-2");
+		});
+
+		it("keeps opponentName null for a bot match (no userId leak on the bot path)", () => {
+			const clock = { t: 0 };
+			const queue = MatchmakingQueue.createForTests(makeDeps({ now: () => clock.t }));
+			enqueue(queue, "t1", "user-1");
+
+			clock.t = QUEUE_TTL_MS - 1;
+			queue.poll("t1");
+			clock.t = BOT_FALLBACK_MS + 1;
+			queue.tick();
+
+			const s1 = queue.poll("t1");
+			expect(s1).toMatchObject({ state: "matched", opponentType: "bot", opponentName: null });
+			expect(JSON.stringify(s1)).not.toContain("user-1");
 		});
 	});
 

--- a/src/ygopro/matchmaking/domain/MatchmakingQueue.ts
+++ b/src/ygopro/matchmaking/domain/MatchmakingQueue.ts
@@ -24,10 +24,15 @@ export interface BotRoomHandle extends RankedRoomHandle {
  */
 export interface MatchmakingQueueDeps {
 	now: () => number;
-	/** Creates a ranked (Verified) room for a human pair. */
-	createRankedRoom: (format: MatchmakingFormat) => RankedRoomHandle;
-	/** Creates a casual (unrated) room for a bot game and returns its id for the spawn. */
-	createBotRoom: (format: MatchmakingFormat) => BotRoomHandle;
+	/** Creates a ranked (Verified) room for a human pair. The pair's userIds
+	 * become the room's seat reservation — only they may enter it. */
+	createRankedRoom: (
+		format: MatchmakingFormat,
+		reservedUserIds: readonly [string, string],
+	) => RankedRoomHandle;
+	/** Creates a casual (unrated) room for a bot game and returns its id for the
+	 * spawn. The human's userId becomes the room's seat reservation. */
+	createBotRoom: (format: MatchmakingFormat, reservedUserId: string) => BotRoomHandle;
 	/** Fires the windbot join for the given room (fire-and-forget). */
 	spawnBot: (roomId: number, format: MatchmakingFormat) => void;
 	/** Whether bot fallback is currently possible (windbot initialized + enabled). */
@@ -41,6 +46,8 @@ export interface EnqueueInput {
 	ticketId: string;
 	userId: string;
 	format: MatchmakingFormat;
+	/** Public name pre-resolved by the caller; omitted/null when unresolvable. */
+	displayName?: string | null;
 }
 
 export type PollResult =
@@ -49,7 +56,8 @@ export type PollResult =
 			state: "matched";
 			roomPassword: string;
 			opponentType: "human" | "bot";
-			opponentName?: string;
+			/** Opponent's public display name; null when unresolved. Never a userId. */
+			opponentName: string | null;
 			rated: boolean;
 	  };
 
@@ -68,7 +76,8 @@ export class DuplicateQueueEntryError extends Error {
  * work (room creation side effects, windbot HTTP) is delegated to injected ports
  * and, for the bot spawn, fired-and-forgotten.
  *
- * The tick (run on an unref'd interval AND opportunistically on enqueue/poll):
+ * The tick (run on an unref'd interval AND opportunistically on enqueue — the
+ * state-changing event; poll is a pure read plus heartbeat and never sweeps):
  *   1. TTL sweep: drop searching entries whose last poll fell outside QUEUE_TTL_MS.
  *   2. Pair: two searching entries of the same format → one ranked room, both matched.
  *   3. Bot fallback: a searching entry older than BOT_FALLBACK_MS with no human → bot room.
@@ -141,6 +150,7 @@ export class MatchmakingQueue {
 			ticketId: input.ticketId,
 			userId: input.userId,
 			format: input.format,
+			displayName: input.displayName ?? null,
 			enteredAt: now,
 			lastPollAt: now,
 			state: "searching",
@@ -153,6 +163,12 @@ export class MatchmakingQueue {
 		return entry;
 	}
 
+	/**
+	 * Pure read + heartbeat: refreshes lastPollAt and reports the entry's state.
+	 * Pairing, bot fallback, and expiry run only inside tick() — driven by the
+	 * interval sweep and opportunistically by enqueue — so a poll storm can never
+	 * amplify into O(polls) sweeps or room-creation side effects.
+	 */
 	poll(ticketId: string): PollResult | null {
 		const entry = this.entries.get(ticketId);
 		if (!entry) {
@@ -166,22 +182,8 @@ export class MatchmakingQueue {
 				state: "matched",
 				roomPassword: entry.roomPassword as string,
 				opponentType: entry.opponentType as "human" | "bot",
-				opponentName: entry.opponentName,
+				opponentName: entry.opponentName ?? null,
 				rated: entry.rated as boolean,
-			};
-		}
-
-		// Advance the queue on the poll too — the poll is the client's heartbeat.
-		this.tick();
-
-		const refreshed = this.entries.get(ticketId);
-		if (refreshed && refreshed.state === "matched") {
-			return {
-				state: "matched",
-				roomPassword: refreshed.roomPassword as string,
-				opponentType: refreshed.opponentType as "human" | "bot",
-				opponentName: refreshed.opponentName,
-				rated: refreshed.rated as boolean,
 			};
 		}
 
@@ -212,6 +214,15 @@ export class MatchmakingQueue {
 			removed += 1;
 		}
 		return removed;
+	}
+
+	/**
+	 * Synchronous membership check so callers can refuse a duplicate before
+	 * paying for async work (ticket already consumed, display-name lookup not
+	 * yet started). enqueue() keeps the authoritative atomic guard.
+	 */
+	isUserQueued(userId: string): boolean {
+		return this.usersInQueue.has(userId);
 	}
 
 	get(ticketId: string): QueueEntry | undefined {
@@ -271,9 +282,12 @@ export class MatchmakingQueue {
 				// On failure, leave BOTH entries searching (a retry next tick, or a
 				// bot fallback / TTL drop, will resolve them) and move on.
 				try {
-					const { roomPassword, roomId } = this.deps.createRankedRoom(a.format);
-					this.markMatched(a, roomPassword, "human", true, b.userId, roomId);
-					this.markMatched(b, roomPassword, "human", true, a.userId, roomId);
+					const { roomPassword, roomId } = this.deps.createRankedRoom(a.format, [
+						a.userId,
+						b.userId,
+					]);
+					this.markMatched(a, roomPassword, "human", true, b.displayName, roomId);
+					this.markMatched(b, roomPassword, "human", true, a.displayName, roomId);
 				} catch (error) {
 					this.deps.onRoomCreationError?.(error);
 				}
@@ -297,8 +311,8 @@ export class MatchmakingQueue {
 			// or 500 an unrelated caller. On failure, leave THIS entry searching (a
 			// later tick retries, or the TTL sweep drops it) and continue with the rest.
 			try {
-				const { roomPassword, roomId } = this.deps.createBotRoom(entry.format);
-				this.markMatched(entry, roomPassword, "bot", false, undefined, roomId);
+				const { roomPassword, roomId } = this.deps.createBotRoom(entry.format, entry.userId);
+				this.markMatched(entry, roomPassword, "bot", false, null, roomId);
 				this.deps.spawnBot(roomId, entry.format);
 			} catch (error) {
 				this.deps.onRoomCreationError?.(error);
@@ -311,7 +325,7 @@ export class MatchmakingQueue {
 		roomPassword: string,
 		opponentType: "human" | "bot",
 		rated: boolean,
-		opponentName?: string,
+		opponentName: string | null,
 		roomId?: number,
 	): void {
 		entry.state = "matched";

--- a/src/ygopro/matchmaking/domain/QueueEntry.ts
+++ b/src/ygopro/matchmaking/domain/QueueEntry.ts
@@ -38,6 +38,9 @@ export interface QueueEntry {
 	readonly userId: string;
 	readonly format: MatchmakingFormat;
 	readonly enteredAt: number;
+	/** Public name resolved at enqueue; null when the user has no resolvable name.
+	 * The matched payload's opponentName comes from here — never from userId. */
+	readonly displayName: string | null;
 	/** Refreshed on every status poll; the TTL sweep drops entries that fall behind. */
 	lastPollAt: number;
 	state: QueueEntryState;
@@ -50,6 +53,7 @@ export interface QueueEntry {
 	 * when an incomplete matchmaking lobby is aborted. */
 	roomId?: number;
 	opponentType?: OpponentType;
-	opponentName?: string;
+	/** Opponent's public display name; null when unresolved (never the raw userId). */
+	opponentName?: string | null;
 	rated?: boolean;
 }

--- a/src/ygopro/matchmaking/infrastructure/UserProfileDisplayNameResolver.test.ts
+++ b/src/ygopro/matchmaking/infrastructure/UserProfileDisplayNameResolver.test.ts
@@ -1,0 +1,61 @@
+import { UserProfile } from "@shared/user-profile/domain/UserProfile";
+import { UserProfileRepository } from "@shared/user-profile/domain/UserProfileRepository";
+
+import { UserProfileDisplayNameResolver } from "./UserProfileDisplayNameResolver";
+
+const makeProfiles = (profile: UserProfile | null): UserProfileRepository => ({
+	create: jest.fn(),
+	findByUsername: jest.fn(),
+	findById: jest.fn().mockResolvedValue(profile),
+	isBanned: jest.fn(),
+});
+
+describe("UserProfileDisplayNameResolver", () => {
+	it("resolves the username of a known user", async () => {
+		const profile = UserProfile.from({
+			id: "user-1",
+			username: "Yugi",
+			password: "hashed",
+			email: "yugi@example.com",
+			avatar: null,
+		});
+		const resolver = new UserProfileDisplayNameResolver(makeProfiles(profile));
+
+		await expect(resolver.resolve("user-1")).resolves.toBe("Yugi");
+	});
+
+	it("resolves null for an unknown user", async () => {
+		const resolver = new UserProfileDisplayNameResolver(makeProfiles(null));
+
+		await expect(resolver.resolve("ghost")).resolves.toBeNull();
+	});
+
+	const profileWithUsername = (username: string) =>
+		UserProfile.from({
+			id: "user-1",
+			username,
+			password: "hashed",
+			email: "user@example.com",
+			avatar: null,
+		});
+
+	it("resolves null for an empty username instead of leaking an empty string", async () => {
+		const resolver = new UserProfileDisplayNameResolver(makeProfiles(profileWithUsername("")));
+
+		await expect(resolver.resolve("user-1")).resolves.toBeNull();
+	});
+
+	it("resolves null for a whitespace-only username", async () => {
+		const resolver = new UserProfileDisplayNameResolver(makeProfiles(profileWithUsername("   ")));
+
+		await expect(resolver.resolve("user-1")).resolves.toBeNull();
+	});
+
+	it("trims surrounding whitespace from the username", async () => {
+		const resolver = new UserProfileDisplayNameResolver(
+			makeProfiles(profileWithUsername("  Yugi  ")),
+		);
+
+		await expect(resolver.resolve("user-1")).resolves.toBe("Yugi");
+	});
+});

--- a/src/ygopro/matchmaking/infrastructure/UserProfileDisplayNameResolver.ts
+++ b/src/ygopro/matchmaking/infrastructure/UserProfileDisplayNameResolver.ts
@@ -1,0 +1,16 @@
+import { UserProfileRepository } from "@shared/user-profile/domain/UserProfileRepository";
+
+import { DisplayNameResolver } from "../domain/DisplayNameResolver";
+
+/** Resolves a matchmaking display name from the shared user-profile store. */
+export class UserProfileDisplayNameResolver implements DisplayNameResolver {
+	constructor(private readonly profiles: UserProfileRepository) {}
+
+	async resolve(userId: string): Promise<string | null> {
+		const profile = await this.profiles.findById(userId);
+		// A blank username is not a public name: the matched payload promises a
+		// presentable name or null, never an empty/whitespace string.
+		const username = profile?.username.trim();
+		return username ? username : null;
+	}
+}

--- a/src/ygopro/room/application/join-strategies/AIJoinTokenStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/AIJoinTokenStrategy.test.ts
@@ -217,6 +217,40 @@ describe("AIJoinTokenStrategy", () => {
 				expect(roomEmitSpy).toHaveBeenCalledWith("JOIN", expect.anything(), ctx.socket);
 			});
 
+			it("stamps the socket internal FOR THIS ROOM before emitting JOIN so its reservation admits it", async () => {
+				const { room, emitter } = createRoomInList();
+				room.reservedUserIds = ["u-human"];
+				const token = tokenStore.register(room.id, "Anna", "Anna.ydk");
+
+				let internalRoomAtJoin: number | undefined;
+				jest.spyOn(room, "emit").mockImplementation((_event, _message, socket) => {
+					internalRoomAtJoin = socket.internalForRoomId;
+				});
+
+				const mod = makeModule(tokenStore);
+				const strategy = new AIJoinTokenStrategy(mod);
+
+				const ctx = makeCtx(`AIJOIN#${token}`, {
+					eventEmitter: emitter,
+					messageRepository: makeMessageRepository() as never,
+				});
+
+				await strategy.handle(ctx);
+
+				expect(internalRoomAtJoin).toBe(room.id);
+				expect(room.reservationAdmits(ctx.socket)).toBe(true);
+			});
+
+			it("does NOT mark the socket internal when the token is invalid", async () => {
+				const mod = makeModule(tokenStore);
+				const strategy = new AIJoinTokenStrategy(mod);
+				const socket = makeSocket();
+
+				await strategy.handle(makeCtx("AIJOIN#invalidtoken", { socket: socket as never }));
+
+				expect((socket as { internalForRoomId?: number }).internalForRoomId).toBeUndefined();
+			});
+
 			it("marks the room as an AI room (noHost + noReconnect) so it tears down when the human leaves", async () => {
 				const { room, emitter } = createRoomInList();
 				const token = tokenStore.register(room.id, "Anna", "Anna.ydk");

--- a/src/ygopro/room/application/join-strategies/AIJoinTokenStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/AIJoinTokenStrategy.ts
@@ -60,6 +60,15 @@ export class AIJoinTokenStrategy implements JoinStrategy {
 			return;
 		}
 
+		// The consumed token was minted server-side for exactly this room, so this
+		// socket is a pre-authorized internal (bot) connection: stamp the token's
+		// room id BEFORE the JOIN emit so a seat-reserved matchmaking room admits
+		// it — the bot has no user ticket, and the reservation gate exempts a
+		// socket whose stamp names the room being joined. Scoping the stamp to
+		// the room id keeps the exemption from leaking to any other reserved
+		// room this socket might later present itself to.
+		ctx.socket.internalForRoomId = payload.roomId;
+
 		// A bot has joined — this room is now an AI room. Mark it noHost so the
 		// DisconnectHandler tears it down when the (only) human leaves, and
 		// noReconnect since a bot practice game is not reconnectable. Mirrors

--- a/src/ygopro/room/domain/YGOProRoom.ts
+++ b/src/ygopro/room/domain/YGOProRoom.ts
@@ -93,6 +93,11 @@ export class YGOProRoom extends YgoRoom {
 	 * lifecycle is atomic: if either participant leaves, the reservation aborts. */
 	isMatchmaking: boolean = false;
 
+	/** Present only on rooms whose seats were assigned before anyone connected
+	 * (matchmaking): the userIds allowed through the JOIN door. Undefined for
+	 * ordinary rooms, which admit by (name, password) alone. */
+	reservedUserIds?: readonly string[];
+
 	// Set to true when the room begins teardown (removeRoom entry point in YGOProDuelingState).
 	// The WindBotJoinStrategy retry-abort callback reads this to stop retrying when the room
 	// is being torn down.
@@ -466,6 +471,57 @@ export class YGOProRoom extends YgoRoom {
 				socket.close();
 			},
 		};
+	}
+
+	/**
+	 * Reservation gate for the JOIN door, evaluated in EVERY room state (a
+	 * reserved ranked duel is not even watchable by a third party). The join
+	 * string alone is deliberately not enough to enter a reserved room: it
+	 * travels through client config files and process lists, so entry demands
+	 * a ticket-resolved identity stamped in the reservation set. Internal (bot)
+	 * sockets are pre-authorized by their consumed room-bound join token — a
+	 * bot carries no user identity to compare. Rooms without reservations
+	 * admit everyone, exactly as before.
+	 */
+	reservationAdmits(socket: ISocket): boolean {
+		if (!this.reservedUserIds || this.reservedUserIds.length === 0) {
+			return true;
+		}
+		if (socket.internalForRoomId === this.id) {
+			return true;
+		}
+
+		if (!socket.resolvedUserId || !this.reservedUserIds.includes(socket.resolvedUserId)) {
+			return false;
+		}
+
+		// One seat per reserved identity: a reserved user whose seat is still
+		// held by a live socket cannot enter again, or one player could fill
+		// both seats with two connections and squeeze the opponent out. Seat
+		// liveness reads socket.closed — the same signal the reconnect paths
+		// use — so a crashed player (their seat's socket already closed) can
+		// still come back in through this gate.
+		const holdsLiveSeat = this._players.some(
+			(player) => player.id === socket.resolvedUserId && !player.socket.closed,
+		);
+
+		return !holdsLiveSeat;
+	}
+
+	/**
+	 * Turn a non-reserved joiner away: a red STOC_CHAT explaining why, the real
+	 * JOINERROR, then a graceful close() so both frames flush before teardown —
+	 * the same ygopro-flavored reject sequence as admissionTarget's
+	 * rejectAdmission and the waiting state's name-taken path.
+	 */
+	rejectReservedJoin(socket: ISocket): void {
+		const chat = new YGOProStocChat().fromPartial({
+			player_type: ChatColor.RED,
+			msg: "This room is reserved for its matched players.",
+		});
+		socket.send(Buffer.from(chat.toFullPayload()));
+		socket.send(this.messageSender.errorMessage(ErrorMessageType.JOINERROR, 0));
+		socket.close();
 	}
 
 	createPlayerUnsafe(socket: ISocket, name: string, userId: string | null): YGOProClient | null {

--- a/src/ygopro/room/domain/YGOProRoomReservations.test.ts
+++ b/src/ygopro/room/domain/YGOProRoomReservations.test.ts
@@ -1,0 +1,156 @@
+import { ISocket } from "@shared/socket/domain/ISocket";
+
+import { YGOProRoomMother } from "@test-support/mothers/room/YGOProRoomMother";
+
+import { ChatColor, ErrorMessageType, YGOProStocChat } from "ygopro-msg-encode";
+
+jest.mock("@ygopro/SimpleRoomMessageEmitter");
+
+const makeSocket = (overrides: Partial<ISocket> = {}): ISocket =>
+	({
+		id: `s-${Math.random()}`,
+		send: jest.fn(),
+		close: jest.fn(),
+		destroy: jest.fn(),
+		onMessage: jest.fn(),
+		removeAllListeners: jest.fn(),
+		remoteAddress: "127.0.0.1",
+		closed: false,
+		...overrides,
+	}) as unknown as ISocket;
+
+describe("YGOProRoom.reservationAdmits", () => {
+	describe("rooms without reservations (ordinary rooms)", () => {
+		it("admits an anonymous socket", () => {
+			const room = YGOProRoomMother.create();
+			expect(room.reservationAdmits(makeSocket())).toBe(true);
+		});
+
+		it("admits a ticket-authenticated socket", () => {
+			const room = YGOProRoomMother.create();
+			expect(room.reservationAdmits(makeSocket({ resolvedUserId: "u-any" }))).toBe(true);
+		});
+	});
+
+	describe("rooms with reservations (matchmaking rooms)", () => {
+		it("admits each reserved user", () => {
+			const room = YGOProRoomMother.create();
+			room.reservedUserIds = ["u-a", "u-b"];
+
+			expect(room.reservationAdmits(makeSocket({ resolvedUserId: "u-a" }))).toBe(true);
+			expect(room.reservationAdmits(makeSocket({ resolvedUserId: "u-b" }))).toBe(true);
+		});
+
+		it("rejects a ticket-authenticated stranger", () => {
+			const room = YGOProRoomMother.create();
+			room.reservedUserIds = ["u-a", "u-b"];
+
+			expect(room.reservationAdmits(makeSocket({ resolvedUserId: "u-intruder" }))).toBe(false);
+		});
+
+		it("rejects an anonymous socket (no resolved identity)", () => {
+			const room = YGOProRoomMother.create();
+			room.reservedUserIds = ["u-a", "u-b"];
+
+			expect(room.reservationAdmits(makeSocket())).toBe(false);
+		});
+
+		it("admits an internal (bot) socket whose one-shot join token named THIS room", () => {
+			const room = YGOProRoomMother.create({ id: 77 });
+			room.reservedUserIds = ["u-human"];
+
+			expect(room.reservationAdmits(makeSocket({ internalForRoomId: 77 }))).toBe(true);
+		});
+
+		it("rejects an internal (bot) socket whose token named a DIFFERENT room", () => {
+			const room = YGOProRoomMother.create({ id: 77 });
+			room.reservedUserIds = ["u-human"];
+
+			expect(room.reservationAdmits(makeSocket({ internalForRoomId: 78 }))).toBe(false);
+		});
+	});
+});
+
+describe("YGOProRoom.rejectReservedJoin", () => {
+	it("sends a red chat explaining the reservation, then the JOINERROR frame", () => {
+		const room = YGOProRoomMother.create();
+		const socket = makeSocket();
+
+		room.rejectReservedJoin(socket);
+
+		const sends = (socket.send as jest.Mock).mock.calls.map(([buf]) => buf as Buffer);
+		const expectedChat = Buffer.from(
+			new YGOProStocChat()
+				.fromPartial({
+					player_type: ChatColor.RED,
+					msg: "This room is reserved for its matched players.",
+				})
+				.toFullPayload(),
+		);
+		expect(sends.some((buf) => buf.equals(expectedChat))).toBe(true);
+		expect(room.messageSender.errorMessage).toHaveBeenCalledWith(ErrorMessageType.JOINERROR, 0);
+	});
+
+	it("closes the socket gracefully so the error frames flush before teardown", () => {
+		const room = YGOProRoomMother.create();
+		const socket = makeSocket();
+
+		room.rejectReservedJoin(socket);
+
+		expect(socket.close).toHaveBeenCalled();
+		expect(socket.destroy).not.toHaveBeenCalled();
+	});
+});
+
+describe("YGOProRoom.reservationAdmits — one seat per reserved identity", () => {
+	// Minimal seated-player entry: reservationAdmits only reads the seat's
+	// stamped userId and its socket's liveness, the same signal the reconnect
+	// paths use (socket.closed).
+	const seatPlayer = (
+		room: ReturnType<typeof YGOProRoomMother.create>,
+		userId: string,
+		closed = false,
+	): void => {
+		room.players.push({ id: userId, socket: { closed } } as never);
+	};
+
+	it("rejects a reserved user whose seat is still held by a live socket (second concurrent join)", () => {
+		const room = YGOProRoomMother.create();
+		room.reservedUserIds = ["u-a", "u-b"];
+		seatPlayer(room, "u-a");
+
+		expect(room.reservationAdmits(makeSocket({ resolvedUserId: "u-a" }))).toBe(false);
+	});
+
+	it("still admits the opponent while the first player holds their own seat", () => {
+		const room = YGOProRoomMother.create();
+		room.reservedUserIds = ["u-a", "u-b"];
+		seatPlayer(room, "u-a");
+
+		expect(room.reservationAdmits(makeSocket({ resolvedUserId: "u-b" }))).toBe(true);
+	});
+
+	it("admits the reserved user again once their seat's socket is closed (crash recovery)", () => {
+		const room = YGOProRoomMother.create();
+		room.reservedUserIds = ["u-a", "u-b"];
+		seatPlayer(room, "u-a", true);
+
+		expect(room.reservationAdmits(makeSocket({ resolvedUserId: "u-a" }))).toBe(true);
+	});
+
+	it("rejects the human's second concurrent join in a bot-fallback room (single reserved id)", () => {
+		const room = YGOProRoomMother.create();
+		room.reservedUserIds = ["u-human"];
+		seatPlayer(room, "u-human");
+
+		expect(room.reservationAdmits(makeSocket({ resolvedUserId: "u-human" }))).toBe(false);
+	});
+
+	it("ignores guest seats (null id) when checking the double-seat guard", () => {
+		const room = YGOProRoomMother.create();
+		room.reservedUserIds = ["u-a", "u-b"];
+		room.players.push({ id: null, socket: { closed: false } } as never);
+
+		expect(room.reservationAdmits(makeSocket({ resolvedUserId: "u-a" }))).toBe(true);
+	});
+});

--- a/src/ygopro/room/domain/states/YGOProChoosingOrderState.ts
+++ b/src/ygopro/room/domain/states/YGOProChoosingOrderState.ts
@@ -82,6 +82,15 @@ export class YGOProChoosingOrderState extends YGOProRoomState {
 	private handleJoin(message: ClientMessage, room: YGOProRoom, socket: ISocket): void {
 		this.logger.info("handleJoin");
 
+		// Reservation gate: past WAITING, a reserved room is not even watchable
+		// by a third party — the join string alone never buys a spectator seat.
+		// A reserved player's own reconnect passes this check (its ticket-resolved
+		// identity is in the reservation set) and proceeds below unchanged.
+		if (!room.reservationAdmits(socket)) {
+			room.rejectReservedJoin(socket);
+			return;
+		}
+
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
 		const playerAlreadyInRoom = findReconnectingPlayer({
 			players: room.players,

--- a/src/ygopro/room/domain/states/YGOProDuelingState.ts
+++ b/src/ygopro/room/domain/states/YGOProDuelingState.ts
@@ -241,6 +241,15 @@ export class YGOProDuelingState extends YGOProRoomState {
 	private handleJoin(message: ClientMessage, room: YGOProRoom, socket: ISocket): void {
 		this.logger.info("handleJoin");
 
+		// Reservation gate: past WAITING, a reserved room is not even watchable
+		// by a third party — the join string alone never buys a spectator seat.
+		// A reserved player's own reconnect passes this check (its ticket-resolved
+		// identity is in the reservation set) and proceeds below unchanged.
+		if (!room.reservationAdmits(socket)) {
+			room.rejectReservedJoin(socket);
+			return;
+		}
+
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
 		const playerAlreadyInRoom = findReconnectingPlayer({
 			players: room.players,

--- a/src/ygopro/room/domain/states/YGOProReservedRoomJoin.test.ts
+++ b/src/ygopro/room/domain/states/YGOProReservedRoomJoin.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Seat reservation at the JOIN door of every non-waiting state.
+ *
+ * A matchmaking room's join string travels through client config and process
+ * lists, so it must not be enough to enter the room once the duel is underway:
+ * a third party is explicitly rejected — not seated, not spectator — while a
+ * reserved player's own reconnect keeps working. States are exercised on
+ * prototype instances (same approach as the express-reconnect tests) because
+ * the dueling state's full constructor needs an OCGCore spin-up.
+ */
+
+import { Logger } from "@shared/logger/domain/Logger";
+import { ClientMessage } from "@shared/messages/MessageProcessor";
+import { TokenIndex } from "@shared/room/domain/TokenIndex";
+import { ISocket } from "@shared/socket/domain/ISocket";
+
+import { YGOProClient } from "../../../client/domain/YGOProClient";
+import { YGOProRoom } from "../YGOProRoom";
+import { YGOProChoosingOrderState } from "./YGOProChoosingOrderState";
+import { YGOProDuelingState } from "./YGOProDuelingState";
+import { YGOProRockPaperScissorState } from "./YGOProRockPaperScissorState";
+import { YGOProSideDeckingState } from "./YGOProSideDeckingState";
+
+const makeLogger = (): jest.Mocked<Logger> =>
+	({
+		child: jest.fn().mockReturnThis(),
+		info: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+		debug: jest.fn(),
+	}) as unknown as jest.Mocked<Logger>;
+
+// "Jaden" in UTF-16LE with no password separator (40 bytes)
+const PLAYER_INFO_HEX =
+	"4a006100640065006e00000000000000000000000000000000000000000000000000000000000000";
+
+const makeJoinMessage = (): ClientMessage =>
+	({
+		data: Buffer.alloc(48),
+		previousMessage: Buffer.from(PLAYER_INFO_HEX, "hex"),
+	}) as unknown as ClientMessage;
+
+const makeSocket = (overrides: Partial<ISocket> = {}): jest.Mocked<ISocket> =>
+	({
+		send: jest.fn(),
+		close: jest.fn(),
+		destroy: jest.fn(),
+		remoteAddress: "127.0.0.1",
+		closed: false,
+		...overrides,
+	}) as unknown as jest.Mocked<ISocket>;
+
+const makeSpectator = () =>
+	({ sendMessageToClient: jest.fn() }) as unknown as jest.Mocked<YGOProClient>;
+
+const makeRoom = (overrides: Record<string, unknown> = {}): jest.Mocked<YGOProRoom> =>
+	({
+		ranked: true,
+		players: [],
+		reservationAdmits: jest.fn().mockReturnValue(true),
+		rejectReservedJoin: jest.fn(),
+		createSpectatorUnsafe: jest.fn().mockReturnValue(makeSpectator()),
+		addSpectatorUnsafe: jest.fn(),
+		reconnect: jest.fn(),
+		sendDeckCountMessage: jest.fn(),
+		sendPreviousDuelsHistoricalMessages: jest.fn(),
+		sendCurrentDuelHistoricalMessages: jest.fn(),
+		messageSender: {
+			duelStartMessage: jest.fn().mockReturnValue(Buffer.from("duel-start")),
+			changeSideMessage: jest.fn().mockReturnValue(Buffer.from("change-side")),
+		},
+		...overrides,
+	}) as unknown as jest.Mocked<YGOProRoom>;
+
+// A YGOProClient instance (passes `instanceof YGOProClient`) without running
+// the real constructor. A weak-auth seat with a matching name so
+// findReconnectingPlayer resolves it in a ranked room.
+const makeSeatedPlayer = (name = "Jaden"): YGOProClient => {
+	const client = Object.create(YGOProClient.prototype) as Record<string, unknown>;
+	client._credential = null;
+	client.name = name;
+	client.sendMessageToClient = jest.fn();
+	return client as unknown as YGOProClient;
+};
+
+type JoinCapableState = {
+	handleJoin(message: ClientMessage, room: YGOProRoom, socket: ISocket): void;
+};
+
+const buildState = (
+	proto: { prototype: object },
+	fields: Record<string, unknown> = {},
+): JoinCapableState => {
+	const state = Object.create(proto.prototype);
+	Object.assign(state, { logger: makeLogger(), ...fields });
+	return state as JoinCapableState;
+};
+
+const expectRejected = (room: jest.Mocked<YGOProRoom>, socket: jest.Mocked<ISocket>): void => {
+	expect(room.rejectReservedJoin).toHaveBeenCalledWith(socket);
+	expect(room.createSpectatorUnsafe).not.toHaveBeenCalled();
+	expect(room.addSpectatorUnsafe).not.toHaveBeenCalled();
+	expect(room.reconnect).not.toHaveBeenCalled();
+};
+
+const expectSpectated = (room: jest.Mocked<YGOProRoom>): void => {
+	expect(room.rejectReservedJoin).not.toHaveBeenCalled();
+	expect(room.createSpectatorUnsafe).toHaveBeenCalled();
+	expect(room.addSpectatorUnsafe).toHaveBeenCalled();
+};
+
+describe("YGOProDuelingState.handleJoin — reserved rooms", () => {
+	const build = (room: jest.Mocked<YGOProRoom>) => buildState(YGOProDuelingState, { room });
+
+	it("rejects a third party the reservation does not admit — not even as spectator", () => {
+		const room = makeRoom();
+		(room.reservationAdmits as jest.Mock).mockReturnValue(false);
+		const socket = makeSocket({ resolvedUserId: "u-intruder" });
+
+		build(room).handleJoin(makeJoinMessage(), room, socket);
+
+		expectRejected(room, socket);
+	});
+
+	it("still spectates a third party in a room without reservations", () => {
+		const room = makeRoom();
+
+		build(room).handleJoin(makeJoinMessage(), room, makeSocket());
+
+		expectSpectated(room);
+	});
+
+	it("still reconnects a seated player the reservation admits", () => {
+		const player = makeSeatedPlayer();
+		const room = makeRoom({ players: [player] });
+		const socket = makeSocket({ resolvedUserId: "u-a" });
+
+		build(room).handleJoin(makeJoinMessage(), room, socket);
+
+		expect(room.reconnect).toHaveBeenCalledWith(player, socket);
+		expect(room.rejectReservedJoin).not.toHaveBeenCalled();
+	});
+
+	it("still reconnects a reserved player through its token (EXPRESS_RECONNECT bypasses the JOIN gate)", async () => {
+		// The reconnection token is itself proof of a prior admitted seat, so the
+		// reservation gate never inspects that path — a fresh socket without a
+		// resolved identity must get back into the reserved duel.
+		const player = Object.create(YGOProClient.prototype) as Record<string, unknown>;
+		player._reconnectionToken = "tok";
+		player.sendMessageToClient = jest.fn();
+		player.setReconnectionToken = jest.fn();
+		player.clearReconnecting = jest.fn();
+		TokenIndex.getInstance().register("tok", player as unknown as YGOProClient, 1);
+
+		const room = makeRoom({ id: 1, reservedUserIds: ["u-a", "u-b"] });
+		const socket = makeSocket();
+		const ocgCore = {
+			sendStartMessageForReconnect: jest.fn(),
+			sendTurnMessages: jest.fn(),
+			sendPhaseMessage: jest.fn(),
+			sendRequestFieldMessage: jest.fn().mockResolvedValue(undefined),
+			sendRefreshZonesMessages: jest.fn().mockResolvedValue(undefined),
+			sendDeckReversedAndTopMessages: jest.fn().mockResolvedValue(undefined),
+			sendReconnectTimeLimitAndResponseState: jest.fn().mockResolvedValue(undefined),
+		};
+		const state = buildState(YGOProDuelingState, { room, ocgCore }) as unknown as {
+			handleExpressReconnect(
+				message: ClientMessage,
+				room: YGOProRoom,
+				socket: ISocket,
+			): Promise<void>;
+		};
+
+		await state.handleExpressReconnect(
+			{ data: Buffer.from("tok", "utf8") } as ClientMessage,
+			room,
+			socket,
+		);
+
+		expect(room.reconnect).toHaveBeenCalledWith(player, socket);
+		expect(socket.destroy).not.toHaveBeenCalled();
+		TokenIndex.getInstance().clear();
+	});
+});
+
+describe("YGOProRockPaperScissorState.handleJoin — reserved rooms", () => {
+	const build = () => buildState(YGOProRockPaperScissorState, { handResult: [0, 0] });
+
+	it("rejects a third party the reservation does not admit", () => {
+		const room = makeRoom();
+		(room.reservationAdmits as jest.Mock).mockReturnValue(false);
+		const socket = makeSocket();
+
+		build().handleJoin(makeJoinMessage(), room, socket);
+
+		expectRejected(room, socket);
+	});
+
+	it("still spectates a third party in a room without reservations", () => {
+		const room = makeRoom();
+
+		build().handleJoin(makeJoinMessage(), room, makeSocket());
+
+		expectSpectated(room);
+	});
+});
+
+describe("YGOProChoosingOrderState.handleJoin — reserved rooms", () => {
+	it("rejects a third party the reservation does not admit", () => {
+		const room = makeRoom();
+		(room.reservationAdmits as jest.Mock).mockReturnValue(false);
+		const socket = makeSocket();
+
+		buildState(YGOProChoosingOrderState).handleJoin(makeJoinMessage(), room, socket);
+
+		expectRejected(room, socket);
+	});
+
+	it("still spectates a third party in a room without reservations", () => {
+		const room = makeRoom();
+
+		buildState(YGOProChoosingOrderState).handleJoin(makeJoinMessage(), room, makeSocket());
+
+		expectSpectated(room);
+	});
+});
+
+describe("YGOProSideDeckingState.handleJoin — reserved rooms", () => {
+	it("rejects a third party the reservation does not admit", () => {
+		const room = makeRoom();
+		(room.reservationAdmits as jest.Mock).mockReturnValue(false);
+		const socket = makeSocket();
+
+		buildState(YGOProSideDeckingState).handleJoin(makeJoinMessage(), room, socket);
+
+		expectRejected(room, socket);
+	});
+
+	it("still spectates a third party in a room without reservations", () => {
+		const room = makeRoom();
+
+		buildState(YGOProSideDeckingState).handleJoin(makeJoinMessage(), room, makeSocket());
+
+		expectSpectated(room);
+	});
+});

--- a/src/ygopro/room/domain/states/YGOProRockPaperScissorState.ts
+++ b/src/ygopro/room/domain/states/YGOProRockPaperScissorState.ts
@@ -74,6 +74,15 @@ export class YGOProRockPaperScissorState extends YGOProRoomState {
 	private handleJoin(message: ClientMessage, room: YGOProRoom, socket: ISocket): void {
 		this.logger.info("handleJoin");
 
+		// Reservation gate: past WAITING, a reserved room is not even watchable
+		// by a third party — the join string alone never buys a spectator seat.
+		// A reserved player's own reconnect passes this check (its ticket-resolved
+		// identity is in the reservation set) and proceeds below unchanged.
+		if (!room.reservationAdmits(socket)) {
+			room.rejectReservedJoin(socket);
+			return;
+		}
+
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
 		const playerAlreadyInRoom = findReconnectingPlayer({
 			players: room.players,

--- a/src/ygopro/room/domain/states/YGOProSideDeckingState.ts
+++ b/src/ygopro/room/domain/states/YGOProSideDeckingState.ts
@@ -193,6 +193,15 @@ export class YGOProSideDeckingState extends YGOProRoomState {
 	private handleJoin(message: ClientMessage, room: YGOProRoom, socket: ISocket): void {
 		this.logger.info("handleJoin");
 
+		// Reservation gate: past WAITING, a reserved room is not even watchable
+		// by a third party — the join string alone never buys a spectator seat.
+		// A reserved player's own reconnect passes this check (its ticket-resolved
+		// identity is in the reservation set) and proceeds below unchanged.
+		if (!room.reservationAdmits(socket)) {
+			room.rejectReservedJoin(socket);
+			return;
+		}
+
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
 		const playerAlreadyInRoom = findReconnectingPlayer({
 			players: room.players,

--- a/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
@@ -258,6 +258,8 @@ describe("YGOProWaitingState.handleJoin", () => {
 				runExclusive: jest.fn().mockImplementation(async (fn: () => Promise<void>) => fn()),
 			},
 			admissionTarget: jest.fn().mockReturnValue(admissionTarget),
+			reservationAdmits: jest.fn().mockReturnValue(true),
+			rejectReservedJoin: jest.fn(),
 			messageSender: {
 				errorMessage: jest.fn().mockReturnValue(Buffer.alloc(0)),
 			},
@@ -321,6 +323,31 @@ describe("YGOProWaitingState.handleJoin", () => {
 			expect.anything(),
 			admissionTarget,
 		);
+	});
+
+	describe("seat reservation", () => {
+		it("asks the room whether the reservation admits the joining socket", async () => {
+			await emitJoin(mockRoom, mockSocket);
+
+			expect(mockRoom.reservationAdmits).toHaveBeenCalledWith(mockSocket);
+		});
+
+		it("rejects a joiner the reservation does not admit, without delegating to AdmitToRoom", async () => {
+			(mockRoom.reservationAdmits as jest.Mock).mockReturnValue(false);
+
+			await emitJoin(mockRoom, mockSocket);
+
+			expect(mockRoom.rejectReservedJoin).toHaveBeenCalledWith(mockSocket);
+			expect(mockAdmitToRoom.run).not.toHaveBeenCalled();
+			expect(mockRoom.admissionTarget).not.toHaveBeenCalled();
+		});
+
+		it("still delegates an admitted joiner to AdmitToRoom (ordinary rooms unaffected)", async () => {
+			await emitJoin(mockRoom, mockSocket);
+
+			expect(mockRoom.rejectReservedJoin).not.toHaveBeenCalled();
+			expect(mockAdmitToRoom.run).toHaveBeenCalled();
+		});
 	});
 
 	it("rejects a duplicate name without delegating to AdmitToRoom", async () => {

--- a/src/ygopro/room/domain/states/YGOProWaitingState.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.ts
@@ -82,6 +82,14 @@ export class YGOProWaitingState extends YGOProRoomState {
 			return;
 		}
 
+		// Reservation gate before any admission work: a reserved room's join
+		// string is not a key — only the stamped identities (or the bot's
+		// token-marked socket) get past this door, not even as spectators.
+		if (!room.reservationAdmits(socket)) {
+			room.rejectReservedJoin(socket);
+			return;
+		}
+
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
 		if (isNameTaken(room.players, playerInfoMessage.name)) {
 			this.sendNameTakenError(room, playerInfoMessage.name, socket);


### PR DESCRIPTION
## Summary

Hardening batch for the matchmaking pipeline, from the HTTP surface down to room admission.

### Queue HTTP surface
- **Enqueue is now rate-limited** with its own bucket (`enqueue`, 20/min per IP) via a scoped rate-limit middleware factory. The deployed `inspect` bucket, key format, and budget are untouched, so status/cancel behavior and any ops tooling keyed on `rate-limit:inspect:<ip>` are unaffected. Exhausting one bucket provably leaves the other intact.
- **`opponentName` no longer leaks the internal user id.** A new `DisplayNameResolver` domain port (adapter over `UserProfileRepository`) resolves the name at enqueue time, where the controller is already async — `tick()` stays synchronous and DB-free. The matched payload carries the trimmed display name or `null`, never the user id; the bot-fallback path carries `null`.
- **Duplicate enqueues return 409 without a DB round-trip**: a synchronous `isUserQueued` pre-check runs before the Postgres lookup, while the atomic guard inside `enqueue()` remains the authority.
- **`poll()` is now a pure heartbeat + read.** Pairing, bot fallback, and expiry run only on the 2s interval sweep and on enqueue (the state-changing event). Per-poll cost drops to O(1); worst-case added match-visibility latency is one sweep interval, within the client's poll cadence.

### Seat reservations
- Matchmaking rooms are stamped with the matched user ids at creation (human-only for bot-fallback rooms; an empty reservation list fails loudly).
- The reservation gate runs at the top of **every room state's join door** (Waiting, Dueling, RPS, ChoosingOrder, SideDecking): a joiner whose resolved user id is not reserved is rejected with a JOINERROR — never seated, never a spectator. This covers all entry paths, including the edopro-flavor id-based join, and closes a griefing surface where a stranger could spectate-and-abort a matchmaking lobby.
- **A reserved identity holding a live-socket seat cannot take a second seat**, so a player cannot fill both chairs and demote their real opponent to spectator. Liveness uses the same `socket.closed` signal as the existing reconnect paths, which preserves crash recovery (a disconnected player re-enters their own match).
- The windbot exemption is room-scoped: the bot socket is stamped with the room id bound to its consumed one-shot token, and the gate compares it — a token for room X cannot admit into room Y. Express-reconnect keeps bypassing the gate by design: the single-use, room-bound token is proof of a prior seat.
- Ordinary rooms carry no reservations and behave exactly as before.

## Verification
- Full suite: **147 suites / 1405 tests green**
- `tsc --noEmit` clean, biome clean
- Two independent adversarial review rounds (queue surface, then seat reservations); every finding fixed test-first, including mutation-proofed tests (middleware ordering, wire-shape pinning, gate semantics)