### PR TITLE
feat(join): add watch-by-id spectator command

### DIFF
--- a/docs/join-commands.md
+++ b/docs/join-commands.md
@@ -36,8 +36,14 @@ Strategy chain, first `matches()` wins
 |---|----------|--------------|----------|
 | 1 | `AIJoinTokenStrategy` | windbot enabled AND `rawPass` starts with `AIJOIN#` | The bot itself connecting back: consumes a one-shot token, finds the room **by id**, marks the client internal. |
 | 2 | `WindBotJoinStrategy` | windbot enabled AND `ai` among config tokens | Creates an AI room, resolves the bot (by name after `#`, or format-scoped random via `resolveBotPool`), fires the bot request. Rejects tag mode. |
-| 3 | `TicketJoinStrategy` | socket authenticated via WS ticket (`resolvedUserId`) | Shared `findOrCreateRoom` helper (`rankedOverride=true`) — see §5 for the pairing-vs-non-pairing lookup it performs. |
-| 4 | `DefaultJoinStrategy` | always | Shared `findOrCreateRoom` helper (`rankedOverride=undefined`) — see §5 for the pairing-vs-non-pairing lookup it performs. Admission is delegated to the room state (§6). |
+| 3 | `WatchJoinStrategy` | command segment is exactly `w,<digits>` (see §9) | Intentional spectating **by room id**: finds the room via `findById`, gates on an exact password match, marks the socket with watch intent and routes the JOIN. Never creates a room. |
+| 4 | `TicketJoinStrategy` | socket authenticated via WS ticket (`resolvedUserId`) | Shared `findOrCreateRoom` helper (`rankedOverride=true`) — see §5 for the pairing-vs-non-pairing lookup it performs. |
+| 5 | `DefaultJoinStrategy` | always | Shared `findOrCreateRoom` helper (`rankedOverride=undefined`) — see §5 for the pairing-vs-non-pairing lookup it performs. Admission is delegated to the room state (§6). |
+
+`WatchJoinStrategy` must sit BEFORE `TicketJoinStrategy`: the ticket strategy
+matches on socket auth alone, not command shape, so a ticketed socket sending
+`w,1234` would otherwise fall into `findOrCreateRoom` and mint a junk room
+literally named `w,1234` instead of watching room 1234.
 
 On strategy error: `JOINERROR` frame + `socket.close()`.
 
@@ -282,6 +288,72 @@ Admission depends on the room state active when `JOIN` fires:
    instead of an explicit reject. Because there is no reject on this path, a
    mismatched password also no longer terminates the connection: the socket
    is never destroyed, and the joiner instead lands in the newly created room.
+   Watch joins (§9) are the deliberate exception: they resolve by id, not by
+   the (name, password) pair, so a wrong password there is an explicit reject
+   rather than a fresh room.
 5. The 20-char `pass` ceiling applies to the entire command string; bot names
    are boot-validated against a 13-char budget that assumes short (≤3 chars +
    comma) format tokens.
+
+## 9. Watch joins (`w,<roomId>[#password]`)
+
+Intentional spectating of a specific room, addressed **by id** instead of the
+(name, password) pair. Handled by `WatchJoinStrategy`
+(`src/ygopro/room/application/join-strategies/WatchJoinStrategy.ts`), placed
+after the windbot strategies and BEFORE `TicketJoinStrategy` in the chain
+(§2 — placement rationale there).
+
+**Shape.** The command segment (before the first `#`) must be exactly two
+comma-separated tokens: `w` (trimmed, case-insensitive) followed by an
+all-digit room id (trimmed; inner whitespace or any non-digit disqualifies).
+The password segment after the first `#` is the room password, `""` when
+absent — same split as every other join (§1). `w,123`, `W, 123 ` and
+`w,123#secret` are watch joins; `w`, `w,12a`, `tcg,w` and `w,123,extra` are
+not — they fall through to the rest of the chain untouched, so `w,123,extra`
+can still become an ordinary room name.
+
+**Semantics.**
+
+- The room is resolved via `YGOProRoomList.findById`. Unknown id → explicit
+  reject (red `STOC_CHAT` + `JOINERROR` + graceful `close()`, the same idiom
+  as `rejectReservedJoin`). A watch join **never creates a room**.
+- Password gate: the supplied password must equal `room.password` exactly
+  (empty matches empty). Mismatch → the same explicit reject. This
+  deliberately CONTRASTS with the non-pairing name path (§4/§8 caveat 4),
+  where a mistyped password silently creates a fresh room: an id names one
+  concrete room, so there is nothing sensible to create — rejecting is the
+  honest answer, and it costs none of the identity trade-offs the name path
+  makes.
+- On success the joiner enters as a SPECTATOR in ANY room state. Mid-duel
+  states spectate unknown joiners (§6), and for a watch-stamped socket they
+  FORCE that spectator branch: the name-based reconnect
+  (`findReconnectingPlayer`) is skipped entirely, so a watcher whose nickname
+  matches a seated player never takes that seat. In WAITING, the strategy
+  stamps the socket server-side with
+  `watchForRoomId = room.id` (ISocket, mirroring the `internalForRoomId`
+  precedent) before emitting JOIN; `YGOProRoom.admissionTarget` then offers
+  that socket no seat, so the unchanged admission policy (`RoomAdmission`)
+  routes it to the stands. Only the seat offer is affected: ranked+guest
+  rejection and league checks still apply, and the stamp is derived
+  exclusively from the server-parsed command — no client-controlled field
+  can set it. A watch spectator in WAITING may still self-promote through
+  the existing `TO_DUEL` flow (§6), like any other spectator.
+- Reservation interaction: the reservation gate at the top of every state's
+  `handleJoin` (`reservationAdmits`) runs BEFORE watch admission and never
+  reads the watch stamp — a reserved (matchmaking) room rejects a watcher
+  like any other third party, even with the correct password.
+
+**Room id uniqueness.** `findById` is first-match, so id-addressed paths
+(watch joins, the windbot `AIJOIN` return trip) require live ids to be
+unique. Every ygopro room creation site (`findOrCreateRoom`,
+`WindBotJoinStrategy`, `createMatchmakingRoom`) therefore draws its id from
+`generateUnusedRoomId`
+(`src/ygopro/room/application/generateUnusedRoomId.ts`), which retries
+`generateUniqueId` until the id is unused by any live room in
+`YGOProRoomList` and throws after a bounded number of attempts. The edopro
+`RoomCreator` keeps its own separate generator — it feeds a different room
+list.
+
+`w` is a join command, not a rule token: it is deliberately absent from
+`RuleMappings`/`isRecognizedToken`, so a bare `w` can never become a pairing
+pool (§5).

--- a/docs/join-commands.md
+++ b/docs/join-commands.md
@@ -337,11 +337,20 @@ can still become an ordinary room name.
   rejection and league checks still apply, and the stamp is derived
   exclusively from the server-parsed command — no client-controlled field
   can set it. A watch spectator in WAITING may still self-promote through
-  the existing `TO_DUEL` flow (§6), like any other spectator.
+  the existing `TO_DUEL` flow (§6), like any other spectator — except in a
+  reserved room, where the promotion door additionally runs the seat-taking
+  reservation check (`reservationPermitsSeat`): only a ticket-resolved
+  identity in the reservation set may leave the stands, so a non-reserved
+  watch spectator stays a spectator.
 - Reservation interaction: the reservation gate at the top of every state's
-  `handleJoin` (`reservationAdmits`) runs BEFORE watch admission and never
-  reads the watch stamp — a reserved (matchmaking) room rejects a watcher
-  like any other third party, even with the correct password.
+  `handleJoin` (`reservationAdmits`) runs BEFORE watch admission. A reserved
+  (matchmaking) room is spectator-only watchable: a socket whose watch stamp
+  names that room is admitted to the stands (spectators see only the
+  opponent view, and a watch-stamped socket can never take a seat), while
+  every other third party is still rejected outright, even with the correct
+  password. Seats stay reserved: seat-taking paths use
+  `reservationPermitsSeat`, which ignores the watch stamp and demands a
+  reserved identity.
 
 **Room id uniqueness.** `findById` is first-match, so id-addressed paths
 (watch joins, the windbot `AIJOIN` return trip) require live ids to be

--- a/src/shared/room/domain/findMidDuelReconnectingPlayer.test.ts
+++ b/src/shared/room/domain/findMidDuelReconnectingPlayer.test.ts
@@ -1,0 +1,88 @@
+import { YgoClient } from "@shared/client/domain/YgoClient";
+import { ISocket } from "@shared/socket/domain/ISocket";
+
+import { findMidDuelReconnectingPlayer } from "./findMidDuelReconnectingPlayer";
+
+const player = (
+	overrides: Partial<{
+		name: string;
+		isStrongAuth: boolean;
+		closed: boolean;
+		remoteAddress: string | null;
+	}> = {},
+): YgoClient =>
+	({
+		name: overrides.name ?? "Jaden",
+		isStrongAuth: overrides.isStrongAuth ?? false,
+		socket: {
+			closed: overrides.closed ?? true,
+			remoteAddress: overrides.remoteAddress ?? "1.1.1.1",
+		},
+	}) as unknown as YgoClient;
+
+const socket = (overrides: Partial<ISocket> = {}): ISocket =>
+	({
+		remoteAddress: "1.1.1.1",
+		...overrides,
+	}) as unknown as ISocket;
+
+describe("findMidDuelReconnectingPlayer", () => {
+	it("NEVER matches when the socket's watch stamp names this room — a ranked still-connected name match stays seated", () => {
+		const p = player({ closed: false });
+		const found = findMidDuelReconnectingPlayer({
+			players: [p],
+			name: "Jaden",
+			socket: socket({ watchForRoomId: 7 }),
+			roomId: 7,
+			ranked: true,
+		});
+		expect(found).toBeNull();
+	});
+
+	it("NEVER matches when the stamp names this room — even a fully reconnect-eligible casual match", () => {
+		const p = player({ closed: true, remoteAddress: "1.1.1.1" });
+		const found = findMidDuelReconnectingPlayer({
+			players: [p],
+			name: "Jaden",
+			socket: socket({ watchForRoomId: 7 }),
+			roomId: 7,
+			ranked: false,
+		});
+		expect(found).toBeNull();
+	});
+
+	it("a stamp for a DIFFERENT room is inert — the by-name reconnect still resolves", () => {
+		const p = player();
+		const found = findMidDuelReconnectingPlayer({
+			players: [p],
+			name: "Jaden",
+			socket: socket({ watchForRoomId: 8 }),
+			roomId: 7,
+			ranked: true,
+		});
+		expect(found).toBe(p);
+	});
+
+	it("without a stamp it behaves exactly like findReconnectingPlayer — match found", () => {
+		const p = player();
+		const found = findMidDuelReconnectingPlayer({
+			players: [p],
+			name: "Jaden",
+			socket: socket(),
+			roomId: 7,
+			ranked: true,
+		});
+		expect(found).toBe(p);
+	});
+
+	it("without a stamp it behaves exactly like findReconnectingPlayer — no match is null", () => {
+		const found = findMidDuelReconnectingPlayer({
+			players: [],
+			name: "Jaden",
+			socket: socket(),
+			roomId: 7,
+			ranked: true,
+		});
+		expect(found).toBeNull();
+	});
+});

--- a/src/shared/room/domain/findMidDuelReconnectingPlayer.ts
+++ b/src/shared/room/domain/findMidDuelReconnectingPlayer.ts
@@ -1,0 +1,39 @@
+import { YgoClient } from "@shared/client/domain/YgoClient";
+import { ISocket } from "@shared/socket/domain/ISocket";
+
+import { findReconnectingPlayer } from "./findReconnectingPlayer";
+
+/**
+ * Mid-duel JOIN resolution that honors the socket's watch stamp BEFORE the
+ * by-name reconnect is attempted. A watch join ("w,<roomId>") asked for the
+ * stands, never for a seat: when the stamp names this exact room, the joiner
+ * must fall through to the spectator branch even if its nickname matches a
+ * reconnect-eligible player (in a ranked room that player may even still be
+ * connected — the by-name path skips the address and liveness checks there).
+ *
+ * The stamp is scoped to the room the parsed command named and is never
+ * cleared, so a stamp for any OTHER room is inert here.
+ *
+ * Every mid-duel state resolves its JOIN through this single seam so the
+ * spectate-forcing rule cannot drift between states.
+ */
+export function findMidDuelReconnectingPlayer(params: {
+	players: YgoClient[];
+	name: string;
+	socket: ISocket;
+	roomId: number;
+	ranked: boolean;
+}): YgoClient | null {
+	const { socket } = params;
+
+	if (socket.watchForRoomId !== undefined && socket.watchForRoomId === params.roomId) {
+		return null;
+	}
+
+	return findReconnectingPlayer({
+		players: params.players,
+		name: params.name,
+		remoteAddress: socket.remoteAddress,
+		ranked: params.ranked,
+	});
+}

--- a/src/shared/socket/domain/ISocket.ts
+++ b/src/shared/socket/domain/ISocket.ts
@@ -8,6 +8,17 @@ export interface ISocket {
 	 * Holds that room's id so the authorization cannot leak to another room
 	 * over the socket's lifetime. */
 	internalForRoomId?: number;
+	/** Set ONLY by WatchJoinStrategy when the parsed join command was a watch
+	 * request ("w,<roomId>"): this joiner asked to spectate, never to take a
+	 * seat — in every room state. Derived exclusively from the command string
+	 * the server parsed — no client-controlled field can set it — and scoped
+	 * to that one room's id. Read only by seat-offer/seat-taking decisions:
+	 * the waiting admission's freeSeat guard and the mid-duel states'
+	 * spectate-forcing (findMidDuelReconnectingPlayer). Every other gate
+	 * (reservation, ranked, league) still applies. Never cleared, so a stale
+	 * stamp for room A must never affect any other room — readers must always
+	 * compare it against their own room id. */
+	watchForRoomId?: number;
 	send(message: Buffer): void;
 	onMessage(callback: (message: Buffer) => void): void;
 	onClose(callback: () => void): void;

--- a/src/ygopro/matchmaking/application/MatchmakingRoomFactory.test.ts
+++ b/src/ygopro/matchmaking/application/MatchmakingRoomFactory.test.ts
@@ -1,5 +1,7 @@
 import { EventEmitter } from "stream";
 
+import * as uniqueIdModule from "src/utils/generateUniqueId";
+
 import { RoomLeague } from "@shared/room/admission/domain/RoomLeague";
 
 import { ErrorMessageType } from "ygopro-msg-encode";
@@ -447,5 +449,32 @@ describe("FORMAT_ROOM_TOKEN_MATCH", () => {
 	it('maps tcg to "tmr" (tt rules + best-of-3) and jtp to "jm"', () => {
 		expect(FORMAT_ROOM_TOKEN_MATCH.tcg).toBe("tmr");
 		expect(FORMAT_ROOM_TOKEN_MATCH.jtp).toBe("jm");
+	});
+});
+
+describe("createMatchmakingRoom — room id uniqueness", () => {
+	beforeEach(clearRooms);
+	afterEach(() => {
+		clearRooms();
+		jest.restoreAllMocks();
+	});
+
+	// findById is first-match: a matchmaking room reusing a live room's id
+	// would be shadowed on every id-addressed path (watch joins, AIJOIN).
+	it("skips an id already used by a live room", () => {
+		YGOProRoomList.addRoom({ id: 4444 } as never);
+		jest
+			.spyOn(uniqueIdModule, "generateUniqueId")
+			.mockReturnValueOnce(4444)
+			.mockReturnValueOnce(5555);
+
+		const { room } = createMatchmakingRoom({
+			reservedUserIds: ["u-a", "u-b"],
+			rankedOverride: true,
+			logger: makeLogger(),
+			emitter: new EventEmitter(),
+		});
+
+		expect(room.id).toBe(5555);
 	});
 });

--- a/src/ygopro/matchmaking/application/MatchmakingRoomFactory.ts
+++ b/src/ygopro/matchmaking/application/MatchmakingRoomFactory.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from "stream";
 import { PlayerInfoMessage } from "@edopro/messages/client-to-server/PlayerInfoMessage";
 import { Logger } from "@shared/logger/domain/Logger";
 
-import { generateUniqueId } from "src/utils/generateUniqueId";
+import { generateUnusedRoomId } from "../../room/application/generateUnusedRoomId";
 
 import { MatchmakingFormat } from "@ygopro/matchmaking/domain/QueueEntry";
 import { YGOProMessageRepository } from "../../room/infrastructure/YGOProMessageRepository";
@@ -158,7 +158,7 @@ export function createMatchmakingRoom(input: CreateMatchmakingRoomInput): Matchm
 	const syntheticPlayerInfo = new PlayerInfoMessage(Buffer.alloc(0), 0);
 
 	const room = YGOProRoom.create(
-		generateUniqueId(),
+		generateUnusedRoomId(),
 		command,
 		input.logger,
 		input.emitter,

--- a/src/ygopro/room/application/generateUnusedRoomId.test.ts
+++ b/src/ygopro/room/application/generateUnusedRoomId.test.ts
@@ -1,0 +1,54 @@
+import { generateUniqueId } from "src/utils/generateUniqueId";
+
+import { generateUnusedRoomId } from "./generateUnusedRoomId";
+import { YGOProRoom } from "../domain/YGOProRoom";
+import YGOProRoomList from "../infrastructure/YGOProRoomList";
+
+jest.mock("src/utils/generateUniqueId");
+
+const mockedGenerateUniqueId = generateUniqueId as jest.MockedFunction<typeof generateUniqueId>;
+
+const seedRoom = (id: number): void => {
+	// findById only compares room.id — a stub is all the list needs here.
+	YGOProRoomList.addRoom({ id } as unknown as YGOProRoom);
+};
+
+const clearRooms = (): void => {
+	const rooms = YGOProRoomList.getRooms();
+	while (rooms.length) {
+		YGOProRoomList.deleteRoom(rooms[0]);
+	}
+};
+
+describe("generateUnusedRoomId", () => {
+	beforeEach(() => {
+		mockedGenerateUniqueId.mockReset();
+		clearRooms();
+	});
+
+	it("returns the first generated id when no live room uses it", () => {
+		mockedGenerateUniqueId.mockReturnValueOnce(4321);
+
+		expect(generateUnusedRoomId()).toBe(4321);
+	});
+
+	it("retries past ids already used by live rooms (findById is first-match, so a duplicate id would shadow the older room)", () => {
+		seedRoom(1111);
+		seedRoom(2222);
+		mockedGenerateUniqueId
+			.mockReturnValueOnce(1111)
+			.mockReturnValueOnce(2222)
+			.mockReturnValueOnce(3333);
+
+		expect(generateUnusedRoomId()).toBe(3333);
+		expect(mockedGenerateUniqueId).toHaveBeenCalledTimes(3);
+	});
+
+	it("throws after the bounded number of attempts instead of looping forever", () => {
+		seedRoom(1111);
+		mockedGenerateUniqueId.mockReturnValue(1111);
+
+		expect(() => generateUnusedRoomId()).toThrow(/room id/i);
+		expect(mockedGenerateUniqueId.mock.calls.length).toBeLessThanOrEqual(100);
+	});
+});

--- a/src/ygopro/room/application/generateUnusedRoomId.ts
+++ b/src/ygopro/room/application/generateUnusedRoomId.ts
@@ -1,0 +1,30 @@
+import { generateUniqueId } from "src/utils/generateUniqueId";
+
+import YGOProRoomList from "../infrastructure/YGOProRoomList";
+
+/**
+ * Bounded, not exhaustive: the id space (1000-9999) is far larger than any
+ * realistic live-room count, so a run of collisions this long means the list
+ * is effectively saturated — failing loudly beats scanning the whole space.
+ */
+const MAX_ATTEMPTS = 100;
+
+/**
+ * A ygopro room id that no live room in YGOProRoomList currently uses.
+ *
+ * YGOProRoomList.findById is first-match, so two live rooms sharing an id
+ * would make every id-addressed path (watch joins, the windbot AIJOIN return
+ * trip, reconnection) resolve to whichever room was added first. Every ygopro
+ * room creation site must draw its id from here instead of calling
+ * generateUniqueId directly.
+ */
+export function generateUnusedRoomId(): number {
+	for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+		const id = generateUniqueId();
+		if (!YGOProRoomList.findById(id)) {
+			return id;
+		}
+	}
+
+	throw new Error(`No unused room id found after ${MAX_ATTEMPTS} attempts`);
+}

--- a/src/ygopro/room/application/join-strategies/WatchJoinStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/WatchJoinStrategy.test.ts
@@ -1,0 +1,197 @@
+import { EventEmitter } from "stream";
+
+import { ISocket } from "@shared/socket/domain/ISocket";
+
+import { JoinContext } from "./JoinStrategy";
+import { WatchJoinStrategy } from "./WatchJoinStrategy";
+import { isRecognizedToken } from "../../domain/RuleMappings";
+import { YGOProRoom } from "../../domain/YGOProRoom";
+import YGOProRoomList from "../../infrastructure/YGOProRoomList";
+
+// ---- helpers ----
+
+const makeLogger = () => ({
+	child: jest.fn().mockReturnThis(),
+	info: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn(),
+	debug: jest.fn(),
+});
+
+const makeMessageRepository = () => ({
+	errorMessage: jest.fn().mockReturnValue(Buffer.from("join-error")),
+});
+
+const makeSocket = (): jest.Mocked<ISocket> =>
+	({
+		id: "sock-watch",
+		send: jest.fn(),
+		close: jest.fn(),
+		destroy: jest.fn(),
+		remoteAddress: "127.0.0.1",
+		closed: false,
+	}) as unknown as jest.Mocked<ISocket>;
+
+const makeCtx = (rawPass: string, overrides: Partial<JoinContext> = {}): JoinContext => {
+	const [command, password = ""] = rawPass.split("#");
+	return {
+		rawPass,
+		command,
+		password,
+		playerInfo: { name: "Watcher", password: "", previousMessage: Buffer.alloc(0) },
+		socket: makeSocket(),
+		socketId: "sock-watch",
+		eventEmitter: new EventEmitter(),
+		messageRepository: makeMessageRepository(),
+		logger: makeLogger(),
+		message: { data: Buffer.alloc(48), previousMessage: Buffer.alloc(0) },
+		...overrides,
+	} as unknown as JoinContext;
+};
+
+const makeRoom = (id: number, rawPass: string): YGOProRoom => {
+	const room = YGOProRoom.create(
+		id,
+		rawPass,
+		makeLogger() as never,
+		new EventEmitter(),
+		{ name: "Host", password: "", previousMessage: Buffer.alloc(0) } as never,
+		"sock-host",
+		makeMessageRepository() as never,
+	);
+	YGOProRoomList.addRoom(room);
+	return room;
+};
+
+const clearRooms = (): void => {
+	const rooms = YGOProRoomList.getRooms();
+	while (rooms.length) {
+		YGOProRoomList.deleteRoom(rooms[0]);
+	}
+};
+
+// ---- tests ----
+
+describe("WatchJoinStrategy", () => {
+	let strategy: WatchJoinStrategy;
+	let emitSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		strategy = new WatchJoinStrategy();
+		emitSpy = jest.spyOn(YGOProRoom.prototype, "emit").mockImplementation(() => undefined);
+		clearRooms();
+	});
+
+	afterEach(() => {
+		emitSpy.mockRestore();
+		clearRooms();
+	});
+
+	describe("matches() — command shape", () => {
+		const accepted = ["w,123", "W,123", " w , 123 ", "w,1", "w,999999"];
+		it.each(accepted)("accepts %j", (rawPass) => {
+			expect(strategy.matches(makeCtx(rawPass))).toBe(true);
+		});
+
+		it("accepts the shape regardless of the password segment", () => {
+			expect(strategy.matches(makeCtx("w,123#secret"))).toBe(true);
+		});
+
+		const rejected = [
+			"w",
+			"w,",
+			"w,12a",
+			"w,12 3",
+			"tcg,w",
+			"w,123,extra",
+			"ww,123",
+			"tcg",
+			"TESTROOM",
+			"",
+			",123",
+		];
+		it.each(rejected)("rejects %j (falls through to the other strategies)", (rawPass) => {
+			expect(strategy.matches(makeCtx(rawPass))).toBe(false);
+		});
+	});
+
+	describe("handle() — room resolution and password gate", () => {
+		it("routes the joiner into the room found by id, marking the socket with watch intent scoped to that room", async () => {
+			const room = makeRoom(1234, "tcg");
+			const ctx = makeCtx("w,1234");
+
+			await strategy.handle(ctx);
+
+			expect(ctx.socket.watchForRoomId).toBe(1234);
+			expect(emitSpy).toHaveBeenCalledWith("JOIN", ctx.message, ctx.socket);
+			expect(emitSpy.mock.instances[0]).toBe(room);
+		});
+
+		it("routes into a mid-duel room the same way (spectating decided downstream by the state)", async () => {
+			const room = makeRoom(1234, "tcg");
+			room.rps();
+			const ctx = makeCtx("w,1234");
+
+			await strategy.handle(ctx);
+
+			expect(ctx.socket.watchForRoomId).toBe(1234);
+			expect(emitSpy).toHaveBeenCalledWith("JOIN", ctx.message, ctx.socket);
+		});
+
+		it("admits when the supplied password matches the room password exactly", async () => {
+			makeRoom(1234, "tcg#secret");
+			const ctx = makeCtx("w,1234#secret");
+
+			await strategy.handle(ctx);
+
+			expect(emitSpy).toHaveBeenCalled();
+			expect(ctx.socket.close).not.toHaveBeenCalled();
+		});
+
+		it("rejects an unknown room id with chat + JOINERROR + close, and NEVER creates a room", async () => {
+			const ctx = makeCtx("w,4321");
+
+			await strategy.handle(ctx);
+
+			expect(YGOProRoomList.getRooms()).toHaveLength(0);
+			expect(emitSpy).not.toHaveBeenCalled();
+			// Red chat first, then the JOINERROR frame, then a graceful close.
+			expect(ctx.socket.send).toHaveBeenCalledTimes(2);
+			expect(ctx.messageRepository.errorMessage).toHaveBeenCalled();
+			expect(ctx.socket.close).toHaveBeenCalled();
+			expect(ctx.socket.destroy).not.toHaveBeenCalled();
+		});
+
+		it("rejects a wrong password with chat + JOINERROR + close, leaving the room untouched", async () => {
+			const room = makeRoom(1234, "tcg#secret");
+			const ctx = makeCtx("w,1234#wrong");
+
+			await strategy.handle(ctx);
+
+			expect(emitSpy).not.toHaveBeenCalled();
+			expect(ctx.socket.watchForRoomId).toBeUndefined();
+			expect(ctx.socket.send).toHaveBeenCalledTimes(2);
+			expect(ctx.socket.close).toHaveBeenCalled();
+			expect(YGOProRoomList.getRooms()).toEqual([room]);
+		});
+
+		it("rejects a missing password for a passworded room", async () => {
+			makeRoom(1234, "tcg#secret");
+			const ctx = makeCtx("w,1234");
+
+			await strategy.handle(ctx);
+
+			expect(emitSpy).not.toHaveBeenCalled();
+			expect(ctx.socket.close).toHaveBeenCalled();
+		});
+	});
+});
+
+// "w" is a join command, not a rule token: it must never become recognizable
+// config (that would turn "w" into a pairing-join room name — see
+// docs/join-commands.md).
+describe("watch command token", () => {
+	it("is not a recognized rule token", () => {
+		expect(isRecognizedToken("w")).toBe(false);
+	});
+});

--- a/src/ygopro/room/application/join-strategies/WatchJoinStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/WatchJoinStrategy.ts
@@ -1,0 +1,91 @@
+import { ChatColor, ErrorMessageType, YGOProStocChat } from "ygopro-msg-encode";
+
+import { JoinContext, JoinStrategy } from "./JoinStrategy";
+import YGOProRoomList from "../../infrastructure/YGOProRoomList";
+
+/**
+ * WatchJoinStrategy — intentional spectating by room id: "w,<roomId>[#password]".
+ *
+ * The command segment must be exactly two comma-separated tokens: "w"
+ * (trimmed, case-insensitive) followed by an all-digit room id. Any other
+ * shape is NOT a watch join and falls through to the rest of the chain.
+ *
+ * Unlike every other join, a watch join NEVER creates a room: an unknown id
+ * or a password mismatch is an explicit reject (red chat + JOINERROR +
+ * close, the established idiom), not a silent new room. The room password
+ * must match exactly (empty matches empty).
+ *
+ * On success the socket is stamped with watchForRoomId BEFORE the JOIN emit,
+ * so the waiting state's admission offers no seat and the joiner lands in
+ * the stands; mid-duel states force their spectator branch for the stamped
+ * socket, skipping the by-name reconnect so a matching nickname never takes
+ * a seated player's place. The stamp is derived only from the server-parsed
+ * command and never bypasses the reservation gate, which runs first in every
+ * state's handleJoin.
+ */
+export class WatchJoinStrategy implements JoinStrategy {
+	matches(ctx: JoinContext): boolean {
+		return WatchJoinStrategy.parseRoomId(ctx.command) !== null;
+	}
+
+	async handle(ctx: JoinContext): Promise<void> {
+		const roomId = WatchJoinStrategy.parseRoomId(ctx.command);
+		if (roomId === null) {
+			// Unreachable behind matches(); the throw surfaces a mis-wired chain
+			// through the handler's generic JOINERROR path instead of hiding it.
+			throw new Error("WatchJoinStrategy.handle called for a non-watch command");
+		}
+
+		const room = YGOProRoomList.findById(roomId);
+		if (!room) {
+			this.reject(ctx, `There is no room with id ${roomId}.`);
+			return;
+		}
+
+		if (room.password !== ctx.password) {
+			this.reject(ctx, `Wrong password for room ${roomId}.`);
+			return;
+		}
+
+		ctx.socket.watchForRoomId = room.id;
+		room.emit("JOIN", ctx.message, ctx.socket);
+	}
+
+	/**
+	 * "w,<digits>" (tokens trimmed, "w" case-insensitive) → the room id;
+	 * anything else → null. The id token must be all digits AFTER trimming —
+	 * inner whitespace or any non-digit disqualifies the whole command.
+	 */
+	private static parseRoomId(command: string): number | null {
+		const tokens = command.split(",");
+		if (tokens.length !== 2) {
+			return null;
+		}
+
+		const [watchToken, idToken] = tokens.map((token) => token.trim());
+		if (watchToken.toLowerCase() !== "w") {
+			return null;
+		}
+
+		if (!/^\d+$/.test(idToken)) {
+			return null;
+		}
+
+		return Number(idToken);
+	}
+
+	/**
+	 * Red chat explaining why, the real JOINERROR, then a graceful close() so
+	 * both frames flush — the same sequence as YGOProRoom.rejectReservedJoin
+	 * and the waiting state's name-taken path.
+	 */
+	private reject(ctx: JoinContext, reason: string): void {
+		const chat = new YGOProStocChat().fromPartial({
+			player_type: ChatColor.RED,
+			msg: reason,
+		});
+		ctx.socket.send(Buffer.from(chat.toFullPayload()));
+		ctx.socket.send(ctx.messageRepository.errorMessage(ErrorMessageType.JOINERROR, 0));
+		ctx.socket.close();
+	}
+}

--- a/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.test.ts
+++ b/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.test.ts
@@ -16,6 +16,8 @@ jest.mock("../../../../web-socket-server/WebSocketSingleton", () => {
 
 import { Seat } from "@shared/room/admission/domain/Seat";
 
+import * as uniqueIdModule from "src/utils/generateUniqueId";
+
 import { MessageRepositoryMock } from "@test-support/mocks/MessageRepositoryMock";
 
 import { JoinContext } from "./JoinStrategy";
@@ -636,5 +638,41 @@ describe("WindBotJoinStrategy", () => {
 				expect(capturedIsFinalizing!()).toBe(true);
 			});
 		});
+	});
+});
+
+describe("WindBotJoinStrategy — room id uniqueness", () => {
+	let waitingSpy: jest.SpyInstance;
+	let emitSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		waitingSpy = jest.spyOn(YGOProRoom.prototype, "waiting").mockImplementation(() => undefined);
+		emitSpy = jest.spyOn(YGOProRoom.prototype, "emit").mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		waitingSpy.mockRestore();
+		emitSpy.mockRestore();
+		jest.restoreAllMocks();
+		const rooms = YGOProRoomList.getRooms();
+		while (rooms.length) {
+			YGOProRoomList.deleteRoom(rooms[0]);
+		}
+	});
+
+	// findById is first-match: an AI room reusing a live room's id would make
+	// the bot's AIJOIN return trip land in the wrong room.
+	it("skips an id already used by a live room", async () => {
+		YGOProRoomList.addRoom({ id: 7777 } as never);
+		jest
+			.spyOn(uniqueIdModule, "generateUniqueId")
+			.mockReturnValueOnce(7777)
+			.mockReturnValueOnce(8888);
+
+		const strategy = new WindBotJoinStrategy(makeModule());
+		await strategy.handle(makeCtx("AI"));
+
+		const aiRoom = YGOProRoomList.getRooms().find((room) => room.id !== 7777);
+		expect(aiRoom?.id).toBe(8888);
 	});
 });

--- a/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.ts
+++ b/src/ygopro/room/application/join-strategies/WindBotJoinStrategy.ts
@@ -1,4 +1,4 @@
-import { generateUniqueId } from "src/utils/generateUniqueId";
+import { generateUnusedRoomId } from "../generateUnusedRoomId";
 
 import { ErrorMessageType } from "ygopro-msg-encode";
 
@@ -64,7 +64,7 @@ export class WindBotJoinStrategy implements JoinStrategy {
 
 		// Create the room through the SAME path as the default flow
 		const room = YGOProRoom.create(
-			generateUniqueId(),
+			generateUnusedRoomId(),
 			ctx.rawPass,
 			ctx.logger,
 			ctx.eventEmitter,

--- a/src/ygopro/room/application/join-strategies/composeJoinStrategies.test.ts
+++ b/src/ygopro/room/application/join-strategies/composeJoinStrategies.test.ts
@@ -1,8 +1,11 @@
 import { composeJoinStrategies } from "./composeJoinStrategies";
 import { AIJoinTokenStrategy } from "./AIJoinTokenStrategy";
 import { WindBotJoinStrategy } from "./WindBotJoinStrategy";
+import { WatchJoinStrategy } from "./WatchJoinStrategy";
 import { TicketJoinStrategy } from "./TicketJoinStrategy";
 import { DefaultJoinStrategy } from "./DefaultJoinStrategy";
+import { JoinStrategyRegistry } from "./JoinStrategyRegistry";
+import { JoinContext } from "./JoinStrategy";
 import { WindbotModule } from "../../../windbot/application/WindbotModule";
 import { WindbotTokenStore } from "../../../windbot/domain/WindbotTokenStore";
 
@@ -19,21 +22,72 @@ const makeModule = (): WindbotModule =>
 	});
 
 describe("composeJoinStrategies", () => {
-	it("returns the base chain [Ticket, Default] when windbot is absent", () => {
+	it("returns the base chain [Watch, Ticket, Default] when windbot is absent", () => {
 		const strategies = composeJoinStrategies();
 
-		expect(strategies).toHaveLength(2);
-		expect(strategies[0]).toBeInstanceOf(TicketJoinStrategy);
-		expect(strategies[1]).toBeInstanceOf(DefaultJoinStrategy);
+		expect(strategies).toHaveLength(3);
+		expect(strategies[0]).toBeInstanceOf(WatchJoinStrategy);
+		expect(strategies[1]).toBeInstanceOf(TicketJoinStrategy);
+		expect(strategies[2]).toBeInstanceOf(DefaultJoinStrategy);
 	});
 
 	it("prepends [AIJoinToken, WindBot] before the base chain when windbot is present", () => {
 		const strategies = composeJoinStrategies(makeModule());
 
-		expect(strategies).toHaveLength(4);
+		expect(strategies).toHaveLength(5);
 		expect(strategies[0]).toBeInstanceOf(AIJoinTokenStrategy);
 		expect(strategies[1]).toBeInstanceOf(WindBotJoinStrategy);
-		expect(strategies[2]).toBeInstanceOf(TicketJoinStrategy);
-		expect(strategies[3]).toBeInstanceOf(DefaultJoinStrategy);
+		expect(strategies[2]).toBeInstanceOf(WatchJoinStrategy);
+		expect(strategies[3]).toBeInstanceOf(TicketJoinStrategy);
+		expect(strategies[4]).toBeInstanceOf(DefaultJoinStrategy);
+	});
+});
+
+describe("composeJoinStrategies — resolution order", () => {
+	const makeCtx = (overrides: Partial<JoinContext>): JoinContext =>
+		({
+			rawPass: "TESTROOM",
+			command: "TESTROOM",
+			password: "",
+			socket: { id: "sock-1" },
+			...overrides,
+		}) as unknown as JoinContext;
+
+	// TicketJoinStrategy matches on socket auth, not command shape: if it
+	// preceded WatchJoinStrategy, a ticketed socket sending "w,1234" would
+	// fall into findOrCreateRoom and mint a junk room literally named
+	// "w,1234" instead of watching room 1234.
+	it("resolves a ticketed socket sending a watch command to WatchJoinStrategy, not TicketJoinStrategy", () => {
+		const registry = JoinStrategyRegistry.createForTests(composeJoinStrategies(makeModule()));
+		const ctx = makeCtx({
+			rawPass: "w,1234",
+			command: "w,1234",
+			socket: { id: "sock-1", resolvedUserId: "user-abc" } as never,
+		});
+
+		expect(registry.resolve(ctx)).toBeInstanceOf(WatchJoinStrategy);
+	});
+
+	it("still resolves a ticketed non-watch join to TicketJoinStrategy (normal joins unaffected)", () => {
+		const registry = JoinStrategyRegistry.createForTests(composeJoinStrategies(makeModule()));
+		const ctx = makeCtx({
+			socket: { id: "sock-1", resolvedUserId: "user-abc" } as never,
+		});
+
+		expect(registry.resolve(ctx)).toBeInstanceOf(TicketJoinStrategy);
+	});
+
+	it("still resolves an anonymous pairing-style join to DefaultJoinStrategy (normal joins unaffected)", () => {
+		const registry = JoinStrategyRegistry.createForTests(composeJoinStrategies(makeModule()));
+		const ctx = makeCtx({ rawPass: "tcg", command: "tcg" });
+
+		expect(registry.resolve(ctx)).toBeInstanceOf(DefaultJoinStrategy);
+	});
+
+	it("still resolves a name#password join to DefaultJoinStrategy (normal joins unaffected)", () => {
+		const registry = JoinStrategyRegistry.createForTests(composeJoinStrategies(makeModule()));
+		const ctx = makeCtx({ rawPass: "MYROOM#secret", command: "MYROOM", password: "secret" });
+
+		expect(registry.resolve(ctx)).toBeInstanceOf(DefaultJoinStrategy);
 	});
 });

--- a/src/ygopro/room/application/join-strategies/composeJoinStrategies.ts
+++ b/src/ygopro/room/application/join-strategies/composeJoinStrategies.ts
@@ -2,13 +2,19 @@ import { WindbotModule } from "../../../windbot/application/WindbotModule";
 import { JoinStrategy } from "./JoinStrategy";
 import { AIJoinTokenStrategy } from "./AIJoinTokenStrategy";
 import { WindBotJoinStrategy } from "./WindBotJoinStrategy";
+import { WatchJoinStrategy } from "./WatchJoinStrategy";
 import { TicketJoinStrategy } from "./TicketJoinStrategy";
 import { DefaultJoinStrategy } from "./DefaultJoinStrategy";
 
 // Join-routing policy: this context owns the strategy priority order; the
 // composition root only decides whether windbot is available.
+//
+// WatchJoinStrategy must precede TicketJoinStrategy: the ticket strategy
+// matches on socket auth alone, not command shape, so a ticketed socket
+// sending "w,<id>" would otherwise reach findOrCreateRoom and mint a junk
+// room literally named "w,<id>" instead of watching room <id>.
 export function composeJoinStrategies(windbot?: WindbotModule): JoinStrategy[] {
-	const baseChain = [new TicketJoinStrategy(), new DefaultJoinStrategy()];
+	const baseChain = [new WatchJoinStrategy(), new TicketJoinStrategy(), new DefaultJoinStrategy()];
 
 	if (!windbot) {
 		return baseChain;

--- a/src/ygopro/room/application/join-strategies/findOrCreateRoom.test.ts
+++ b/src/ygopro/room/application/join-strategies/findOrCreateRoom.test.ts
@@ -1,5 +1,7 @@
 import { EventEmitter } from "stream";
 
+import * as uniqueIdModule from "src/utils/generateUniqueId";
+
 import { MessageRepositoryMock } from "@test-support/mocks/MessageRepositoryMock";
 
 import { JoinContext } from "./JoinStrategy";
@@ -704,5 +706,49 @@ describe("findOrCreateRoom", () => {
 				expect(secondAuthed).toBe(authedRoom);
 			});
 		});
+	});
+});
+
+describe("findOrCreateRoom — room id uniqueness", () => {
+	let waitingSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		waitingSpy = jest.spyOn(YGOProRoom.prototype, "waiting").mockImplementation(() => undefined);
+		const rooms = YGOProRoomList.getRooms();
+		while (rooms.length) {
+			YGOProRoomList.deleteRoom(rooms[0]);
+		}
+	});
+
+	afterEach(() => {
+		waitingSpy.mockRestore();
+		jest.restoreAllMocks();
+	});
+
+	// findById is first-match: a created room reusing a live room's id would be
+	// unreachable by every id-addressed path (watch joins, AIJOIN return trip).
+	it("skips an id already used by a live room when creating", () => {
+		const occupied = YGOProRoom.create(
+			1234,
+			"OCCUPIED",
+			makeLogger() as never,
+			new EventEmitter(),
+			{ name: "P", password: "", previousMessage: Buffer.alloc(0) } as never,
+			"sock-orig",
+			makeMessageRepository() as never,
+		);
+		YGOProRoomList.addRoom(occupied);
+
+		jest
+			.spyOn(uniqueIdModule, "generateUniqueId")
+			.mockReturnValueOnce(1234)
+			.mockReturnValueOnce(5678);
+
+		const result = findOrCreateRoom(makeCtx({ rawPass: "NEWROOM", command: "NEWROOM" }), {
+			rankedOverride: undefined,
+		});
+
+		expect(result.id).toBe(5678);
+		expect(YGOProRoomList.findById(1234)).toBe(occupied);
 	});
 });

--- a/src/ygopro/room/application/join-strategies/findOrCreateRoom.ts
+++ b/src/ygopro/room/application/join-strategies/findOrCreateRoom.ts
@@ -1,4 +1,4 @@
-import { generateUniqueId } from "src/utils/generateUniqueId";
+import { generateUnusedRoomId } from "../generateUnusedRoomId";
 
 import { findReconnectingPlayer } from "@shared/room/domain/findReconnectingPlayer";
 
@@ -104,7 +104,7 @@ function createRoom(
 	path: "pairing" | "non-pairing",
 ): YGOProRoom {
 	const room = YGOProRoom.create(
-		generateUniqueId(),
+		generateUnusedRoomId(),
 		ctx.rawPass,
 		ctx.logger,
 		ctx.eventEmitter,

--- a/src/ygopro/room/domain/YGOProRoom.ts
+++ b/src/ygopro/room/domain/YGOProRoom.ts
@@ -483,14 +483,20 @@ export class YGOProRoom extends YgoRoom {
 	}
 
 	/**
-	 * Reservation gate for the JOIN door, evaluated in EVERY room state (a
-	 * reserved ranked duel is not even watchable by a third party). The join
-	 * string alone is deliberately not enough to enter a reserved room: it
-	 * travels through client config files and process lists, so entry demands
-	 * a ticket-resolved identity stamped in the reservation set. Internal (bot)
+	 * Reservation gate for the JOIN door, evaluated in EVERY room state. A
+	 * reserved room rejects third parties from SEATS, but admits watch-stamped
+	 * spectators: seat security is independent from watchability. The join
+	 * string alone is deliberately not enough to take a seat in a reserved
+	 * room: it travels through client config files and process lists, so a
+	 * seat demands a ticket-resolved identity stamped in the reservation set.
+	 * A watch-stamped socket ("w,<roomId>") can only ever spectate — the
+	 * waiting door offers it no seat and the mid-duel states force its
+	 * spectator branch — and spectators see only the opponent view (no hands),
+	 * so admitting it grants the stands and nothing more. Internal (bot)
 	 * sockets are pre-authorized by their consumed room-bound join token — a
-	 * bot carries no user identity to compare. Rooms without reservations
-	 * admit everyone, exactly as before.
+	 * bot carries no user identity to compare. Everything else (non-watch,
+	 * non-reserved, non-bot) is still rejected outright. Rooms without
+	 * reservations admit everyone, exactly as before.
 	 */
 	reservationAdmits(socket: ISocket): boolean {
 		if (!this.reservedUserIds || this.reservedUserIds.length === 0) {
@@ -499,22 +505,54 @@ export class YGOProRoom extends YgoRoom {
 		if (socket.internalForRoomId === this.id) {
 			return true;
 		}
+		// A watch stamp is spectate-only capability, never seat capability:
+		// seat-taking paths (spectator -> player promotion) must consult
+		// reservationPermitsSeat instead of this gate.
+		if (socket.watchForRoomId === this.id) {
+			return true;
+		}
 
 		if (!socket.resolvedUserId || !this.reservedUserIds.includes(socket.resolvedUserId)) {
 			return false;
 		}
 
-		// One seat per reserved identity: a reserved user whose seat is still
-		// held by a live socket cannot enter again, or one player could fill
-		// both seats with two connections and squeeze the opponent out. Seat
-		// liveness reads socket.closed — the same signal the reconnect paths
-		// use — so a crashed player (their seat's socket already closed) can
-		// still come back in through this gate.
-		const holdsLiveSeat = this._players.some(
-			(player) => player.id === socket.resolvedUserId && !player.socket.closed,
-		);
+		return !this.holdsLiveSeat(socket.resolvedUserId);
+	}
 
-		return !holdsLiveSeat;
+	/**
+	 * Seat-taking form of the reservation check, for paths that hand an
+	 * ALREADY-ADMITTED client a seat (spectator -> player promotion via
+	 * TO_DUEL). Deliberately distinct from reservationAdmits: the JOIN gate
+	 * also admits watch-stamped sockets, and a watch stamp grants the stands
+	 * only — reusing it here would let a non-reserved watcher escalate into a
+	 * reserved seat during the pre-duel window. Only a ticket-resolved
+	 * identity in the reservation set may sit, and — same one-seat-per-identity
+	 * rule as the JOIN gate — not while that identity already holds a live
+	 * seat: a seated player could otherwise re-enter through the watch door on
+	 * a second connection and TO_DUEL into the opponent's still-free seat.
+	 * Rooms without reservations permit everyone, exactly as before.
+	 */
+	reservationPermitsSeat(socket: ISocket): boolean {
+		if (!this.reservedUserIds || this.reservedUserIds.length === 0) {
+			return true;
+		}
+		if (!socket.resolvedUserId || !this.reservedUserIds.includes(socket.resolvedUserId)) {
+			return false;
+		}
+
+		return !this.holdsLiveSeat(socket.resolvedUserId);
+	}
+
+	/**
+	 * One seat per reserved identity, shared by BOTH reservation gates (JOIN
+	 * admission and seat-taking promotion): a user whose seat is still held by
+	 * a live socket may not take another, or one player could fill both seats
+	 * with two connections and squeeze the opponent out. Seat liveness reads
+	 * socket.closed — the same signal the reconnect paths use — so a crashed
+	 * player (their seat's socket already closed) can still come back in.
+	 */
+	private holdsLiveSeat(userId: string): boolean {
+		return this._players.some((player) => player.id === userId && !player.socket.closed);
 	}
 
 	/**

--- a/src/ygopro/room/domain/YGOProRoom.ts
+++ b/src/ygopro/room/domain/YGOProRoom.ts
@@ -440,6 +440,15 @@ export class YGOProRoom extends YgoRoom {
 		return {
 			league: this.league,
 			freeSeat: () => {
+				// A watch joiner ("w,<roomId>") asked for the stands: offering it no
+				// seat routes the unchanged admission policy to spectator. Only the
+				// seat offer is affected — ranked-guest rejection, league checks and
+				// the upstream reservation gate all still apply. The stamp is set
+				// server-side from the parsed command and scoped to this room's id.
+				if (socket.watchForRoomId === this.id) {
+					return null;
+				}
+
 				const place = this.calculatePlaceUnsafe();
 				return place ? new Seat(place.position, place.team) : null;
 			},

--- a/src/ygopro/room/domain/YGOProRoomReservations.test.ts
+++ b/src/ygopro/room/domain/YGOProRoomReservations.test.ts
@@ -154,3 +154,106 @@ describe("YGOProRoom.reservationAdmits — one seat per reserved identity", () =
 		expect(room.reservationAdmits(makeSocket({ resolvedUserId: "u-a" }))).toBe(true);
 	});
 });
+
+describe("YGOProRoom.reservationAdmits — watch spectators", () => {
+	it("admits a watch-stamped socket for THIS room (spectate-only entry)", () => {
+		const room = YGOProRoomMother.create({ id: 42 });
+		room.reservedUserIds = ["u-a", "u-b"];
+
+		expect(room.reservationAdmits(makeSocket({ watchForRoomId: 42 }))).toBe(true);
+	});
+
+	it("rejects a socket whose watch stamp names a DIFFERENT room", () => {
+		const room = YGOProRoomMother.create({ id: 42 });
+		room.reservedUserIds = ["u-a", "u-b"];
+
+		expect(room.reservationAdmits(makeSocket({ watchForRoomId: 43 }))).toBe(false);
+	});
+});
+
+describe("YGOProRoom.reservationPermitsSeat — seat-taking reservation check", () => {
+	// Distinct from reservationAdmits on purpose: the JOIN gate also lets
+	// watch-stamped sockets through, but a watch stamp is spectate-only
+	// capability. Promotion paths (spectator -> player) must consult THIS
+	// check, or a non-reserved watcher could escalate into a reserved seat.
+	it("permits anyone in a room without reservations (ordinary rooms unchanged)", () => {
+		const room = YGOProRoomMother.create();
+
+		expect(room.reservationPermitsSeat(makeSocket())).toBe(true);
+		expect(room.reservationPermitsSeat(makeSocket({ resolvedUserId: "u-any" }))).toBe(true);
+	});
+
+	it("permits a reserved identity", () => {
+		const room = YGOProRoomMother.create();
+		room.reservedUserIds = ["u-a", "u-b"];
+
+		expect(room.reservationPermitsSeat(makeSocket({ resolvedUserId: "u-a" }))).toBe(true);
+	});
+
+	it("denies a watch-stamped socket carrying no reserved identity", () => {
+		const room = YGOProRoomMother.create({ id: 42 });
+		room.reservedUserIds = ["u-a", "u-b"];
+
+		expect(room.reservationPermitsSeat(makeSocket({ watchForRoomId: 42 }))).toBe(false);
+	});
+
+	it("denies a non-reserved authenticated identity", () => {
+		const room = YGOProRoomMother.create();
+		room.reservedUserIds = ["u-a", "u-b"];
+
+		expect(room.reservationPermitsSeat(makeSocket({ resolvedUserId: "u-intruder" }))).toBe(false);
+	});
+
+	it("denies an anonymous socket", () => {
+		const room = YGOProRoomMother.create();
+		room.reservedUserIds = ["u-a", "u-b"];
+
+		expect(room.reservationPermitsSeat(makeSocket())).toBe(false);
+	});
+});
+
+describe("YGOProRoom.reservationPermitsSeat — one seat per reserved identity", () => {
+	// The promotion door must enforce the same liveness guard as the JOIN
+	// door: a reserved user already holding a live seat could otherwise open a
+	// second connection through the watch door and TO_DUEL into the
+	// opponent's still-free seat.
+	const seatPlayer = (
+		room: ReturnType<typeof YGOProRoomMother.create>,
+		userId: string,
+		closed = false,
+	): void => {
+		room.players.push({ id: userId, socket: { closed } } as never);
+	};
+
+	it("denies a reserved user whose seat is still held by a live socket (double-seat via watch + TO_DUEL)", () => {
+		const room = YGOProRoomMother.create();
+		room.reservedUserIds = ["u-a", "u-b"];
+		seatPlayer(room, "u-a");
+
+		expect(room.reservationPermitsSeat(makeSocket({ resolvedUserId: "u-a" }))).toBe(false);
+	});
+
+	it("still permits the opponent's first seat while the first player holds their own", () => {
+		const room = YGOProRoomMother.create();
+		room.reservedUserIds = ["u-a", "u-b"];
+		seatPlayer(room, "u-a");
+
+		expect(room.reservationPermitsSeat(makeSocket({ resolvedUserId: "u-b" }))).toBe(true);
+	});
+
+	it("permits the reserved user again once their seat's socket is closed (crash recovery)", () => {
+		const room = YGOProRoomMother.create();
+		room.reservedUserIds = ["u-a", "u-b"];
+		seatPlayer(room, "u-a", true);
+
+		expect(room.reservationPermitsSeat(makeSocket({ resolvedUserId: "u-a" }))).toBe(true);
+	});
+
+	it("ignores guest seats (null id) when checking the double-seat guard", () => {
+		const room = YGOProRoomMother.create();
+		room.reservedUserIds = ["u-a", "u-b"];
+		room.players.push({ id: null, socket: { closed: false } } as never);
+
+		expect(room.reservationPermitsSeat(makeSocket({ resolvedUserId: "u-a" }))).toBe(true);
+	});
+});

--- a/src/ygopro/room/domain/YGOProRoomWatchAdmission.test.ts
+++ b/src/ygopro/room/domain/YGOProRoomWatchAdmission.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Watch-intent seam at the WAITING door.
+ *
+ * A watch joiner ("w,<roomId>") is marked server-side on its socket
+ * (watchForRoomId) by the watch strategy. The room's admission target simply
+ * offers that joiner no seat, so the unchanged admission policy
+ * (RoomAdmission) routes it to the stands — every other rule (ranked-guest
+ * rejection, league segregation, reservation gate upstream) still applies.
+ */
+
+import { RoomAdmission } from "@shared/room/admission/domain/RoomAdmission";
+import { ISocket } from "@shared/socket/domain/ISocket";
+
+import { YGOProRoomMother } from "@test-support/mothers/room/YGOProRoomMother";
+
+jest.mock("@ygopro/SimpleRoomMessageEmitter");
+
+const makeSocket = (overrides: Partial<ISocket> = {}): ISocket =>
+	({
+		id: `s-${Math.random()}`,
+		send: jest.fn(),
+		close: jest.fn(),
+		destroy: jest.fn(),
+		onMessage: jest.fn(),
+		removeAllListeners: jest.fn(),
+		remoteAddress: "127.0.0.1",
+		closed: false,
+		...overrides,
+	}) as unknown as ISocket;
+
+const playerInfo = { name: "Watcher", password: "" } as never;
+
+describe("YGOProRoom.admissionTarget — watch intent", () => {
+	it("offers no seat to a socket watching THIS room, even with seats free", () => {
+		const room = YGOProRoomMother.create({ id: 42 });
+		const target = room.admissionTarget(makeSocket({ watchForRoomId: 42 }), playerInfo);
+
+		expect(room.hasFreeSeat()).toBe(true);
+		expect(target.freeSeat()).toBeNull();
+	});
+
+	it("still offers a seat to a socket whose watch intent names a DIFFERENT room", () => {
+		const room = YGOProRoomMother.create({ id: 42 });
+		const target = room.admissionTarget(makeSocket({ watchForRoomId: 43 }), playerInfo);
+
+		expect(target.freeSeat()).not.toBeNull();
+	});
+
+	it("still offers a seat to an unmarked socket (normal joins unaffected)", () => {
+		const room = YGOProRoomMother.create({ id: 42 });
+		const target = room.admissionTarget(makeSocket(), playerInfo);
+
+		expect(target.freeSeat()).not.toBeNull();
+	});
+
+	it("lands a watch joiner of a waiting casual room in the stands: 0 players, 1 spectator", async () => {
+		const room = YGOProRoomMother.create({ id: 42 });
+		const socket = makeSocket({ watchForRoomId: 42 });
+		const target = room.admissionTarget(socket, playerInfo);
+		const credential = { kind: "guest" as const, name: "Watcher" };
+
+		const decision = new RoomAdmission().decide(credential, {
+			league: target.league,
+			freeSeat: target.freeSeat(),
+		});
+		expect(decision.kind).toBe("spectator");
+
+		await target.admitSpectator(credential);
+
+		expect(room.playersCount).toBe(0);
+		expect(room.spectators).toHaveLength(1);
+	});
+});

--- a/src/ygopro/room/domain/YGOProRoomWatchAdmission.test.ts
+++ b/src/ygopro/room/domain/YGOProRoomWatchAdmission.test.ts
@@ -71,3 +71,36 @@ describe("YGOProRoom.admissionTarget — watch intent", () => {
 		expect(room.spectators).toHaveLength(1);
 	});
 });
+
+describe("YGOProRoom.admissionTarget — watch intent in a RESERVED room", () => {
+	it("lands a watch joiner of a reserved waiting room in the stands, reserved seats intact", async () => {
+		const room = YGOProRoomMother.create({ id: 42 });
+		room.reservedUserIds = ["u-a", "u-b"];
+		const socket = makeSocket({ watchForRoomId: 42 });
+
+		expect(room.reservationAdmits(socket)).toBe(true);
+
+		const target = room.admissionTarget(socket, playerInfo);
+		const credential = { kind: "guest" as const, name: "Watcher" };
+		const decision = new RoomAdmission().decide(credential, {
+			league: target.league,
+			freeSeat: target.freeSeat(),
+		});
+		expect(decision.kind).toBe("spectator");
+
+		await target.admitSpectator(credential);
+
+		expect(room.playersCount).toBe(0);
+		expect(room.spectators).toHaveLength(1);
+		expect(room.reservedUserIds).toEqual(["u-a", "u-b"]);
+	});
+
+	it("still offers the seat path to a reserved matched player (non-watch socket)", () => {
+		const room = YGOProRoomMother.create({ id: 42 });
+		room.reservedUserIds = ["u-a", "u-b"];
+		const socket = makeSocket({ resolvedUserId: "u-a" });
+
+		expect(room.reservationAdmits(socket)).toBe(true);
+		expect(room.admissionTarget(socket, playerInfo).freeSeat()).not.toBeNull();
+	});
+});

--- a/src/ygopro/room/domain/states/YGOProChoosingOrderState.ts
+++ b/src/ygopro/room/domain/states/YGOProChoosingOrderState.ts
@@ -8,7 +8,7 @@ import { Logger } from "../../../../shared/logger/domain/Logger";
 import { ISocket } from "../../../../shared/socket/domain/ISocket";
 import { YGOProClient } from "../../../client/domain/YGOProClient";
 import { YGOProRoom } from "../YGOProRoom";
-import { findReconnectingPlayer } from "@shared/room/domain/findReconnectingPlayer";
+import { findMidDuelReconnectingPlayer } from "@shared/room/domain/findMidDuelReconnectingPlayer";
 import { TurnPlayerResult, YGOProCtosTpResult, YGOProStocDuelStart } from "ygopro-msg-encode";
 import { ReconnectionTokenIssuer } from "@shared/room/application/reconnect/ReconnectionTokenIssuer";
 import { ReconnectionAckMessage } from "@shared/messages/server-to-client/ReconnectionAckMessage";
@@ -92,10 +92,13 @@ export class YGOProChoosingOrderState extends YGOProRoomState {
 		}
 
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
-		const playerAlreadyInRoom = findReconnectingPlayer({
+		// The shared seam honors the watch stamp: a "w,<roomId>" joiner asked to
+		// spectate, never to take a seat, so a name match must not reconnect it.
+		const playerAlreadyInRoom = findMidDuelReconnectingPlayer({
 			players: room.players,
 			name: playerInfoMessage.name,
-			remoteAddress: socket.remoteAddress,
+			socket,
+			roomId: room.id,
 			ranked: room.ranked,
 		});
 

--- a/src/ygopro/room/domain/states/YGOProChoosingOrderState.ts
+++ b/src/ygopro/room/domain/states/YGOProChoosingOrderState.ts
@@ -82,10 +82,11 @@ export class YGOProChoosingOrderState extends YGOProRoomState {
 	private handleJoin(message: ClientMessage, room: YGOProRoom, socket: ISocket): void {
 		this.logger.info("handleJoin");
 
-		// Reservation gate: past WAITING, a reserved room is not even watchable
-		// by a third party — the join string alone never buys a spectator seat.
-		// A reserved player's own reconnect passes this check (its ticket-resolved
-		// identity is in the reservation set) and proceeds below unchanged.
+		// Reservation gate: past WAITING, a reserved room keeps its seats closed
+		// to third parties — the join string alone never buys a seat. The gate
+		// admits watch-stamped sockets (spectate-only by construction) alongside
+		// a reserved player's own reconnect (its ticket-resolved identity is in
+		// the reservation set); both proceed below unchanged.
 		if (!room.reservationAdmits(socket)) {
 			room.rejectReservedJoin(socket);
 			return;

--- a/src/ygopro/room/domain/states/YGOProDuelingState.ts
+++ b/src/ygopro/room/domain/states/YGOProDuelingState.ts
@@ -241,10 +241,11 @@ export class YGOProDuelingState extends YGOProRoomState {
 	private handleJoin(message: ClientMessage, room: YGOProRoom, socket: ISocket): void {
 		this.logger.info("handleJoin");
 
-		// Reservation gate: past WAITING, a reserved room is not even watchable
-		// by a third party — the join string alone never buys a spectator seat.
-		// A reserved player's own reconnect passes this check (its ticket-resolved
-		// identity is in the reservation set) and proceeds below unchanged.
+		// Reservation gate: past WAITING, a reserved room keeps its seats closed
+		// to third parties — the join string alone never buys a seat. The gate
+		// admits watch-stamped sockets (spectate-only by construction) alongside
+		// a reserved player's own reconnect (its ticket-resolved identity is in
+		// the reservation set); both proceed below unchanged.
 		if (!room.reservationAdmits(socket)) {
 			room.rejectReservedJoin(socket);
 			return;

--- a/src/ygopro/room/domain/states/YGOProDuelingState.ts
+++ b/src/ygopro/room/domain/states/YGOProDuelingState.ts
@@ -24,7 +24,7 @@ import { YGOProClient } from "../../../client/domain/YGOProClient";
 import { DuelRecord } from "../DuelRecord";
 import { FinalizeYGOProRoom } from "../../application/FinalizeYGOProRoom";
 import { YGOProRoom } from "../YGOProRoom";
-import { findReconnectingPlayer } from "@shared/room/domain/findReconnectingPlayer";
+import { findMidDuelReconnectingPlayer } from "@shared/room/domain/findMidDuelReconnectingPlayer";
 import { getMessageIdentifier } from "../../../utils/response-time-utils";
 
 import {
@@ -251,10 +251,13 @@ export class YGOProDuelingState extends YGOProRoomState {
 		}
 
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
-		const playerAlreadyInRoom = findReconnectingPlayer({
+		// The shared seam honors the watch stamp: a "w,<roomId>" joiner asked to
+		// spectate, never to take a seat, so a name match must not reconnect it.
+		const playerAlreadyInRoom = findMidDuelReconnectingPlayer({
 			players: room.players,
 			name: playerInfoMessage.name,
-			remoteAddress: socket.remoteAddress,
+			socket,
+			roomId: room.id,
 			ranked: room.ranked,
 		});
 

--- a/src/ygopro/room/domain/states/YGOProReservedRoomJoin.test.ts
+++ b/src/ygopro/room/domain/states/YGOProReservedRoomJoin.test.ts
@@ -75,11 +75,18 @@ const makeRoom = (overrides: Record<string, unknown> = {}): jest.Mocked<YGOProRo
 // A YGOProClient instance (passes `instanceof YGOProClient`) without running
 // the real constructor. A weak-auth seat with a matching name so
 // findReconnectingPlayer resolves it in a ranked room.
-const makeSeatedPlayer = (name = "Jaden"): YGOProClient => {
+const makeSeatedPlayer = (
+	name = "Jaden",
+	socket?: { closed: boolean; remoteAddress: string | undefined },
+): YGOProClient => {
 	const client = Object.create(YGOProClient.prototype) as Record<string, unknown>;
 	client._credential = null;
 	client.name = name;
 	client.sendMessageToClient = jest.fn();
+	client.clearReconnecting = jest.fn();
+	if (socket) {
+		client._socket = socket;
+	}
 	return client as unknown as YGOProClient;
 };
 
@@ -242,5 +249,121 @@ describe("YGOProSideDeckingState.handleJoin — reserved rooms", () => {
 		buildState(YGOProSideDeckingState).handleJoin(makeJoinMessage(), room, makeSocket());
 
 		expectSpectated(room);
+	});
+});
+
+// Watch joins ("w,<roomId>") reach these states carrying a server-side watch
+// stamp on the socket. The reservation gate still runs first and rejects a
+// watcher in a reserved room like any other third party; in an unreserved
+// room the stamp forces the spectator branch.
+describe("mid-duel states — watch-marked joiners", () => {
+	const buildDueling = (room: jest.Mocked<YGOProRoom>) => buildState(YGOProDuelingState, { room });
+
+	it("rejects a watch-marked third party when the reservation does not admit it", () => {
+		const room = makeRoom();
+		(room.reservationAdmits as jest.Mock).mockReturnValue(false);
+		const socket = makeSocket({ watchForRoomId: 99 });
+
+		buildDueling(room).handleJoin(makeJoinMessage(), room, socket);
+
+		expectRejected(room, socket);
+	});
+
+	it("spectates a watch-marked joiner in an unreserved dueling room (existing fallback path)", () => {
+		const room = makeRoom();
+		const socket = makeSocket({ watchForRoomId: 99 });
+
+		buildDueling(room).handleJoin(makeJoinMessage(), room, socket);
+
+		expectSpectated(room);
+	});
+
+	it("spectates a watch-marked joiner in an unreserved RPS room (existing fallback path)", () => {
+		const room = makeRoom();
+		const socket = makeSocket({ watchForRoomId: 99 });
+
+		buildState(YGOProRockPaperScissorState).handleJoin(makeJoinMessage(), room, socket);
+
+		expectSpectated(room);
+	});
+});
+
+// The watch stamp's contract in every mid-duel state: a "w,<roomId>" joiner
+// asked to spectate, never to take a seat. Even when its nickname matches a
+// reconnect-eligible player, the JOIN must land in the stands and the seated
+// player's connection must stay untouched. A stamp for a DIFFERENT room is
+// inert — never cleared, so a stale stamp must not leak across rooms.
+describe("mid-duel states — watch stamp never takes a seat", () => {
+	const ROOM_ID = 7;
+
+	const stateBuilders: ReadonlyArray<
+		[string, (room: jest.Mocked<YGOProRoom>) => JoinCapableState]
+	> = [
+		["YGOProDuelingState", (room) => buildState(YGOProDuelingState, { room })],
+		[
+			"YGOProRockPaperScissorState",
+			() => buildState(YGOProRockPaperScissorState, { handResult: [0, 0] }),
+		],
+		["YGOProChoosingOrderState", () => buildState(YGOProChoosingOrderState)],
+		["YGOProSideDeckingState", () => buildState(YGOProSideDeckingState)],
+	];
+
+	const expectSeatUntouched = (room: jest.Mocked<YGOProRoom>, victim: YGOProClient): void => {
+		expectSpectated(room);
+		expect(room.reconnect).not.toHaveBeenCalled();
+		expect(victim.sendMessageToClient).not.toHaveBeenCalled();
+	};
+
+	it.each(
+		stateBuilders,
+	)("%s: a watch-marked joiner matching a DISCONNECTED player in a casual room lands in the stands", (_name, build) => {
+		// Casual reconnect eligibility: same name, same remote address, socket
+		// already closed — the strongest legitimate-looking claim on the seat.
+		const victim = makeSeatedPlayer("Jaden", { closed: true, remoteAddress: "127.0.0.1" });
+		const room = makeRoom({ id: ROOM_ID, ranked: false, players: [victim] });
+		const socket = makeSocket({ watchForRoomId: ROOM_ID });
+
+		build(room).handleJoin(makeJoinMessage(), room, socket);
+
+		expectSeatUntouched(room, victim);
+	});
+
+	it.each(
+		stateBuilders,
+	)("%s: a watch-marked joiner matching a STILL-CONNECTED player in a ranked room lands in the stands", (_name, build) => {
+		// Ranked rooms (incl. external leagues) skip the address and liveness
+		// checks, so without the stamp this name match would take over the
+		// victim's live seat.
+		const victim = makeSeatedPlayer("Jaden", { closed: false, remoteAddress: "9.9.9.9" });
+		const room = makeRoom({ id: ROOM_ID, ranked: true, players: [victim] });
+		const socket = makeSocket({ watchForRoomId: ROOM_ID });
+
+		build(room).handleJoin(makeJoinMessage(), room, socket);
+
+		expectSeatUntouched(room, victim);
+	});
+
+	it.each(
+		stateBuilders,
+	)("%s: a genuine (non-watch) by-name reconnect still reaches the seat", (_name, build) => {
+		const victim = makeSeatedPlayer("Jaden");
+		const room = makeRoom({ id: ROOM_ID, ranked: true, players: [victim] });
+		const socket = makeSocket();
+
+		build(room).handleJoin(makeJoinMessage(), room, socket);
+
+		expect(room.reconnect).toHaveBeenCalledWith(victim, socket);
+		expect(room.createSpectatorUnsafe).not.toHaveBeenCalled();
+	});
+
+	it("a stale stamp for ANOTHER room does not suppress the reconnect", () => {
+		const victim = makeSeatedPlayer("Jaden");
+		const room = makeRoom({ id: ROOM_ID, ranked: true, players: [victim] });
+		const socket = makeSocket({ watchForRoomId: ROOM_ID + 1 });
+
+		buildState(YGOProDuelingState, { room }).handleJoin(makeJoinMessage(), room, socket);
+
+		expect(room.reconnect).toHaveBeenCalledWith(victim, socket);
+		expect(room.createSpectatorUnsafe).not.toHaveBeenCalled();
 	});
 });

--- a/src/ygopro/room/domain/states/YGOProReservedRoomJoin.test.ts
+++ b/src/ygopro/room/domain/states/YGOProReservedRoomJoin.test.ts
@@ -2,9 +2,10 @@
  * Seat reservation at the JOIN door of every non-waiting state.
  *
  * A matchmaking room's join string travels through client config and process
- * lists, so it must not be enough to enter the room once the duel is underway:
- * a third party is explicitly rejected — not seated, not spectator — while a
- * reserved player's own reconnect keeps working. States are exercised on
+ * lists, so it must not be enough to take a seat once the duel is underway:
+ * a non-watch third party is explicitly rejected — not seated, not spectator —
+ * while a reserved player's own reconnect keeps working and a watch-stamped
+ * socket ("w,<roomId>") is admitted to the stands only. States are exercised on
  * prototype instances (same approach as the express-reconnect tests) because
  * the dueling state's full constructor needs an OCGCore spin-up.
  */
@@ -253,9 +254,10 @@ describe("YGOProSideDeckingState.handleJoin — reserved rooms", () => {
 });
 
 // Watch joins ("w,<roomId>") reach these states carrying a server-side watch
-// stamp on the socket. The reservation gate still runs first and rejects a
-// watcher in a reserved room like any other third party; in an unreserved
-// room the stamp forces the spectator branch.
+// stamp on the socket. The reservation gate still runs first: a stamp for
+// THIS room is admitted (stands only), any other socket the reservation does
+// not admit is rejected. In an unreserved room the stamp forces the
+// spectator branch.
 describe("mid-duel states — watch-marked joiners", () => {
 	const buildDueling = (room: jest.Mocked<YGOProRoom>) => buildState(YGOProDuelingState, { room });
 
@@ -365,5 +367,63 @@ describe("mid-duel states — watch stamp never takes a seat", () => {
 
 		expect(room.reconnect).toHaveBeenCalledWith(victim, socket);
 		expect(room.createSpectatorUnsafe).not.toHaveBeenCalled();
+	});
+});
+
+// Reserved-room spectating through the REAL reservation gate: a watch stamp
+// for THIS room is spectate-only capability, so it passes the JOIN door and
+// lands in the stands, while every non-watch third party stays fully
+// rejected — no seat, no stands.
+describe("mid-duel states — watch spectating a RESERVED room (real gate)", () => {
+	const ROOM_ID = 7;
+
+	const makeReservedRoom = (): jest.Mocked<YGOProRoom> => {
+		const room = makeRoom({ id: ROOM_ID, reservedUserIds: ["u-a", "u-b"] });
+		room.reservationAdmits = YGOProRoom.prototype.reservationAdmits.bind(
+			room,
+		) as typeof room.reservationAdmits;
+		return room;
+	};
+
+	it("spectates a watch-stamped joiner in a reserved DUELING room without touching seats", () => {
+		const room = makeReservedRoom();
+		const socket = makeSocket({ watchForRoomId: ROOM_ID });
+
+		buildState(YGOProDuelingState, { room }).handleJoin(makeJoinMessage(), room, socket);
+
+		expectSpectated(room);
+		expect(room.reconnect).not.toHaveBeenCalled();
+	});
+
+	it("spectates a watch-stamped joiner in a reserved RPS room", () => {
+		const room = makeReservedRoom();
+		const socket = makeSocket({ watchForRoomId: ROOM_ID });
+
+		buildState(YGOProRockPaperScissorState, { handResult: [0, 0] }).handleJoin(
+			makeJoinMessage(),
+			room,
+			socket,
+		);
+
+		expectSpectated(room);
+		expect(room.reconnect).not.toHaveBeenCalled();
+	});
+
+	it("still fully rejects a ticketed non-reserved third party", () => {
+		const room = makeReservedRoom();
+		const socket = makeSocket({ resolvedUserId: "u-intruder" });
+
+		buildState(YGOProDuelingState, { room }).handleJoin(makeJoinMessage(), room, socket);
+
+		expectRejected(room, socket);
+	});
+
+	it("still fully rejects an anonymous guest third party", () => {
+		const room = makeReservedRoom();
+		const socket = makeSocket();
+
+		buildState(YGOProDuelingState, { room }).handleJoin(makeJoinMessage(), room, socket);
+
+		expectRejected(room, socket);
 	});
 });

--- a/src/ygopro/room/domain/states/YGOProRockPaperScissorState.ts
+++ b/src/ygopro/room/domain/states/YGOProRockPaperScissorState.ts
@@ -74,10 +74,11 @@ export class YGOProRockPaperScissorState extends YGOProRoomState {
 	private handleJoin(message: ClientMessage, room: YGOProRoom, socket: ISocket): void {
 		this.logger.info("handleJoin");
 
-		// Reservation gate: past WAITING, a reserved room is not even watchable
-		// by a third party — the join string alone never buys a spectator seat.
-		// A reserved player's own reconnect passes this check (its ticket-resolved
-		// identity is in the reservation set) and proceeds below unchanged.
+		// Reservation gate: past WAITING, a reserved room keeps its seats closed
+		// to third parties — the join string alone never buys a seat. The gate
+		// admits watch-stamped sockets (spectate-only by construction) alongside
+		// a reserved player's own reconnect (its ticket-resolved identity is in
+		// the reservation set); both proceed below unchanged.
 		if (!room.reservationAdmits(socket)) {
 			room.rejectReservedJoin(socket);
 			return;

--- a/src/ygopro/room/domain/states/YGOProRockPaperScissorState.ts
+++ b/src/ygopro/room/domain/states/YGOProRockPaperScissorState.ts
@@ -7,7 +7,7 @@ import { Logger } from "../../../../shared/logger/domain/Logger";
 import { ISocket } from "../../../../shared/socket/domain/ISocket";
 import { YGOProClient } from "../../../client/domain/YGOProClient";
 import { YGOProRoom } from "../YGOProRoom";
-import { findReconnectingPlayer } from "@shared/room/domain/findReconnectingPlayer";
+import { findMidDuelReconnectingPlayer } from "@shared/room/domain/findMidDuelReconnectingPlayer";
 import { YGOProCtosHandResult } from "ygopro-msg-encode";
 import { Team } from "@shared/room/Team";
 import { YGOProRoomState } from "../YGOProRoomState";
@@ -84,10 +84,13 @@ export class YGOProRockPaperScissorState extends YGOProRoomState {
 		}
 
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
-		const playerAlreadyInRoom = findReconnectingPlayer({
+		// The shared seam honors the watch stamp: a "w,<roomId>" joiner asked to
+		// spectate, never to take a seat, so a name match must not reconnect it.
+		const playerAlreadyInRoom = findMidDuelReconnectingPlayer({
 			players: room.players,
 			name: playerInfoMessage.name,
-			remoteAddress: socket.remoteAddress,
+			socket,
+			roomId: room.id,
 			ranked: room.ranked,
 		});
 

--- a/src/ygopro/room/domain/states/YGOProSideDeckingState.ts
+++ b/src/ygopro/room/domain/states/YGOProSideDeckingState.ts
@@ -193,10 +193,11 @@ export class YGOProSideDeckingState extends YGOProRoomState {
 	private handleJoin(message: ClientMessage, room: YGOProRoom, socket: ISocket): void {
 		this.logger.info("handleJoin");
 
-		// Reservation gate: past WAITING, a reserved room is not even watchable
-		// by a third party — the join string alone never buys a spectator seat.
-		// A reserved player's own reconnect passes this check (its ticket-resolved
-		// identity is in the reservation set) and proceeds below unchanged.
+		// Reservation gate: past WAITING, a reserved room keeps its seats closed
+		// to third parties — the join string alone never buys a seat. The gate
+		// admits watch-stamped sockets (spectate-only by construction) alongside
+		// a reserved player's own reconnect (its ticket-resolved identity is in
+		// the reservation set); both proceed below unchanged.
 		if (!room.reservationAdmits(socket)) {
 			room.rejectReservedJoin(socket);
 			return;

--- a/src/ygopro/room/domain/states/YGOProSideDeckingState.ts
+++ b/src/ygopro/room/domain/states/YGOProSideDeckingState.ts
@@ -16,7 +16,7 @@ import { ISocket } from "../../../../shared/socket/domain/ISocket";
 
 import { YGOProClient } from "../../../client/domain/YGOProClient";
 import { YGOProRoom } from "../YGOProRoom";
-import { findReconnectingPlayer } from "@shared/room/domain/findReconnectingPlayer";
+import { findMidDuelReconnectingPlayer } from "@shared/room/domain/findMidDuelReconnectingPlayer";
 import { config } from "../../../../config";
 import { ReconnectionTokenIssuer } from "@shared/room/application/reconnect/ReconnectionTokenIssuer";
 import { ReconnectionAckMessage } from "@shared/messages/server-to-client/ReconnectionAckMessage";
@@ -203,10 +203,13 @@ export class YGOProSideDeckingState extends YGOProRoomState {
 		}
 
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
-		const playerAlreadyInRoom = findReconnectingPlayer({
+		// The shared seam honors the watch stamp: a "w,<roomId>" joiner asked to
+		// spectate, never to take a seat, so a name match must not reconnect it.
+		const playerAlreadyInRoom = findMidDuelReconnectingPlayer({
 			players: room.players,
 			name: playerInfoMessage.name,
-			remoteAddress: socket.remoteAddress,
+			socket,
+			roomId: room.id,
 			ranked: room.ranked,
 		});
 

--- a/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
@@ -342,11 +342,11 @@ describe("YGOProWaitingState.handleJoin", () => {
 			expect(mockRoom.admissionTarget).not.toHaveBeenCalled();
 		});
 
-		// The gate runs BEFORE any admission work and reads only the reserved
-		// identities: a watch join ("w,<roomId>") is a third party like any
-		// other, and its server-side watch stamp must never open a reserved
-		// room — not even to the stands.
-		it("rejects a watch-intent joiner the reservation does not admit (watch never bypasses the gate)", async () => {
+		// The gate runs BEFORE any admission work. A watch stamp for THIS room
+		// is admitted (stands only); a stamp for another room is inert, so a
+		// watch-intent joiner the gate does not admit is rejected like any
+		// other third party.
+		it("rejects a watch-intent joiner the reservation does not admit (a foreign stamp never bypasses the gate)", async () => {
 			(mockRoom.reservationAdmits as jest.Mock).mockReturnValue(false);
 			(mockSocket as { watchForRoomId?: number }).watchForRoomId = 99;
 
@@ -477,6 +477,9 @@ describe("YGOProWaitingState.handleToDuel (spectator -> player)", () => {
 			mutex: {
 				runExclusive: jest.fn().mockImplementation((fn: () => void) => fn()),
 			},
+			// Default true = a room without reservations (ordinary rooms permit
+			// every promotion, exactly as before the reservation seat gate).
+			reservationPermitsSeat: jest.fn().mockReturnValue(true),
 			spectatorToPlayerUnsafe: jest.fn(),
 			movePlayerToAnotherCellUnsafe: jest.fn(),
 		}) as unknown as jest.Mocked<YGOProRoom>;
@@ -486,6 +489,7 @@ describe("YGOProWaitingState.handleToDuel (spectator -> player)", () => {
 			isSpectator: true,
 			credential,
 			name: "X",
+			socket: { id: "spectator-socket" },
 			logger: makeLogger(),
 		}) as unknown as jest.Mocked<YGOProClient>;
 
@@ -539,5 +543,43 @@ describe("YGOProWaitingState.handleToDuel (spectator -> player)", () => {
 		await emitToDuel(room, spectator);
 
 		expect(room.spectatorToPlayerUnsafe).toHaveBeenCalledWith(spectator);
+	});
+
+	// Reserved rooms admit watch spectators through the JOIN door, so the
+	// promotion door needs its own gate: only a reserved identity may leave the
+	// stands. The state must consult the room's SEAT-taking reservation check
+	// (reservationPermitsSeat) with the spectator's socket — never the
+	// watch-permitting JOIN gate — or a watcher could TO_DUEL into a reserved
+	// seat during the pre-duel window.
+	describe("reserved rooms", () => {
+		it("does NOT seat a spectator the reservation denies (watch spectator in a reserved room)", async () => {
+			const room = makeRoom(RoomLeague.Verified);
+			(room.reservationPermitsSeat as jest.Mock).mockReturnValue(false);
+			const spectator = makeSpectator({ kind: "verified", userId: "u-watcher" });
+
+			await emitToDuel(room, spectator);
+
+			expect(room.spectatorToPlayerUnsafe).not.toHaveBeenCalled();
+		});
+
+		it("consults the seat-taking reservation check with the spectator's socket", async () => {
+			const room = makeRoom(RoomLeague.Verified);
+			(room.reservationPermitsSeat as jest.Mock).mockReturnValue(false);
+			const spectator = makeSpectator({ kind: "verified", userId: "u-watcher" });
+
+			await emitToDuel(room, spectator);
+
+			expect(room.reservationPermitsSeat).toHaveBeenCalledWith(spectator.socket);
+		});
+
+		it("still seats a spectator the reservation permits (reserved player)", async () => {
+			const room = makeRoom(RoomLeague.Verified);
+			(room.reservationPermitsSeat as jest.Mock).mockReturnValue(true);
+			const spectator = makeSpectator({ kind: "verified", userId: "u-a" });
+
+			await emitToDuel(room, spectator);
+
+			expect(room.spectatorToPlayerUnsafe).toHaveBeenCalledWith(spectator);
+		});
 	});
 });

--- a/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
@@ -342,6 +342,21 @@ describe("YGOProWaitingState.handleJoin", () => {
 			expect(mockRoom.admissionTarget).not.toHaveBeenCalled();
 		});
 
+		// The gate runs BEFORE any admission work and reads only the reserved
+		// identities: a watch join ("w,<roomId>") is a third party like any
+		// other, and its server-side watch stamp must never open a reserved
+		// room — not even to the stands.
+		it("rejects a watch-intent joiner the reservation does not admit (watch never bypasses the gate)", async () => {
+			(mockRoom.reservationAdmits as jest.Mock).mockReturnValue(false);
+			(mockSocket as { watchForRoomId?: number }).watchForRoomId = 99;
+
+			await emitJoin(mockRoom, mockSocket);
+
+			expect(mockRoom.rejectReservedJoin).toHaveBeenCalledWith(mockSocket);
+			expect(mockAdmitToRoom.run).not.toHaveBeenCalled();
+			expect(mockRoom.admissionTarget).not.toHaveBeenCalled();
+		});
+
 		it("still delegates an admitted joiner to AdmitToRoom (ordinary rooms unaffected)", async () => {
 			await emitJoin(mockRoom, mockSocket);
 

--- a/src/ygopro/room/domain/states/YGOProWaitingState.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.ts
@@ -83,8 +83,9 @@ export class YGOProWaitingState extends YGOProRoomState {
 		}
 
 		// Reservation gate before any admission work: a reserved room's join
-		// string is not a key — only the stamped identities (or the bot's
-		// token-marked socket) get past this door, not even as spectators.
+		// string is not a key — only the stamped identities, the bot's
+		// token-marked socket, or a watch-stamped spectator (stands only, by
+		// construction) get past this door.
 		if (!room.reservationAdmits(socket)) {
 			room.rejectReservedJoin(socket);
 			return;
@@ -210,6 +211,13 @@ export class YGOProWaitingState extends YGOProRoomState {
 				// stands door, mirroring the JOIN door).
 				const credential = player.credential ?? { kind: "guest" as const, name: player.name };
 				if (!room.league.admitsAsPlayer(credential)) {
+					return;
+				}
+				// In a reserved room only a reserved identity may leave the stands:
+				// the JOIN gate admits watch spectators, so this promotion door must
+				// run the seat-taking reservation check or a non-reserved watcher
+				// could TO_DUEL into a reserved seat before the duel starts.
+				if (!room.reservationPermitsSeat(player.socket)) {
 					return;
 				}
 				room.spectatorToPlayerUnsafe(player);


### PR DESCRIPTION
## Summary

Adds `w,<roomId>[#password]` as a first-class spectate command, closing the gap where the lobby advertised `canWatch: true` for rooms the socket path could not actually let you watch.

### Behavior
- **`w,<id>`** resolves the room by id via `YGOProRoomList.findById` and enters as **spectator in any room state** (waiting or mid-duel). Unknown id → explicit JOINERROR. **A watch join never creates a room.**
- **`w,<id>#password`** carries the room password in the normal `#` slot; the password must match exactly (empty matches empty). Mismatch → JOINERROR — a deliberate reject, unlike the `name#password` path's silent-new-room behavior.
- **Reserved matchmaking rooms stay unwatchable**: the reservation gate (PR #343) runs first in every state and rejects a watcher like any third party.

### Why id-first
The room browser already exposes `id`, `status`, `private`, and `spectators` in `toRoomListDTO`. Watch is browse-then-pick, so the id is the natural identity and it dissolves the "which same-named room?" ambiguity a name-based token would carry. The client can wire a Watch button straight from the listing.

### Design seams
- **Strategy placement**: `WatchJoinStrategy` sits before `TicketJoinStrategy` — Ticket matches on socket auth, not command shape, so a ticketed socket sending `w,1234` would otherwise fall through and create a junk room named `w,1234`.
- **Spectate intent**: a server-derived, room-scoped socket stamp (`watchForRoomId`) — never set from any client-controlled field beyond the parsed command. The waiting state offers no chair to a watcher; the four mid-duel states force the spectator branch instead of name-based reconnect (see Security below).

### Security
A watch join reaching a mid-duel room must not be mistaken for a reconnecting player. The four mid-duel states now force the spectator branch for a watch-marked socket, bypassing `findReconnectingPlayer` — otherwise a watcher could enter an unreserved External/casual duel by id, present a seated player's nickname, and be reconnected into that seat. Covered by per-state negative tests (casual disconnected-name-match and ranked still-connected-name-match), plus a genuine-reconnect regression.

### Bundled fix — room id uniqueness
`generateUniqueId` (`randomInt(1000, 9999)`) was used with no uniqueness check at the three ygopro creation sites, and `findById` is first-match — so two live rooms could share an id and watch (or the bot AIJOIN return path) would resolve the wrong one. Room ids now come from `generateUnusedRoomId`, a bounded retry against the live room list.

## Verification
- Full suite: **151 suites / 1465 tests green**
- `tsc --noEmit` clean, biome clean
- Adversarial review round; the seat-hijack finding above was fixed test-first before this PR