### PR TITLE
fix(room): bind mid-duel reconnect to account identity + rate-limit joins

### DIFF
--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The JOIN rate-limit knob must honor any explicit numeric value an operator
+ * sets — including 0 (deny every join) — and fall back to the default only
+ * when the variable is unset or non-numeric.
+ */
+
+const loadConfig = (): typeof import("./index").config => {
+	let loaded: typeof import("./index").config | undefined;
+	jest.isolateModules(() => {
+		// biome-ignore lint/style/noCommonJs: jest.isolateModules needs a synchronous require to re-read env at import time
+		loaded = (require("./index") as typeof import("./index")).config;
+	});
+	if (!loaded) {
+		throw new Error("config failed to load");
+	}
+
+	return loaded;
+};
+
+describe("config.rateLimit.join.limit", () => {
+	const originalValue = process.env.RATE_LIMIT_JOIN;
+
+	afterEach(() => {
+		if (originalValue === undefined) {
+			delete process.env.RATE_LIMIT_JOIN;
+		} else {
+			process.env.RATE_LIMIT_JOIN = originalValue;
+		}
+	});
+
+	it("defaults to 60 when unset", () => {
+		delete process.env.RATE_LIMIT_JOIN;
+		expect(loadConfig().rateLimit.join.limit).toBe(60);
+	});
+
+	it("defaults to 60 when non-numeric", () => {
+		process.env.RATE_LIMIT_JOIN = "plenty";
+		expect(loadConfig().rateLimit.join.limit).toBe(60);
+	});
+
+	it("honors an explicit 0 instead of folding it into the default", () => {
+		process.env.RATE_LIMIT_JOIN = "0";
+		expect(loadConfig().rateLimit.join.limit).toBe(0);
+	});
+
+	it("honors any other explicit numeric value", () => {
+		process.env.RATE_LIMIT_JOIN = "7";
+		expect(loadConfig().rateLimit.join.limit).toBe(7);
+	});
+});

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,21 @@
 import { parseWindbotConfig } from "../ygopro/windbot/infrastructure/WindbotConfig";
 
+/**
+ * Honors any explicit numeric env value — including 0 — and falls back only
+ * when the variable is unset or non-numeric. The `Number(...) || default`
+ * idiom used elsewhere in this file silently turns an explicit 0 into the
+ * default, which matters for knobs where 0 is a meaningful operator choice
+ * (e.g. a deny-all rate limit).
+ */
+function numberFromEnv(value: string | undefined, fallback: number): number {
+	if (value === undefined || value === "") {
+		return fallback;
+	}
+	const parsed = Number(value);
+
+	return Number.isNaN(parsed) ? fallback : parsed;
+}
+
 export const config = {
 	redis: {
 		use: process.env.USE_REDIS === "true",
@@ -23,6 +39,16 @@ export const config = {
 		enabled: process.env.RATE_LIMIT_ENABLED === "true",
 		limit: Number(process.env.RATE_LIMIT),
 		window: Number(process.env.RATE_LIMIT_WINDOW),
+		// Per-IP budget for ygopro socket JOIN attempts. Deliberately separate
+		// from limit/window above (a small per-room wrong-password budget):
+		// this one must absorb every join a whole NAT'd LAN plus a flapping
+		// mobile reconnect can legitimately produce, so it defaults generous.
+		join: {
+			// 0 is a valid operator choice here (deny every join), so this knob
+			// must not fold an explicit 0 into the default.
+			limit: numberFromEnv(process.env.RATE_LIMIT_JOIN, 60),
+			window: Number(process.env.RATE_LIMIT_JOIN_WINDOW) || 60,
+		},
 	},
 	servers: {
 		host: {

--- a/src/edopro/room/domain/states/chossing-order/ChossingOrderState.ts
+++ b/src/edopro/room/domain/states/chossing-order/ChossingOrderState.ts
@@ -122,11 +122,15 @@ export class ChossingOrderState extends RoomState {
 		this.logger.info("CHOSSING_ORDER: JOIN");
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
 		const joinMessage = new JoinGameMessage(message.data);
+		// edopro seats never record a credential, so there is no seat identity to
+		// bind here; ranked reconnects are account-gated afterwards by
+		// Reconnect.run (CheckIfUseCanJoin).
 		const reconnectingPlayer = findReconnectingPlayer({
 			players: room.players,
 			name: playerInfoMessage.name,
 			remoteAddress: socket.remoteAddress,
 			ranked: room.ranked,
+			joinerUserId: null,
 		});
 
 		if (!(reconnectingPlayer instanceof Client)) {

--- a/src/edopro/room/domain/states/dueling/DuelingState.ts
+++ b/src/edopro/room/domain/states/dueling/DuelingState.ts
@@ -743,11 +743,15 @@ export class DuelingState extends RoomState {
 
 			return;
 		}
+		// edopro seats never record a credential, so there is no seat identity to
+		// bind here; ranked reconnects are account-gated afterwards by
+		// Reconnect.run (CheckIfUseCanJoin).
 		const reconnectingPlayer = findReconnectingPlayer({
 			players: room.players,
 			name: playerInfoMessage.name,
 			remoteAddress: socket.remoteAddress,
 			ranked: room.ranked,
+			joinerUserId: null,
 		});
 
 		if (!(reconnectingPlayer instanceof Client)) {

--- a/src/edopro/room/domain/states/rps/RockPaperScissorsState.ts
+++ b/src/edopro/room/domain/states/rps/RockPaperScissorsState.ts
@@ -113,11 +113,15 @@ export class RockPaperScissorState extends RoomState {
 		this.logger.info("JOIN");
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
 		const joinMessage = new JoinGameMessage(message.data);
+		// edopro seats never record a credential, so there is no seat identity to
+		// bind here; ranked reconnects are account-gated afterwards by
+		// Reconnect.run (CheckIfUseCanJoin).
 		const reconnectingPlayer = findReconnectingPlayer({
 			players: room.players,
 			name: playerInfoMessage.name,
 			remoteAddress: socket.remoteAddress,
 			ranked: room.ranked,
+			joinerUserId: null,
 		});
 
 		if (!(reconnectingPlayer instanceof Client)) {

--- a/src/edopro/room/domain/states/side-decking/SideDeckingState.ts
+++ b/src/edopro/room/domain/states/side-decking/SideDeckingState.ts
@@ -95,11 +95,15 @@ export class SideDeckingState extends RoomState {
 		this.logger.info("JOIN");
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
 		const joinMessage = new JoinGameMessage(message.data);
+		// edopro seats never record a credential, so there is no seat identity to
+		// bind here; ranked reconnects are account-gated afterwards by
+		// Reconnect.run (CheckIfUseCanJoin).
 		const reconnectingPlayer = findReconnectingPlayer({
 			players: room.players,
 			name: playerInfoMessage.name,
 			remoteAddress: socket.remoteAddress,
 			ranked: room.ranked,
+			joinerUserId: null,
 		});
 
 		if (!(reconnectingPlayer instanceof Client)) {

--- a/src/http-server/middlewares/RateLimitMiddleware.ts
+++ b/src/http-server/middlewares/RateLimitMiddleware.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, Response } from "express";
 
 import { Redis } from "@shared/db/redis/infrastructure/Redis";
+import { isRateLimited, RateLimitStore } from "@shared/rate-limit/application/isRateLimited";
 import { config } from "src/config";
 
 const WINDOW_SECONDS = 60;
@@ -10,24 +11,8 @@ const MAX_REQUESTS = 60;
 // covering several players behind one shared NAT IP.
 const ENQUEUE_MAX_REQUESTS = 20;
 
-export interface RateLimitStore {
-	incr(key: string): Promise<number>;
-	expire(key: string, seconds: number): Promise<unknown>;
-}
-
-export async function isRateLimited(
-	store: RateLimitStore,
-	key: string,
-	max: number,
-	windowSeconds: number,
-): Promise<boolean> {
-	const attempts = await store.incr(key);
-	if (attempts === 1) {
-		await store.expire(key, windowSeconds);
-	}
-
-	return attempts > max;
-}
+export { isRateLimited };
+export type { RateLimitStore };
 
 export type RateLimitMiddlewareFn = (
 	request: Request,

--- a/src/shared/rate-limit/application/isRateLimited.ts
+++ b/src/shared/rate-limit/application/isRateLimited.ts
@@ -1,0 +1,24 @@
+export interface RateLimitStore {
+	incr(key: string): Promise<number>;
+	expire(key: string, seconds: number): Promise<unknown>;
+}
+
+/**
+ * Fixed-window counter over one store bucket: INCR the key, arm the window
+ * expiry on the first hit only, and report whether the count exceeded `max`.
+ * Shared by the HTTP middlewares and the ygopro socket JOIN path so every
+ * limiter counts the same way against the same Redis semantics.
+ */
+export async function isRateLimited(
+	store: RateLimitStore,
+	key: string,
+	max: number,
+	windowSeconds: number,
+): Promise<boolean> {
+	const attempts = await store.incr(key);
+	if (attempts === 1) {
+		await store.expire(key, windowSeconds);
+	}
+
+	return attempts > max;
+}

--- a/src/shared/room/domain/findMidDuelReconnectingPlayer.test.ts
+++ b/src/shared/room/domain/findMidDuelReconnectingPlayer.test.ts
@@ -1,4 +1,5 @@
 import { YgoClient } from "@shared/client/domain/YgoClient";
+import { PlayerCredential } from "@shared/room/admission/domain/PlayerCredential";
 import { ISocket } from "@shared/socket/domain/ISocket";
 
 import { findMidDuelReconnectingPlayer } from "./findMidDuelReconnectingPlayer";
@@ -9,11 +10,13 @@ const player = (
 		isStrongAuth: boolean;
 		closed: boolean;
 		remoteAddress: string | null;
+		credential: PlayerCredential | null;
 	}> = {},
 ): YgoClient =>
 	({
 		name: overrides.name ?? "Jaden",
 		isStrongAuth: overrides.isStrongAuth ?? false,
+		credential: overrides.credential ?? null,
 		socket: {
 			closed: overrides.closed ?? true,
 			remoteAddress: overrides.remoteAddress ?? "1.1.1.1",
@@ -35,6 +38,20 @@ describe("findMidDuelReconnectingPlayer", () => {
 			socket: socket({ watchForRoomId: 7 }),
 			roomId: 7,
 			ranked: true,
+			joinerUserId: null,
+		});
+		expect(found).toBeNull();
+	});
+
+	it("the watch stamp wins even over a joiner presenting the seat's own account id", () => {
+		const p = player({ credential: { kind: "external", userId: "acc-1" } });
+		const found = findMidDuelReconnectingPlayer({
+			players: [p],
+			name: "Jaden",
+			socket: socket({ watchForRoomId: 7 }),
+			roomId: 7,
+			ranked: true,
+			joinerUserId: "acc-1",
 		});
 		expect(found).toBeNull();
 	});
@@ -47,6 +64,7 @@ describe("findMidDuelReconnectingPlayer", () => {
 			socket: socket({ watchForRoomId: 7 }),
 			roomId: 7,
 			ranked: false,
+			joinerUserId: null,
 		});
 		expect(found).toBeNull();
 	});
@@ -59,8 +77,35 @@ describe("findMidDuelReconnectingPlayer", () => {
 			socket: socket({ watchForRoomId: 8 }),
 			roomId: 7,
 			ranked: true,
+			joinerUserId: null,
 		});
 		expect(found).toBe(p);
+	});
+
+	it("hands the joiner's account id through — the same id reclaims an external seat", () => {
+		const p = player({ credential: { kind: "external", userId: "acc-1" } });
+		const found = findMidDuelReconnectingPlayer({
+			players: [p],
+			name: "Jaden",
+			socket: socket(),
+			roomId: 7,
+			ranked: true,
+			joinerUserId: "acc-1",
+		});
+		expect(found).toBe(p);
+	});
+
+	it("hands the joiner's account id through — an identity-less name match is denied an external seat", () => {
+		const p = player({ credential: { kind: "external", userId: "acc-1" } });
+		const found = findMidDuelReconnectingPlayer({
+			players: [p],
+			name: "Jaden",
+			socket: socket(),
+			roomId: 7,
+			ranked: true,
+			joinerUserId: null,
+		});
+		expect(found).toBeNull();
 	});
 
 	it("without a stamp it behaves exactly like findReconnectingPlayer — match found", () => {
@@ -71,6 +116,7 @@ describe("findMidDuelReconnectingPlayer", () => {
 			socket: socket(),
 			roomId: 7,
 			ranked: true,
+			joinerUserId: null,
 		});
 		expect(found).toBe(p);
 	});
@@ -82,6 +128,7 @@ describe("findMidDuelReconnectingPlayer", () => {
 			socket: socket(),
 			roomId: 7,
 			ranked: true,
+			joinerUserId: null,
 		});
 		expect(found).toBeNull();
 	});

--- a/src/shared/room/domain/findMidDuelReconnectingPlayer.ts
+++ b/src/shared/room/domain/findMidDuelReconnectingPlayer.ts
@@ -23,6 +23,7 @@ export function findMidDuelReconnectingPlayer(params: {
 	socket: ISocket;
 	roomId: number;
 	ranked: boolean;
+	joinerUserId: string | null;
 }): YgoClient | null {
 	const { socket } = params;
 
@@ -35,5 +36,6 @@ export function findMidDuelReconnectingPlayer(params: {
 		name: params.name,
 		remoteAddress: socket.remoteAddress,
 		ranked: params.ranked,
+		joinerUserId: params.joinerUserId,
 	});
 }

--- a/src/shared/room/domain/findReconnectingPlayer.test.ts
+++ b/src/shared/room/domain/findReconnectingPlayer.test.ts
@@ -1,6 +1,10 @@
 import { YgoClient } from "@shared/client/domain/YgoClient";
+import { PlayerCredential } from "@shared/room/admission/domain/PlayerCredential";
 
-import { findReconnectingPlayer } from "./findReconnectingPlayer";
+import {
+	findReconnectingPlayer,
+	isPairingReconnectRoutingEligible,
+} from "./findReconnectingPlayer";
 
 const player = (
 	overrides: Partial<{
@@ -8,60 +12,225 @@ const player = (
 		isStrongAuth: boolean;
 		closed: boolean;
 		remoteAddress: string | null;
+		credential: PlayerCredential | null;
 	}> = {},
 ): YgoClient =>
 	({
 		name: overrides.name ?? "Jaden",
 		isStrongAuth: overrides.isStrongAuth ?? false,
+		credential: overrides.credential ?? null,
 		socket: {
 			closed: overrides.closed ?? true,
 			remoteAddress: overrides.remoteAddress ?? "1.1.1.1",
 		},
 	}) as unknown as YgoClient;
 
+const externalSeat = (userId = "acc-1", extra: Parameters<typeof player>[0] = {}): YgoClient =>
+	player({ credential: { kind: "external", userId }, ...extra });
+
 describe("findReconnectingPlayer", () => {
-	it("matches a disconnected legacy player by name in a ranked room", () => {
-		const p = player();
-		const found = findReconnectingPlayer({
-			players: [p],
-			name: "Jaden",
-			remoteAddress: "9.9.9.9",
-			ranked: true,
+	describe("ranked seats bound to an account identity (external/PIN seats)", () => {
+		it("grants the seat to a joiner presenting the SAME account id — even over a half-open socket from another address (backgrounded mobile client)", () => {
+			const p = externalSeat("acc-1", { closed: false });
+			const found = findReconnectingPlayer({
+				players: [p],
+				name: "Jaden",
+				remoteAddress: "9.9.9.9",
+				ranked: true,
+				joinerUserId: "acc-1",
+			});
+			expect(found).toBe(p);
 		});
-		expect(found).toBe(p);
+
+		it("DENIES the seat to a name-matching joiner with NO account id — a guest knowing the display name never takes an external seat", () => {
+			const p = externalSeat("acc-1");
+			const found = findReconnectingPlayer({
+				players: [p],
+				name: "Jaden",
+				remoteAddress: "1.1.1.1",
+				ranked: true,
+				joinerUserId: null,
+			});
+			expect(found).toBeNull();
+		});
+
+		it("DENIES the seat to a name-matching joiner with a DIFFERENT account id", () => {
+			const p = externalSeat("acc-1");
+			const found = findReconnectingPlayer({
+				players: [p],
+				name: "Jaden",
+				remoteAddress: "1.1.1.1",
+				ranked: true,
+				joinerUserId: "acc-2",
+			});
+			expect(found).toBeNull();
+		});
+
+		it("denies even a still-connected victim's seat to an identity-less name match — the half-open allowance never weakens the identity rule", () => {
+			const p = externalSeat("acc-1", { closed: false });
+			const found = findReconnectingPlayer({
+				players: [p],
+				name: "Jaden",
+				remoteAddress: "1.1.1.1",
+				ranked: true,
+				joinerUserId: null,
+			});
+			expect(found).toBeNull();
+		});
 	});
 
-	it("NEVER matches a strong-auth (ticket) player — it is unreachable by name", () => {
-		const p = player({ isStrongAuth: true });
+	it("NEVER matches a strong-auth (ticket) player — it is unreachable by name even with the matching account id", () => {
+		const p = player({
+			isStrongAuth: true,
+			credential: { kind: "verified", userId: "acc-1" },
+		});
 		const found = findReconnectingPlayer({
 			players: [p],
 			name: "Jaden",
 			remoteAddress: "1.1.1.1",
 			ranked: true,
+			joinerUserId: "acc-1",
 		});
 		expect(found).toBeNull();
 	});
 
-	it("matches even a still-open socket in a ranked room — a backgrounded mobile client leaves a half-open socket that never reports closed, so the by-name reconnect must take it over (last-join-wins)", () => {
-		const p = player({ closed: false });
-		const found = findReconnectingPlayer({
-			players: [p],
-			name: "Jaden",
-			remoteAddress: "9.9.9.9",
-			ranked: true,
+	describe("ranked seats without a recorded credential (legacy flavor)", () => {
+		it("matches a disconnected legacy player by name in a ranked room", () => {
+			const p = player();
+			const found = findReconnectingPlayer({
+				players: [p],
+				name: "Jaden",
+				remoteAddress: "9.9.9.9",
+				ranked: true,
+				joinerUserId: null,
+			});
+			expect(found).toBe(p);
 		});
-		expect(found).toBe(p);
+
+		it("matches even a still-open socket in a ranked room — a backgrounded mobile client leaves a half-open socket that never reports closed, so the by-name reconnect must take it over (last-join-wins)", () => {
+			const p = player({ closed: false });
+			const found = findReconnectingPlayer({
+				players: [p],
+				name: "Jaden",
+				remoteAddress: "9.9.9.9",
+				ranked: true,
+				joinerUserId: null,
+			});
+			expect(found).toBe(p);
+		});
 	});
 
-	it("in a casual room NEVER takes over a still-open socket", () => {
-		const p = player({ closed: false, remoteAddress: "1.1.1.1" });
+	describe("casual rooms — the address+liveness rule is untouched by identity", () => {
+		it("in a casual room NEVER takes over a still-open socket", () => {
+			const p = player({ closed: false, remoteAddress: "1.1.1.1" });
+			const found = findReconnectingPlayer({
+				players: [p],
+				name: "Jaden",
+				remoteAddress: "1.1.1.1",
+				ranked: false,
+				joinerUserId: null,
+			});
+			expect(found).toBeNull();
+		});
+
+		it("in a casual room ALSO requires the same remote address", () => {
+			const p = player({ remoteAddress: "1.1.1.1" });
+			const found = findReconnectingPlayer({
+				players: [p],
+				name: "Jaden",
+				remoteAddress: "2.2.2.2",
+				ranked: false,
+				joinerUserId: null,
+			});
+			expect(found).toBeNull();
+		});
+
+		it("a matching account id does NOT relax the casual rule — address still has to match", () => {
+			const p = externalSeat("acc-1", { remoteAddress: "1.1.1.1" });
+			const found = findReconnectingPlayer({
+				players: [p],
+				name: "Jaden",
+				remoteAddress: "2.2.2.2",
+				ranked: false,
+				joinerUserId: "acc-1",
+			});
+			expect(found).toBeNull();
+		});
+
+		it("a casual reconnect from the same address onto a closed socket still works", () => {
+			const p = player({ closed: true, remoteAddress: "1.1.1.1" });
+			const found = findReconnectingPlayer({
+				players: [p],
+				name: "Jaden",
+				remoteAddress: "1.1.1.1",
+				ranked: false,
+				joinerUserId: null,
+			});
+			expect(found).toBe(p);
+		});
+	});
+
+	it("DENIES a by-name reconnect to a guest-credential seat (a bot seat) in a ranked room — even to a joiner presenting an account id", () => {
+		const p = player({ credential: { kind: "guest", name: "Jaden" } });
 		const found = findReconnectingPlayer({
 			players: [p],
 			name: "Jaden",
 			remoteAddress: "1.1.1.1",
-			ranked: false,
+			ranked: true,
+			joinerUserId: "acc-1",
 		});
 		expect(found).toBeNull();
+	});
+
+	describe("isPairingReconnectRoutingEligible — the routing-only predicate", () => {
+		it("reports an external seat as route-eligible by name alone — routing must reach the room whose own door resolves identity for real", () => {
+			const p = externalSeat("acc-1", { closed: false });
+			const eligible = isPairingReconnectRoutingEligible({
+				players: [p],
+				name: "Jaden",
+				remoteAddress: "9.9.9.9",
+				ranked: true,
+			});
+			expect(eligible).toBe(true);
+		});
+
+		it("still never reaches a strong-auth (ticket) seat", () => {
+			const p = player({
+				isStrongAuth: true,
+				credential: { kind: "verified", userId: "acc-1" },
+			});
+			const eligible = isPairingReconnectRoutingEligible({
+				players: [p],
+				name: "Jaden",
+				remoteAddress: "1.1.1.1",
+				ranked: true,
+			});
+			expect(eligible).toBe(false);
+		});
+
+		it("does not weaken the casual address+liveness rule either", () => {
+			const p = player({ closed: false, remoteAddress: "1.1.1.1" });
+			const eligible = isPairingReconnectRoutingEligible({
+				players: [p],
+				name: "Jaden",
+				remoteAddress: "1.1.1.1",
+				ranked: false,
+			});
+			expect(eligible).toBe(false);
+		});
+
+		it("the seating API no longer admits the routing mode — undefined is rejected by the type and denies at runtime", () => {
+			const p = externalSeat("acc-1", { closed: false });
+			const found = findReconnectingPlayer({
+				players: [p],
+				name: "Jaden",
+				remoteAddress: "9.9.9.9",
+				ranked: true,
+				// @ts-expect-error joinerUserId is resolved (string) or absent (null) — a seating caller can never pass the routing-only mode
+				joinerUserId: undefined,
+			});
+			expect(found).toBeNull();
+		});
 	});
 
 	it("requires a matching name", () => {
@@ -71,17 +240,7 @@ describe("findReconnectingPlayer", () => {
 			name: "Jaden",
 			remoteAddress: "1.1.1.1",
 			ranked: true,
-		});
-		expect(found).toBeNull();
-	});
-
-	it("in a casual room ALSO requires the same remote address", () => {
-		const p = player({ remoteAddress: "1.1.1.1" });
-		const found = findReconnectingPlayer({
-			players: [p],
-			name: "Jaden",
-			remoteAddress: "2.2.2.2",
-			ranked: false,
+			joinerUserId: null,
 		});
 		expect(found).toBeNull();
 	});
@@ -92,6 +251,7 @@ describe("findReconnectingPlayer", () => {
 			name: "Jaden",
 			remoteAddress: "1.1.1.1",
 			ranked: true,
+			joinerUserId: null,
 		});
 		expect(found).toBeNull();
 	});

--- a/src/shared/room/domain/findReconnectingPlayer.ts
+++ b/src/shared/room/domain/findReconnectingPlayer.ts
@@ -1,53 +1,112 @@
 import { YgoClient } from "@shared/client/domain/YgoClient";
 
 /**
- * Finds the player that a by-name JOIN is reconnecting to, while a duel is
- * already in progress. This is the WEAK reconnect path used by external
- * clients; the evolution client reconnects through its token instead.
- *
- * A reconnection is granted ONLY when every guard holds:
+ * Shared eligibility guards for a by-name mid-duel reconnect, WITHOUT the
+ * ranked identity binding. Both the seating finder and the routing predicate
+ * agree on these, so the two paths can never diverge:
  *   - the target is NOT strong-auth: ticket players reconnect through their
  *     single-use token, so they are unreachable here (closes the hijack of a
  *     verified player by name, with a stolen PIN or another ticket).
  *   - the name matches.
+ *   - in casual rooms, additionally bound to the original location and only
+ *     over a socket already known closed: casual rooms have no PIN, so the
+ *     remote address is the only credential.
+ */
+function isReconnectEligibleSeat(
+	client: YgoClient,
+	params: { name: string; remoteAddress: string | undefined; ranked: boolean },
+): boolean {
+	if (client.isStrongAuth) {
+		return false;
+	}
+	if (client.name !== params.name) {
+		return false;
+	}
+	if (!params.ranked) {
+		return client.socket.remoteAddress === params.remoteAddress && client.socket.closed;
+	}
+
+	return true;
+}
+
+/**
+ * Finds the player that a by-name JOIN is reconnecting to, while a duel is
+ * already in progress. This is the WEAK reconnect path used by external
+ * clients; the evolution client reconnects through its token instead.
  *
- * In casual rooms it is additionally bound to the original location and only
- * takes over a socket already known closed: casual rooms have no PIN, so the
- * remote address is the only credential.
+ * On top of the shared guards (isReconnectEligibleSeat, above), ranked rooms
+ * bind the seat to the ACCOUNT IDENTITY: a seat whose credential carries a
+ * userId (an external/PIN seat) is only handed back to a joiner whose own
+ * resolved credential carries the SAME userId. The display name is chosen by
+ * the client and is public, so name alone never grants a seat — an
+ * identity-less (guest) joiner or a different account is denied and falls
+ * through to spectating. A ranked seat with no recorded credential belongs to
+ * the legacy flavor that never stores one; it keeps the historical name rule,
+ * and that flavor's caller gates ranked reconnects with its own account check.
  *
- * Ranked (incl. external/PIN) rooms intentionally do NOT require the socket to
- * be closed. Mobile clients on the raw-TCP path leave a half-open socket when
- * backgrounded — no FIN/RST reaches the server, so `socket.closed` stays false
- * indefinitely (the TCP path has no liveness heartbeat). Requiring it there
- * locked legitimate players out of their own duel. The takeover is safe: the
- * stale socket is destroyed when the new one is attached (Client.setSocket).
- * The residual (someone knowing a legacy player's name takes their seat while
- * it looks live) is the accepted limit of the legacy by-name path, and never
- * reaches a ticket player.
+ * Ranked rooms intentionally do NOT require the socket to be closed. Mobile
+ * clients on the raw-TCP path leave a half-open socket when backgrounded — no
+ * FIN/RST reaches the server, so `socket.closed` stays false indefinitely (the
+ * TCP path has no liveness heartbeat). Requiring it there locked legitimate
+ * players out of their own duel; the identity binding above makes liveness
+ * unnecessary. When the seat is granted, the stale socket is detached from the
+ * seat (listeners removed, replaced by the new one — YGOProRoom.reconnect /
+ * Client.setSocket) but NOT destroyed: closing it is a known residual left to
+ * the socket's own lifecycle, and the seat's messages flow only to the new
+ * socket.
+ *
+ * `joinerUserId` is a required two-state:
+ *   - a string: the joiner resolved to this account id — bind ranked seats.
+ *   - null:     the joiner resolved to NO account (guest) — external seats
+ *               are denied.
+ * A caller that CANNOT resolve identity must not seat anyone and therefore
+ * cannot call this at all — it uses isPairingReconnectRoutingEligible
+ * (below), which routes without ever returning a seat.
  */
 export function findReconnectingPlayer(params: {
 	players: YgoClient[];
 	name: string;
 	remoteAddress: string | undefined;
 	ranked: boolean;
+	joinerUserId: string | null;
 }): YgoClient | null {
 	const match = params.players.find((client) => {
-		if (client.isStrongAuth) {
-			return false;
-		}
-		if (client.name !== params.name) {
+		if (!isReconnectEligibleSeat(client, params)) {
 			return false;
 		}
 		if (!params.ranked) {
-			if (client.socket.remoteAddress !== params.remoteAddress) {
-				return false;
-			}
-			if (!client.socket.closed) {
-				return false;
-			}
+			return true;
 		}
-		return true;
+
+		const seatCredential = client.credential;
+		if (seatCredential === null) {
+			// Legacy flavor: no credential is ever recorded on the seat, so there
+			// is no identity to bind — keep the historical name rule.
+			return true;
+		}
+
+		// A verified seat never reaches this line (isStrongAuth bailed above), so
+		// the only grantable seat is an external one reclaimed by its own account.
+		return seatCredential.kind === "external" && seatCredential.userId === params.joinerUserId;
 	});
 
 	return match ?? null;
+}
+
+/**
+ * Whether a pairing join may be ROUTED towards a non-waiting room as a
+ * possible reconnect — nothing more. This is the only surface for callers
+ * that cannot resolve the joiner's identity (synchronous routing — a PIN
+ * needs an async lookup): it deliberately returns a boolean, never a seat, so
+ * a routing caller CANNOT seat anyone on eligibility alone. The room's own
+ * mid-duel JOIN door re-runs the check with a resolved identity
+ * (findReconnectingPlayer) before any seat changes hands.
+ */
+export function isPairingReconnectRoutingEligible(params: {
+	players: YgoClient[];
+	name: string;
+	remoteAddress: string | undefined;
+	ranked: boolean;
+}): boolean {
+	return params.players.some((client) => isReconnectEligibleSeat(client, params));
 }

--- a/src/ygopro/room/admission/application/AdmitToRoom.ts
+++ b/src/ygopro/room/admission/application/AdmitToRoom.ts
@@ -43,6 +43,8 @@ export class AdmitToRoom {
 		playerInfo: PlayerInfoMessage,
 		target: AdmissionTarget,
 	): Promise<Admission> {
+		// This wait is unbounded; the mid-duel states bound the same resolve
+		// with resolveJoinerIdentityWithTimeout, and this path does not yet.
 		const credential = await this.resolver.resolve(socket, playerInfo);
 		const result = this.admission.decide(credential, {
 			league: target.league,

--- a/src/ygopro/room/application/YGOProJoinHandler.rate-limit.test.ts
+++ b/src/ygopro/room/application/YGOProJoinHandler.rate-limit.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Per-IP rate limiting of the ygopro JOIN path.
+ *
+ * The JOIN attempt itself is the guarded resource: a novel JOIN can allocate a
+ * room id (finite 1000-9999 space), a watch JOIN probes which ids exist, and a
+ * ranked mid-duel JOIN with a PIN costs a DB lookup + bcrypt compare. All three
+ * are cross-room, so the limiter must gate every attempt per IP BEFORE any
+ * strategy is resolved — never per room, and never exempting anything a client
+ * can control.
+ *
+ * Degradation contract: when rate limiting is disabled, Redis is unavailable,
+ * the socket has no ip, or the limiter store errors, joins MUST proceed
+ * (fail open) — the limiter can refuse service to an attacker, never to
+ * everyone.
+ */
+
+import { EventEmitter } from "stream";
+
+import { Redis } from "@shared/db/redis/infrastructure/Redis";
+import { ErrorMessageType } from "ygopro-msg-encode";
+
+import { config } from "../../../config";
+import { YGOProJoinHandler } from "./YGOProJoinHandler";
+import { JoinStrategyRegistry } from "./join-strategies/JoinStrategyRegistry";
+
+// ---- fakes ----
+
+class FakeRedis {
+	private counters = new Map<string, number>();
+	expireCalls: Array<{ key: string; seconds: number }> = [];
+	incrCalls = 0;
+
+	async incr(key: string): Promise<number> {
+		this.incrCalls++;
+		const next = (this.counters.get(key) ?? 0) + 1;
+		this.counters.set(key, next);
+
+		return next;
+	}
+
+	async expire(key: string, seconds: number): Promise<unknown> {
+		this.expireCalls.push({ key, seconds });
+
+		return 1;
+	}
+
+	count(key: string): number {
+		return this.counters.get(key) ?? 0;
+	}
+}
+
+const makeLogger = () => ({
+	child: jest.fn().mockReturnThis(),
+	info: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn(),
+	debug: jest.fn(),
+});
+
+// Takes the address wrapped in an object so an explicit `undefined` (the
+// no-remote-address degradation) cannot be silently replaced by a default.
+const makeSocket = (
+	opts: { remoteAddress: string | undefined } = { remoteAddress: "203.0.113.7" },
+) => ({
+	id: "sock-rate-limit",
+	remoteAddress: opts.remoteAddress,
+	send: jest.fn(),
+	close: jest.fn(),
+	destroy: jest.fn(),
+});
+
+const joinErrorBuffer = Buffer.from("JOINERROR-frame");
+
+const makeMessageRepository = () => ({
+	errorMessage: jest.fn().mockReturnValue(joinErrorBuffer),
+});
+
+/**
+ * Minimal CTOS JOIN_GAME payload (version u16 at 0, gameid u32 at 4, pass
+ * utf16 at 8) plus a PlayerInfo previousMessage — same layout the strategy
+ * chain integration tests use.
+ */
+const makeJoinMessage = (pass: string): { data: Buffer; previousMessage: Buffer } => {
+	const prevMsg = Buffer.alloc(40, 0);
+	Buffer.from("TestPlayer", "utf16le").copy(prevMsg, 0);
+
+	const data = Buffer.alloc(48, 0);
+	data.writeUInt16LE(0x1362, 0);
+	data.writeUInt32LE(0, 4);
+	const passChars = pass.slice(0, 20);
+	for (let i = 0; i < passChars.length; i++) {
+		data.writeUInt16LE(passChars.charCodeAt(i), 8 + i * 2);
+	}
+
+	return { data, previousMessage: prevMsg };
+};
+
+// ---- harness ----
+
+const LIMIT = 3;
+const WINDOW = 120;
+
+describe("YGOProJoinHandler — per-IP join rate limiting", () => {
+	let store: FakeRedis;
+	let strategyHandle: jest.Mock;
+	let registryResolve: jest.Mock;
+	let enabledBefore: boolean;
+	let limitBefore: number;
+	let windowBefore: number;
+
+	const makeHandler = (socket = makeSocket(), messageRepo = makeMessageRepository()) => {
+		strategyHandle = jest.fn().mockResolvedValue(undefined);
+		registryResolve = jest.fn().mockReturnValue({ handle: strategyHandle });
+		const registry = { resolve: registryResolve } as unknown as JoinStrategyRegistry;
+		const handler = new YGOProJoinHandler(
+			new EventEmitter(),
+			makeLogger() as never,
+			socket as never,
+			messageRepo as never,
+			registry,
+		);
+
+		return { handler, socket, messageRepo };
+	};
+
+	beforeEach(() => {
+		store = new FakeRedis();
+		jest
+			.spyOn(Redis, "getInstance")
+			.mockReturnValue(store as unknown as ReturnType<typeof Redis.getInstance>);
+		enabledBefore = config.rateLimit.enabled;
+		limitBefore = config.rateLimit.join.limit;
+		windowBefore = config.rateLimit.join.window;
+		config.rateLimit.enabled = true;
+		config.rateLimit.join.limit = LIMIT;
+		config.rateLimit.join.window = WINDOW;
+	});
+
+	afterEach(() => {
+		config.rateLimit.enabled = enabledBefore;
+		config.rateLimit.join.limit = limitBefore;
+		config.rateLimit.join.window = windowBefore;
+		jest.restoreAllMocks();
+	});
+
+	it("lets joins under the limit reach the strategy chain untouched", async () => {
+		const { handler, socket } = makeHandler();
+
+		for (let i = 0; i < LIMIT; i++) {
+			await handler.handleJoinGame(makeJoinMessage("NORMALROOM") as never);
+		}
+
+		expect(registryResolve).toHaveBeenCalledTimes(LIMIT);
+		expect(strategyHandle).toHaveBeenCalledTimes(LIMIT);
+		expect(socket.send).not.toHaveBeenCalled();
+		expect(socket.close).not.toHaveBeenCalled();
+	});
+
+	it("over the limit: sends JOINERROR, closes the socket, and never resolves a strategy", async () => {
+		const { handler, socket, messageRepo } = makeHandler();
+
+		for (let i = 0; i < LIMIT; i++) {
+			await handler.handleJoinGame(makeJoinMessage("NORMALROOM") as never);
+		}
+		await handler.handleJoinGame(makeJoinMessage("NORMALROOM") as never);
+
+		// Only the allowed attempts resolved a strategy — the limited one never
+		// reached resolution, so no room lookup, id allocation, or DB auth ran.
+		expect(registryResolve).toHaveBeenCalledTimes(LIMIT);
+		expect(strategyHandle).toHaveBeenCalledTimes(LIMIT);
+		expect(messageRepo.errorMessage).toHaveBeenCalledWith(ErrorMessageType.JOINERROR, 0);
+		expect(socket.send).toHaveBeenCalledWith(joinErrorBuffer);
+		// close(), not destroy(): the JOINERROR frame must flush before teardown.
+		expect(socket.close).toHaveBeenCalledTimes(1);
+		expect(socket.destroy).not.toHaveBeenCalled();
+	});
+
+	it("counts every attempt in a per-IP bucket keyed rate-limit:ygopro-join:<ip>", async () => {
+		const { handler } = makeHandler(makeSocket({ remoteAddress: "203.0.113.7" }));
+
+		await handler.handleJoinGame(makeJoinMessage("w,1234") as never);
+		await handler.handleJoinGame(makeJoinMessage("OTHERROOM") as never);
+
+		expect(store.count("rate-limit:ygopro-join:203.0.113.7")).toBe(2);
+	});
+
+	it("sets the window expiry only on the first hit of the window", async () => {
+		const { handler } = makeHandler(makeSocket({ remoteAddress: "203.0.113.7" }));
+
+		await handler.handleJoinGame(makeJoinMessage("NORMALROOM") as never);
+		await handler.handleJoinGame(makeJoinMessage("NORMALROOM") as never);
+
+		expect(store.expireCalls).toEqual([
+			{ key: "rate-limit:ygopro-join:203.0.113.7", seconds: WINDOW },
+		]);
+	});
+
+	it("tracks each ip independently: one exhausted ip never blocks another", async () => {
+		const exhausted = makeHandler(makeSocket({ remoteAddress: "198.51.100.1" }));
+		for (let i = 0; i < LIMIT + 2; i++) {
+			await exhausted.handler.handleJoinGame(makeJoinMessage("NORMALROOM") as never);
+		}
+
+		const other = makeHandler(makeSocket({ remoteAddress: "198.51.100.2" }));
+		await other.handler.handleJoinGame(makeJoinMessage("NORMALROOM") as never);
+
+		expect(registryResolve).toHaveBeenCalledTimes(1);
+		expect(strategyHandle).toHaveBeenCalledTimes(1);
+		expect(other.socket.close).not.toHaveBeenCalled();
+	});
+
+	it("fails open when rate limiting is disabled", async () => {
+		config.rateLimit.enabled = false;
+		const { handler, socket } = makeHandler();
+
+		for (let i = 0; i < LIMIT + 3; i++) {
+			await handler.handleJoinGame(makeJoinMessage("NORMALROOM") as never);
+		}
+
+		expect(registryResolve).toHaveBeenCalledTimes(LIMIT + 3);
+		expect(store.incrCalls).toBe(0);
+		expect(socket.close).not.toHaveBeenCalled();
+	});
+
+	it("fails open when Redis is unavailable", async () => {
+		(Redis.getInstance as jest.Mock).mockReturnValue(undefined);
+		const { handler, socket } = makeHandler();
+
+		for (let i = 0; i < LIMIT + 3; i++) {
+			await handler.handleJoinGame(makeJoinMessage("NORMALROOM") as never);
+		}
+
+		expect(registryResolve).toHaveBeenCalledTimes(LIMIT + 3);
+		expect(socket.close).not.toHaveBeenCalled();
+	});
+
+	it("fails open when the socket has no remote address", async () => {
+		const { handler, socket } = makeHandler(makeSocket({ remoteAddress: undefined }));
+
+		for (let i = 0; i < LIMIT + 3; i++) {
+			await handler.handleJoinGame(makeJoinMessage("NORMALROOM") as never);
+		}
+
+		expect(registryResolve).toHaveBeenCalledTimes(LIMIT + 3);
+		expect(store.incrCalls).toBe(0);
+		expect(socket.close).not.toHaveBeenCalled();
+	});
+
+	it("fails open when the limiter store errors", async () => {
+		jest.spyOn(store, "incr").mockRejectedValue(new Error("redis down"));
+		const { handler, socket } = makeHandler();
+
+		await handler.handleJoinGame(makeJoinMessage("NORMALROOM") as never);
+
+		expect(registryResolve).toHaveBeenCalledTimes(1);
+		expect(socket.close).not.toHaveBeenCalled();
+	});
+
+	it("ships a generous default join budget so NAT'd players and flapping reconnects fit", () => {
+		// 60 joins/min per IP: several players behind one NAT plus a mobile
+		// client rejoining after half-open drops stay far under one join per
+		// second sustained, while id-space sweeps (9000 ids) and PIN brute
+		// force (10000 PINs) stretch from seconds to hours.
+		expect(limitBefore).toBe(60);
+		expect(windowBefore).toBe(60);
+	});
+});

--- a/src/ygopro/room/application/YGOProJoinHandler.ts
+++ b/src/ygopro/room/application/YGOProJoinHandler.ts
@@ -9,7 +9,10 @@ import { PlayerInfoMessage } from "@edopro/messages/client-to-server/PlayerInfoM
 
 import { ErrorMessageType, YGOProCtosJoinGame } from "ygopro-msg-encode";
 import { MessageRepository } from "@shared/messages/MessageRepository";
+import { Redis } from "@shared/db/redis/infrastructure/Redis";
+import { isRateLimited } from "@shared/rate-limit/application/isRateLimited";
 
+import { config } from "../../../config";
 import { JoinStrategyRegistry } from "./join-strategies/JoinStrategyRegistry";
 import { JoinContext } from "./join-strategies/JoinStrategy";
 
@@ -40,6 +43,22 @@ export class YGOProJoinHandler implements JoinMessageHandler {
 
 	async handleJoinGame(message: ClientMessage): Promise<void> {
 		this.logger.info("JOIN_GAME");
+
+		// Per-IP gate on the JOIN attempt itself, before any strategy resolves.
+		// The attempt is the guarded resource: a novel JOIN can allocate a room
+		// id from the finite 1000-9999 space, a watch JOIN probes which ids
+		// exist, and a ranked mid-duel JOIN with a PIN costs a DB lookup plus a
+		// bcrypt compare whose outcome is observable. All three are cross-room
+		// (a new room has no id yet; probes span many ids), so a per-room key
+		// cannot cover them — and nothing a client controls may exempt it.
+		if (await this.isJoinRateLimited()) {
+			const errorBuf = this.messageRepository.errorMessage(ErrorMessageType.JOINERROR, 0);
+			this.socket.send(errorBuf);
+			// close() (not destroy()): flush the JOINERROR frame before tearing down.
+			this.socket.close();
+
+			return;
+		}
 
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
 		const joinMessage = new YGOProCtosJoinGame().fromPayload(message.data);
@@ -86,6 +105,39 @@ export class YGOProJoinHandler implements JoinMessageHandler {
 			// close() (not destroy()): flush the JOINERROR frame before tearing down,
 			// consistent with the other join error paths.
 			this.socket.close();
+		}
+	}
+
+	/**
+	 * Fixed-window per-IP counter over `rate-limit:ygopro-join:<ip>`. Every
+	 * attempt counts — cheap and expensive alike — so no client-controlled
+	 * field can carve out an exemption. Fails open on every degradation
+	 * (limiter disabled, Redis unavailable, no remote address, store error):
+	 * the limiter may refuse service to one IP, never to everyone.
+	 */
+	private async isJoinRateLimited(): Promise<boolean> {
+		const redis = Redis.getInstance();
+		const ip = this.socket.remoteAddress;
+
+		if (!config.rateLimit.enabled || !redis || !ip) {
+			return false;
+		}
+
+		try {
+			const limited = await isRateLimited(
+				redis,
+				`rate-limit:ygopro-join:${ip}`,
+				config.rateLimit.join.limit,
+				config.rateLimit.join.window,
+			);
+			if (limited) {
+				this.logger.info(`JOIN_GAME from ip: ${ip} rejected: per-IP join rate limit exceeded`);
+			}
+
+			return limited;
+		} catch {
+			// A limiter backend error must never block joins.
+			return false;
 		}
 	}
 }

--- a/src/ygopro/room/application/join-strategies/findOrCreateRoom.ts
+++ b/src/ygopro/room/application/join-strategies/findOrCreateRoom.ts
@@ -1,6 +1,6 @@
 import { generateUnusedRoomId } from "../generateUnusedRoomId";
 
-import { findReconnectingPlayer } from "@shared/room/domain/findReconnectingPlayer";
+import { isPairingReconnectRoutingEligible } from "@shared/room/domain/findReconnectingPlayer";
 
 import { JoinContext } from "./JoinStrategy";
 import { isPairingJoin } from "./isPairingJoin";
@@ -42,10 +42,12 @@ export interface FindOrCreateRoomOptions {
  * brand-new room instead of resuming its seat. Before the WAITING-only scan,
  * findPairingReconnectTarget looks for a same-name, passwordless, non-WAITING
  * room containing a disconnected occupant this joiner may legitimately
- * resume, reusing findReconnectingPlayer's own eligibility rules so the two
- * paths never diverge. Only ROUTING happens here; the actual re-seat runs
- * downstream, under the room's mutex, when the room's state machine handles
- * the JOIN event.
+ * resume, reusing the reconnect eligibility rules through
+ * isPairingReconnectRoutingEligible so the two paths never diverge. Only
+ * ROUTING happens here — the predicate cannot return a seat by construction.
+ * The room's own mid-duel JOIN door then resolves the joiner's identity and
+ * decides the re-seat, holding the room's mutex across both so the check and
+ * the seat change are atomic.
  *
  * Non-pairing joins identify a room by the exact (name, password) pair
  * (findByNameAndPassword: first-match, state-blind). A matching pair is
@@ -66,15 +68,17 @@ export function findOrCreateRoom(
 		// guests need the league filter — non-guests keep pairing unchanged.
 		const isGuestJoiner = !ctx.socket.resolvedUserId && !ctx.playerInfo.password;
 
-		const reconnectTarget = YGOProRoomList.findPairingReconnectTarget(
-			ctx.command,
-			(room) =>
-				findReconnectingPlayer({
-					players: room.players,
-					name: ctx.playerInfo.name,
-					remoteAddress: ctx.socket.remoteAddress,
-					ranked: room.ranked,
-				}) !== null,
+		// Routing only: a PIN cannot be resolved synchronously here, so this
+		// predicate never sees an identity and can never return a seat. The
+		// room's mid-duel JOIN door resolves the joiner's identity and is the
+		// sole authority over the seat.
+		const reconnectTarget = YGOProRoomList.findPairingReconnectTarget(ctx.command, (room) =>
+			isPairingReconnectRoutingEligible({
+				players: room.players,
+				name: ctx.playerInfo.name,
+				remoteAddress: ctx.socket.remoteAddress,
+				ranked: room.ranked,
+			}),
 		);
 		if (reconnectTarget) {
 			return reconnectTarget;

--- a/src/ygopro/room/domain/YGOProRoom.ts
+++ b/src/ygopro/room/domain/YGOProRoom.ts
@@ -381,6 +381,29 @@ export class YGOProRoom extends YgoRoom {
 		);
 	}
 
+	/**
+	 * Resolves the account identity behind a mid-duel JOIN, with the same
+	 * resolver wiring the WAITING admission uses (waiting(), above). Ranked
+	 * seats are bound to an account id, so the non-waiting states must know who
+	 * is knocking BEFORE the reconnect decision — a client-chosen display name
+	 * alone never identifies anyone. Returns null for a joiner that resolves to
+	 * no account (guest).
+	 */
+	async resolveJoinerIdentity(
+		socket: ISocket,
+		playerInfo: PlayerInfoMessage,
+	): Promise<string | null> {
+		const userProfileRepo = new UserProfilePostgresRepository();
+		const credentialResolver = new CredentialResolver(
+			userProfileRepo,
+			new UserAuth(userProfileRepo),
+			this._logger,
+		);
+		const credential = await credentialResolver.resolve(socket, playerInfo);
+
+		return credential.kind === "guest" ? null : credential.userId;
+	}
+
 	rps(): void {
 		this._state = DuelState.RPS;
 		this._roomState?.removeAllListener();

--- a/src/ygopro/room/domain/resolveJoinerIdentityWithTimeout.ts
+++ b/src/ygopro/room/domain/resolveJoinerIdentityWithTimeout.ts
@@ -1,0 +1,51 @@
+import { PlayerInfoMessage } from "../../../edopro/messages/client-to-server/PlayerInfoMessage";
+import { ISocket } from "../../../shared/socket/domain/ISocket";
+
+/**
+ * Upper bound on the mid-duel identity resolution. The resolve runs INSIDE the
+ * room's exclusive section, so a database connection that never settles would
+ * otherwise hold the room mutex forever and freeze every later join. Long
+ * enough for a slow-but-alive database round trip; short enough that a stuck
+ * room recovers within one reconnect attempt.
+ */
+export const JOINER_IDENTITY_RESOLVE_TIMEOUT_MS = 5000;
+
+/** The seam every non-waiting state resolves a joiner's identity through. */
+interface JoinerIdentityResolver {
+	resolveJoinerIdentity(socket: ISocket, playerInfo: PlayerInfoMessage): Promise<string | null>;
+}
+
+/**
+ * Resolves a mid-duel joiner's identity with a bounded wait. A resolver that
+ * hangs (never settles) rejects at the timeout, funneling into the caller's
+ * existing fail-closed catch — the same outcome as a resolver error: the
+ * joiner spectates, the seat stays untouched, and the mutex releases. The
+ * shared entry point for the four non-waiting states, so the bound lives in
+ * one place.
+ */
+export async function resolveJoinerIdentityWithTimeout(
+	room: JoinerIdentityResolver,
+	socket: ISocket,
+	playerInfo: PlayerInfoMessage,
+	timeoutMs: number = JOINER_IDENTITY_RESOLVE_TIMEOUT_MS,
+): Promise<string | null> {
+	let timer: NodeJS.Timeout | undefined;
+	const resolution = room.resolveJoinerIdentity(socket, playerInfo);
+	// A resolver that loses the race may still reject later (a hung connection
+	// eventually erroring); that late failure is already handled here and must
+	// not surface as an unhandled rejection.
+	resolution.catch(() => undefined);
+	try {
+		return await Promise.race([
+			resolution,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(
+					() => reject(new Error(`identity resolution timed out after ${timeoutMs}ms`)),
+					timeoutMs,
+				);
+			}),
+		]);
+	} finally {
+		clearTimeout(timer);
+	}
+}

--- a/src/ygopro/room/domain/states/YGOProChoosingOrderState.ts
+++ b/src/ygopro/room/domain/states/YGOProChoosingOrderState.ts
@@ -7,6 +7,7 @@ import { YGOProRoomState } from "../YGOProRoomState";
 import { Logger } from "../../../../shared/logger/domain/Logger";
 import { ISocket } from "../../../../shared/socket/domain/ISocket";
 import { YGOProClient } from "../../../client/domain/YGOProClient";
+import { resolveJoinerIdentityWithTimeout } from "../resolveJoinerIdentityWithTimeout";
 import { YGOProRoom } from "../YGOProRoom";
 import { findMidDuelReconnectingPlayer } from "@shared/room/domain/findMidDuelReconnectingPlayer";
 import { TurnPlayerResult, YGOProCtosTpResult, YGOProStocDuelStart } from "ygopro-msg-encode";
@@ -79,7 +80,11 @@ export class YGOProChoosingOrderState extends YGOProRoomState {
 		room.dueling();
 	}
 
-	private handleJoin(message: ClientMessage, room: YGOProRoom, socket: ISocket): void {
+	private async handleJoin(
+		message: ClientMessage,
+		room: YGOProRoom,
+		socket: ISocket,
+	): Promise<void> {
 		this.logger.info("handleJoin");
 
 		// Reservation gate: past WAITING, a reserved room keeps its seats closed
@@ -93,30 +98,64 @@ export class YGOProChoosingOrderState extends YGOProRoomState {
 		}
 
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
-		// The shared seam honors the watch stamp: a "w,<roomId>" joiner asked to
-		// spectate, never to take a seat, so a name match must not reconnect it.
-		const playerAlreadyInRoom = findMidDuelReconnectingPlayer({
-			players: room.players,
-			name: playerInfoMessage.name,
-			socket,
-			roomId: room.id,
-			ranked: room.ranked,
+		// The identity resolution awaits the database, yielding the event loop,
+		// so the eligibility check and the seat change must run as ONE exclusive
+		// section — otherwise two concurrent joins could both observe the seat
+		// as reclaimable before either takes it. Same lock (and same
+		// hold-across-resolver idiom) as the WAITING admission.
+		await room.mutex.runExclusive(async () => {
+			// A ranked seat is bound to an account id, so the joiner's identity is
+			// resolved BEFORE the reconnect decision — the display name alone never
+			// identifies anyone. Casual rooms bind by address and liveness instead
+			// and never consult the resolver.
+			let joinerUserId: string | null = null;
+			if (room.ranked) {
+				try {
+					joinerUserId = await resolveJoinerIdentityWithTimeout(room, socket, playerInfoMessage);
+				} catch (error) {
+					// Fail closed: with the resolver unreachable — erroring, or hung
+					// past the bounded timeout — nobody's identity is proven, so no
+					// seat may change hands. The joiner waits in the stands (a legit
+					// player can simply rejoin once the resolver recovers) instead of
+					// hanging with no response. This catch keeps the resolver failure
+					// off the voided JOIN promise; a later synchronous throw inside
+					// this exclusive section still surfaces to the global handler
+					// (the process survives it and the mutex releases).
+					this.logger.error(`resolveJoinerIdentity failed: ${String(error)}`);
+					this.admitAsSpectator(room, socket, playerInfoMessage.name);
+					return;
+				}
+			}
+			// The shared seam honors the watch stamp: a "w,<roomId>" joiner asked to
+			// spectate, never to take a seat, so a name match must not reconnect it.
+			const playerAlreadyInRoom = findMidDuelReconnectingPlayer({
+				players: room.players,
+				name: playerInfoMessage.name,
+				socket,
+				roomId: room.id,
+				ranked: room.ranked,
+				joinerUserId,
+			});
+
+			if (!(playerAlreadyInRoom instanceof YGOProClient)) {
+				this.admitAsSpectator(room, socket, playerInfoMessage.name);
+				return;
+			}
+
+			room.reconnect(playerAlreadyInRoom, socket);
+			playerAlreadyInRoom.sendMessageToClient(room.messageSender.duelStartMessage());
+			room.sendDeckCountMessage(playerAlreadyInRoom);
+
+			if (room.clientWhoChoosesTurn === playerAlreadyInRoom) {
+				playerAlreadyInRoom.sendMessageToClient(room.messageSender.selectTpMessage());
+			}
 		});
+	}
 
-		if (!(playerAlreadyInRoom instanceof YGOProClient)) {
-			const spectator = room.createSpectatorUnsafe(socket, playerInfoMessage.name);
-			room.addSpectatorUnsafe(spectator);
-			spectator.sendMessageToClient(Buffer.from(new YGOProStocDuelStart().toFullPayload()));
-			room.sendDeckCountMessage(spectator);
-			return;
-		}
-
-		room.reconnect(playerAlreadyInRoom, socket);
-		playerAlreadyInRoom.sendMessageToClient(room.messageSender.duelStartMessage());
-		room.sendDeckCountMessage(playerAlreadyInRoom);
-
-		if (room.clientWhoChoosesTurn === playerAlreadyInRoom) {
-			playerAlreadyInRoom.sendMessageToClient(room.messageSender.selectTpMessage());
-		}
+	private admitAsSpectator(room: YGOProRoom, socket: ISocket, name: string): void {
+		const spectator = room.createSpectatorUnsafe(socket, name);
+		room.addSpectatorUnsafe(spectator);
+		spectator.sendMessageToClient(Buffer.from(new YGOProStocDuelStart().toFullPayload()));
+		room.sendDeckCountMessage(spectator);
 	}
 }

--- a/src/ygopro/room/domain/states/YGOProDuelingState.ts
+++ b/src/ygopro/room/domain/states/YGOProDuelingState.ts
@@ -23,6 +23,7 @@ import { ReconnectionAckMessage } from "@shared/messages/server-to-client/Reconn
 import { YGOProClient } from "../../../client/domain/YGOProClient";
 import { DuelRecord } from "../DuelRecord";
 import { FinalizeYGOProRoom } from "../../application/FinalizeYGOProRoom";
+import { resolveJoinerIdentityWithTimeout } from "../resolveJoinerIdentityWithTimeout";
 import { YGOProRoom } from "../YGOProRoom";
 import { findMidDuelReconnectingPlayer } from "@shared/room/domain/findMidDuelReconnectingPlayer";
 import { getMessageIdentifier } from "../../../utils/response-time-utils";
@@ -238,7 +239,11 @@ export class YGOProDuelingState extends YGOProRoomState {
 		this.ocgCore.advance();
 	}
 
-	private handleJoin(message: ClientMessage, room: YGOProRoom, socket: ISocket): void {
+	private async handleJoin(
+		message: ClientMessage,
+		room: YGOProRoom,
+		socket: ISocket,
+	): Promise<void> {
 		this.logger.info("handleJoin");
 
 		// Reservation gate: past WAITING, a reserved room keeps its seats closed
@@ -252,26 +257,60 @@ export class YGOProDuelingState extends YGOProRoomState {
 		}
 
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
-		// The shared seam honors the watch stamp: a "w,<roomId>" joiner asked to
-		// spectate, never to take a seat, so a name match must not reconnect it.
-		const playerAlreadyInRoom = findMidDuelReconnectingPlayer({
-			players: room.players,
-			name: playerInfoMessage.name,
-			socket,
-			roomId: room.id,
-			ranked: room.ranked,
+		// The identity resolution awaits the database, yielding the event loop,
+		// so the eligibility check and the seat change must run as ONE exclusive
+		// section — otherwise two concurrent joins could both observe the seat
+		// as reclaimable before either takes it. Same lock (and same
+		// hold-across-resolver idiom) as the WAITING admission.
+		await room.mutex.runExclusive(async () => {
+			// A ranked seat is bound to an account id, so the joiner's identity is
+			// resolved BEFORE the reconnect decision — the display name alone never
+			// identifies anyone. Casual rooms bind by address and liveness instead
+			// and never consult the resolver.
+			let joinerUserId: string | null = null;
+			if (room.ranked) {
+				try {
+					joinerUserId = await resolveJoinerIdentityWithTimeout(room, socket, playerInfoMessage);
+				} catch (error) {
+					// Fail closed: with the resolver unreachable — erroring, or hung
+					// past the bounded timeout — nobody's identity is proven, so no
+					// seat may change hands. The joiner waits in the stands (a legit
+					// player can simply rejoin once the resolver recovers) instead of
+					// hanging with no response. This catch keeps the resolver failure
+					// off the voided JOIN promise; a later synchronous throw inside
+					// this exclusive section still surfaces to the global handler
+					// (the process survives it and the mutex releases).
+					this.logger.error(`resolveJoinerIdentity failed: ${String(error)}`);
+					this.admitAsSpectator(room, socket, playerInfoMessage.name);
+					return;
+				}
+			}
+			// The shared seam honors the watch stamp: a "w,<roomId>" joiner asked to
+			// spectate, never to take a seat, so a name match must not reconnect it.
+			const playerAlreadyInRoom = findMidDuelReconnectingPlayer({
+				players: room.players,
+				name: playerInfoMessage.name,
+				socket,
+				roomId: room.id,
+				ranked: room.ranked,
+				joinerUserId,
+			});
+
+			if (!(playerAlreadyInRoom instanceof YGOProClient)) {
+				this.admitAsSpectator(room, socket, playerInfoMessage.name);
+				return;
+			}
+
+			this.room.reconnect(playerAlreadyInRoom, socket);
 		});
+	}
 
-		if (!(playerAlreadyInRoom instanceof YGOProClient)) {
-			const spectator = room.createSpectatorUnsafe(socket, playerInfoMessage.name);
-			room.addSpectatorUnsafe(spectator);
-			spectator.sendMessageToClient(Buffer.from(new YGOProStocDuelStart().toFullPayload()));
-			room.sendPreviousDuelsHistoricalMessages(spectator);
-			room.sendCurrentDuelHistoricalMessages(spectator);
-			return;
-		}
-
-		this.room.reconnect(playerAlreadyInRoom, socket);
+	private admitAsSpectator(room: YGOProRoom, socket: ISocket, name: string): void {
+		const spectator = room.createSpectatorUnsafe(socket, name);
+		room.addSpectatorUnsafe(spectator);
+		spectator.sendMessageToClient(Buffer.from(new YGOProStocDuelStart().toFullPayload()));
+		room.sendPreviousDuelsHistoricalMessages(spectator);
+		room.sendCurrentDuelHistoricalMessages(spectator);
 	}
 
 	private async handleUpdateDeck(

--- a/src/ygopro/room/domain/states/YGOProMidDuelReconnectIdentity.test.ts
+++ b/src/ygopro/room/domain/states/YGOProMidDuelReconnectIdentity.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Identity binding at the mid-duel JOIN door of every non-waiting state.
+ *
+ * A ranked external (PIN) seat is only handed back to the account that owns
+ * it: each state resolves the joiner's credential BEFORE the reconnect
+ * decision and hands the resolved account id to the shared finder. A joiner
+ * that only knows the seated player's display name resolves to no account (or
+ * a different one) and lands in the stands, with the seat untouched. Casual
+ * rooms never consult the resolver — their address+liveness rule is complete
+ * without it. States are exercised on prototype instances (same approach as
+ * the reserved-room join tests).
+ */
+
+import { Logger } from "@shared/logger/domain/Logger";
+import { ClientMessage } from "@shared/messages/MessageProcessor";
+import { isPairingReconnectRoutingEligible } from "@shared/room/domain/findReconnectingPlayer";
+import { ISocket } from "@shared/socket/domain/ISocket";
+
+import { YGOProClient } from "../../../client/domain/YGOProClient";
+import { JOINER_IDENTITY_RESOLVE_TIMEOUT_MS } from "../resolveJoinerIdentityWithTimeout";
+import { YGOProRoom } from "../YGOProRoom";
+import { YGOProChoosingOrderState } from "./YGOProChoosingOrderState";
+import { YGOProDuelingState } from "./YGOProDuelingState";
+import { YGOProRockPaperScissorState } from "./YGOProRockPaperScissorState";
+import { YGOProSideDeckingState } from "./YGOProSideDeckingState";
+
+const makeLogger = (): jest.Mocked<Logger> =>
+	({
+		child: jest.fn().mockReturnThis(),
+		info: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+		debug: jest.fn(),
+	}) as unknown as jest.Mocked<Logger>;
+
+// "Jaden" in UTF-16LE with no password separator (40 bytes)
+const PLAYER_INFO_HEX =
+	"4a006100640065006e00000000000000000000000000000000000000000000000000000000000000";
+
+const makeJoinMessage = (): ClientMessage =>
+	({
+		data: Buffer.alloc(48),
+		previousMessage: Buffer.from(PLAYER_INFO_HEX, "hex"),
+	}) as unknown as ClientMessage;
+
+const makeSocket = (overrides: Partial<ISocket> = {}): jest.Mocked<ISocket> =>
+	({
+		send: jest.fn(),
+		close: jest.fn(),
+		destroy: jest.fn(),
+		remoteAddress: "127.0.0.1",
+		closed: false,
+		...overrides,
+	}) as unknown as jest.Mocked<ISocket>;
+
+const makeSpectator = () =>
+	({ sendMessageToClient: jest.fn() }) as unknown as jest.Mocked<YGOProClient>;
+
+const makeRoom = (overrides: Record<string, unknown> = {}): jest.Mocked<YGOProRoom> =>
+	({
+		id: 7,
+		ranked: true,
+		players: [],
+		mutex: { runExclusive: async (fn: () => unknown) => fn() },
+		reservationAdmits: jest.fn().mockReturnValue(true),
+		rejectReservedJoin: jest.fn(),
+		resolveJoinerIdentity: jest.fn().mockResolvedValue(null),
+		createSpectatorUnsafe: jest.fn().mockReturnValue(makeSpectator()),
+		addSpectatorUnsafe: jest.fn(),
+		reconnect: jest.fn(),
+		sendDeckCountMessage: jest.fn(),
+		sendPreviousDuelsHistoricalMessages: jest.fn(),
+		sendCurrentDuelHistoricalMessages: jest.fn(),
+		messageSender: {
+			duelStartMessage: jest.fn().mockReturnValue(Buffer.from("duel-start")),
+			changeSideMessage: jest.fn().mockReturnValue(Buffer.from("change-side")),
+			selectHandMessage: jest.fn().mockReturnValue(Buffer.from("select-hand")),
+			selectTpMessage: jest.fn().mockReturnValue(Buffer.from("select-tp")),
+		},
+		...overrides,
+	}) as unknown as jest.Mocked<YGOProRoom>;
+
+// A YGOProClient instance (passes `instanceof YGOProClient`) without running
+// the real constructor. An external (PIN) seat: weak-auth, but bound to an
+// account id.
+const makeExternalSeat = (
+	userId = "acc-1",
+	socket: { closed: boolean; remoteAddress: string | undefined } = {
+		closed: false,
+		remoteAddress: "10.0.0.1",
+	},
+): YGOProClient => {
+	const client = Object.create(YGOProClient.prototype) as Record<string, unknown>;
+	client._credential = { kind: "external", userId };
+	client.name = "Jaden";
+	client._team = 0;
+	client._isReady = true;
+	Object.defineProperty(client, "isCaptain", { value: false });
+	client.sendMessageToClient = jest.fn();
+	client.clearReconnecting = jest.fn();
+	client._socket = socket;
+	return client as unknown as YGOProClient;
+};
+
+const makeCasualSeat = (): YGOProClient => {
+	const seat = makeExternalSeat("acc-1", { closed: true, remoteAddress: "127.0.0.1" });
+	(seat as unknown as Record<string, unknown>)._credential = null;
+	return seat;
+};
+
+type JoinCapableState = {
+	handleJoin(message: ClientMessage, room: YGOProRoom, socket: ISocket): void | Promise<void>;
+};
+
+const buildState = (
+	proto: { prototype: object },
+	fields: Record<string, unknown> = {},
+): JoinCapableState => {
+	const state = Object.create(proto.prototype);
+	Object.assign(state, { logger: makeLogger(), ...fields });
+	return state as JoinCapableState;
+};
+
+const states: Array<{
+	label: string;
+	build: (room: jest.Mocked<YGOProRoom>) => JoinCapableState;
+}> = [
+	{
+		label: "YGOProDuelingState",
+		build: (room) => buildState(YGOProDuelingState, { room }),
+	},
+	{
+		label: "YGOProRockPaperScissorState",
+		build: () => buildState(YGOProRockPaperScissorState, { handResult: [0, 0] }),
+	},
+	{
+		label: "YGOProChoosingOrderState",
+		build: () => buildState(YGOProChoosingOrderState),
+	},
+	{
+		label: "YGOProSideDeckingState",
+		build: () => buildState(YGOProSideDeckingState),
+	},
+];
+
+describe.each(states)("$label.handleJoin — ranked identity binding", ({ build }) => {
+	it("grants the seat back to the account that owns it — even while the old socket looks alive", async () => {
+		const seat = makeExternalSeat("acc-1");
+		const room = makeRoom({ players: [seat] });
+		(room.resolveJoinerIdentity as jest.Mock).mockResolvedValue("acc-1");
+		const socket = makeSocket();
+
+		await build(room).handleJoin(makeJoinMessage(), room, socket);
+
+		expect(room.reconnect).toHaveBeenCalledWith(seat, socket);
+		expect(room.createSpectatorUnsafe).not.toHaveBeenCalled();
+	});
+
+	it("sends a name-only joiner with NO account to the stands and leaves the seat untouched", async () => {
+		const seat = makeExternalSeat("acc-1");
+		const room = makeRoom({ players: [seat] });
+		(room.resolveJoinerIdentity as jest.Mock).mockResolvedValue(null);
+		const socket = makeSocket();
+
+		await build(room).handleJoin(makeJoinMessage(), room, socket);
+
+		expect(room.reconnect).not.toHaveBeenCalled();
+		expect(room.createSpectatorUnsafe).toHaveBeenCalledWith(socket, "Jaden");
+		expect(room.addSpectatorUnsafe).toHaveBeenCalled();
+	});
+
+	it("sends a name-only joiner with a DIFFERENT account to the stands", async () => {
+		const seat = makeExternalSeat("acc-1");
+		const room = makeRoom({ players: [seat] });
+		(room.resolveJoinerIdentity as jest.Mock).mockResolvedValue("acc-2");
+		const socket = makeSocket();
+
+		await build(room).handleJoin(makeJoinMessage(), room, socket);
+
+		expect(room.reconnect).not.toHaveBeenCalled();
+		expect(room.addSpectatorUnsafe).toHaveBeenCalled();
+	});
+
+	it("never consults the identity resolver in a casual room — the address+liveness rule stands alone", async () => {
+		const seat = makeCasualSeat();
+		const room = makeRoom({ ranked: false, players: [seat] });
+		const socket = makeSocket();
+
+		await build(room).handleJoin(makeJoinMessage(), room, socket);
+
+		expect(room.resolveJoinerIdentity).not.toHaveBeenCalled();
+		expect(room.reconnect).toHaveBeenCalledWith(seat, socket);
+	});
+
+	it("resolves the identity and re-seats atomically under the room mutex — no seat decision outside the lock", async () => {
+		const seat = makeExternalSeat("acc-1");
+		let mutexHeld = false;
+		let resolvedWhileHeld: boolean | undefined;
+		let reconnectedWhileHeld: boolean | undefined;
+		const room = makeRoom({
+			players: [seat],
+			mutex: {
+				runExclusive: async (fn: () => Promise<unknown>) => {
+					mutexHeld = true;
+					try {
+						return await fn();
+					} finally {
+						mutexHeld = false;
+					}
+				},
+			},
+		});
+		(room.resolveJoinerIdentity as jest.Mock).mockImplementation(async () => {
+			resolvedWhileHeld = mutexHeld;
+			return "acc-1";
+		});
+		(room.reconnect as jest.Mock).mockImplementation(() => {
+			reconnectedWhileHeld = mutexHeld;
+		});
+		const socket = makeSocket();
+
+		await build(room).handleJoin(makeJoinMessage(), room, socket);
+
+		expect(resolvedWhileHeld).toBe(true);
+		expect(reconnectedWhileHeld).toBe(true);
+	});
+
+	it("fails closed when the identity resolver is unavailable — the joiner lands in the stands, the seat is untouched, and nothing rejects", async () => {
+		const seat = makeExternalSeat("acc-1");
+		const room = makeRoom({ players: [seat] });
+		(room.resolveJoinerIdentity as jest.Mock).mockRejectedValue(new Error("db down"));
+		const socket = makeSocket();
+
+		// The JOIN listener voids this promise, so a rejection here would escape
+		// to the global uncaughtException hook — resolving IS the contract.
+		await expect(build(room).handleJoin(makeJoinMessage(), room, socket)).resolves.toBeUndefined();
+
+		expect(room.reconnect).not.toHaveBeenCalled();
+		expect(room.createSpectatorUnsafe).toHaveBeenCalledWith(socket, "Jaden");
+		expect(room.addSpectatorUnsafe).toHaveBeenCalled();
+	});
+
+	it("bounds a HUNG identity resolver: the joiner lands in the stands within the timeout, the seat is untouched, and the mutex releases", async () => {
+		jest.useFakeTimers();
+		try {
+			const seat = makeExternalSeat("acc-1");
+			let mutexReleased = false;
+			const room = makeRoom({
+				players: [seat],
+				mutex: {
+					runExclusive: async (fn: () => Promise<unknown>) => {
+						try {
+							return await fn();
+						} finally {
+							mutexReleased = true;
+						}
+					},
+				},
+			});
+			// A hung connection neither resolves nor rejects — the promise stays
+			// pending forever, so only a bounded wait can end the exclusive section.
+			(room.resolveJoinerIdentity as jest.Mock).mockReturnValue(new Promise(() => undefined));
+			const socket = makeSocket();
+
+			const join = build(room).handleJoin(makeJoinMessage(), room, socket);
+			await jest.advanceTimersByTimeAsync(JOINER_IDENTITY_RESOLVE_TIMEOUT_MS);
+
+			// Same contract as the rejecting resolver: the voided JOIN promise
+			// resolves — a timeout must not escape to the global hook.
+			await expect(join).resolves.toBeUndefined();
+
+			expect(room.reconnect).not.toHaveBeenCalled();
+			expect(room.createSpectatorUnsafe).toHaveBeenCalledWith(socket, "Jaden");
+			expect(room.addSpectatorUnsafe).toHaveBeenCalled();
+			expect(mutexReleased).toBe(true);
+		} finally {
+			jest.useRealTimers();
+		}
+	});
+
+	it("a watch-stamped socket spectates even when it presents the seat's own account", async () => {
+		const seat = makeExternalSeat("acc-1");
+		const room = makeRoom({ players: [seat] });
+		(room.resolveJoinerIdentity as jest.Mock).mockResolvedValue("acc-1");
+		const socket = makeSocket({ watchForRoomId: 7 });
+
+		await build(room).handleJoin(makeJoinMessage(), room, socket);
+
+		expect(room.reconnect).not.toHaveBeenCalled();
+		expect(room.addSpectatorUnsafe).toHaveBeenCalled();
+	});
+});
+
+describe("routing-to-door integration — the routing-only predicate never bypasses the identity gate", () => {
+	it("a pairing reconnect ROUTED in by the identity-less predicate is RE-GATED at the mid-duel door: a non-matching identity lands in the stands", async () => {
+		const seat = makeExternalSeat("acc-1", { closed: false, remoteAddress: "10.0.0.1" });
+
+		// Routing (findOrCreateRoom) sees the seat as reconnect-eligible without
+		// resolving any identity — the join reaches the mid-duel room...
+		expect(
+			isPairingReconnectRoutingEligible({
+				players: [seat],
+				name: "Jaden",
+				remoteAddress: "5.5.5.5",
+				ranked: true,
+			}),
+		).toBe(true);
+
+		// ...but the room's own door resolves the joiner to a DIFFERENT account,
+		// so the seat stays untouched and the joiner spectates.
+		const room = makeRoom({ players: [seat] });
+		(room.resolveJoinerIdentity as jest.Mock).mockResolvedValue("acc-2");
+		const socket = makeSocket({ remoteAddress: "5.5.5.5" });
+
+		await buildState(YGOProDuelingState, { room }).handleJoin(makeJoinMessage(), room, socket);
+
+		expect(room.reconnect).not.toHaveBeenCalled();
+		expect(room.addSpectatorUnsafe).toHaveBeenCalled();
+	});
+});

--- a/src/ygopro/room/domain/states/YGOProReservedRoomJoin.test.ts
+++ b/src/ygopro/room/domain/states/YGOProReservedRoomJoin.test.ts
@@ -58,8 +58,10 @@ const makeRoom = (overrides: Record<string, unknown> = {}): jest.Mocked<YGOProRo
 	({
 		ranked: true,
 		players: [],
+		mutex: { runExclusive: async (fn: () => unknown) => fn() },
 		reservationAdmits: jest.fn().mockReturnValue(true),
 		rejectReservedJoin: jest.fn(),
+		resolveJoinerIdentity: jest.fn().mockResolvedValue(null),
 		createSpectatorUnsafe: jest.fn().mockReturnValue(makeSpectator()),
 		addSpectatorUnsafe: jest.fn(),
 		reconnect: jest.fn(),
@@ -92,7 +94,7 @@ const makeSeatedPlayer = (
 };
 
 type JoinCapableState = {
-	handleJoin(message: ClientMessage, room: YGOProRoom, socket: ISocket): void;
+	handleJoin(message: ClientMessage, room: YGOProRoom, socket: ISocket): void | Promise<void>;
 };
 
 const buildState = (
@@ -120,30 +122,30 @@ const expectSpectated = (room: jest.Mocked<YGOProRoom>): void => {
 describe("YGOProDuelingState.handleJoin — reserved rooms", () => {
 	const build = (room: jest.Mocked<YGOProRoom>) => buildState(YGOProDuelingState, { room });
 
-	it("rejects a third party the reservation does not admit — not even as spectator", () => {
+	it("rejects a third party the reservation does not admit — not even as spectator", async () => {
 		const room = makeRoom();
 		(room.reservationAdmits as jest.Mock).mockReturnValue(false);
 		const socket = makeSocket({ resolvedUserId: "u-intruder" });
 
-		build(room).handleJoin(makeJoinMessage(), room, socket);
+		await build(room).handleJoin(makeJoinMessage(), room, socket);
 
 		expectRejected(room, socket);
 	});
 
-	it("still spectates a third party in a room without reservations", () => {
+	it("still spectates a third party in a room without reservations", async () => {
 		const room = makeRoom();
 
-		build(room).handleJoin(makeJoinMessage(), room, makeSocket());
+		await build(room).handleJoin(makeJoinMessage(), room, makeSocket());
 
 		expectSpectated(room);
 	});
 
-	it("still reconnects a seated player the reservation admits", () => {
+	it("still reconnects a seated player the reservation admits", async () => {
 		const player = makeSeatedPlayer();
 		const room = makeRoom({ players: [player] });
 		const socket = makeSocket({ resolvedUserId: "u-a" });
 
-		build(room).handleJoin(makeJoinMessage(), room, socket);
+		await build(room).handleJoin(makeJoinMessage(), room, socket);
 
 		expect(room.reconnect).toHaveBeenCalledWith(player, socket);
 		expect(room.rejectReservedJoin).not.toHaveBeenCalled();
@@ -194,60 +196,60 @@ describe("YGOProDuelingState.handleJoin — reserved rooms", () => {
 describe("YGOProRockPaperScissorState.handleJoin — reserved rooms", () => {
 	const build = () => buildState(YGOProRockPaperScissorState, { handResult: [0, 0] });
 
-	it("rejects a third party the reservation does not admit", () => {
+	it("rejects a third party the reservation does not admit", async () => {
 		const room = makeRoom();
 		(room.reservationAdmits as jest.Mock).mockReturnValue(false);
 		const socket = makeSocket();
 
-		build().handleJoin(makeJoinMessage(), room, socket);
+		await build().handleJoin(makeJoinMessage(), room, socket);
 
 		expectRejected(room, socket);
 	});
 
-	it("still spectates a third party in a room without reservations", () => {
+	it("still spectates a third party in a room without reservations", async () => {
 		const room = makeRoom();
 
-		build().handleJoin(makeJoinMessage(), room, makeSocket());
+		await build().handleJoin(makeJoinMessage(), room, makeSocket());
 
 		expectSpectated(room);
 	});
 });
 
 describe("YGOProChoosingOrderState.handleJoin — reserved rooms", () => {
-	it("rejects a third party the reservation does not admit", () => {
+	it("rejects a third party the reservation does not admit", async () => {
 		const room = makeRoom();
 		(room.reservationAdmits as jest.Mock).mockReturnValue(false);
 		const socket = makeSocket();
 
-		buildState(YGOProChoosingOrderState).handleJoin(makeJoinMessage(), room, socket);
+		await buildState(YGOProChoosingOrderState).handleJoin(makeJoinMessage(), room, socket);
 
 		expectRejected(room, socket);
 	});
 
-	it("still spectates a third party in a room without reservations", () => {
+	it("still spectates a third party in a room without reservations", async () => {
 		const room = makeRoom();
 
-		buildState(YGOProChoosingOrderState).handleJoin(makeJoinMessage(), room, makeSocket());
+		await buildState(YGOProChoosingOrderState).handleJoin(makeJoinMessage(), room, makeSocket());
 
 		expectSpectated(room);
 	});
 });
 
 describe("YGOProSideDeckingState.handleJoin — reserved rooms", () => {
-	it("rejects a third party the reservation does not admit", () => {
+	it("rejects a third party the reservation does not admit", async () => {
 		const room = makeRoom();
 		(room.reservationAdmits as jest.Mock).mockReturnValue(false);
 		const socket = makeSocket();
 
-		buildState(YGOProSideDeckingState).handleJoin(makeJoinMessage(), room, socket);
+		await buildState(YGOProSideDeckingState).handleJoin(makeJoinMessage(), room, socket);
 
 		expectRejected(room, socket);
 	});
 
-	it("still spectates a third party in a room without reservations", () => {
+	it("still spectates a third party in a room without reservations", async () => {
 		const room = makeRoom();
 
-		buildState(YGOProSideDeckingState).handleJoin(makeJoinMessage(), room, makeSocket());
+		await buildState(YGOProSideDeckingState).handleJoin(makeJoinMessage(), room, makeSocket());
 
 		expectSpectated(room);
 	});
@@ -261,30 +263,30 @@ describe("YGOProSideDeckingState.handleJoin — reserved rooms", () => {
 describe("mid-duel states — watch-marked joiners", () => {
 	const buildDueling = (room: jest.Mocked<YGOProRoom>) => buildState(YGOProDuelingState, { room });
 
-	it("rejects a watch-marked third party when the reservation does not admit it", () => {
+	it("rejects a watch-marked third party when the reservation does not admit it", async () => {
 		const room = makeRoom();
 		(room.reservationAdmits as jest.Mock).mockReturnValue(false);
 		const socket = makeSocket({ watchForRoomId: 99 });
 
-		buildDueling(room).handleJoin(makeJoinMessage(), room, socket);
+		await buildDueling(room).handleJoin(makeJoinMessage(), room, socket);
 
 		expectRejected(room, socket);
 	});
 
-	it("spectates a watch-marked joiner in an unreserved dueling room (existing fallback path)", () => {
+	it("spectates a watch-marked joiner in an unreserved dueling room (existing fallback path)", async () => {
 		const room = makeRoom();
 		const socket = makeSocket({ watchForRoomId: 99 });
 
-		buildDueling(room).handleJoin(makeJoinMessage(), room, socket);
+		await buildDueling(room).handleJoin(makeJoinMessage(), room, socket);
 
 		expectSpectated(room);
 	});
 
-	it("spectates a watch-marked joiner in an unreserved RPS room (existing fallback path)", () => {
+	it("spectates a watch-marked joiner in an unreserved RPS room (existing fallback path)", async () => {
 		const room = makeRoom();
 		const socket = makeSocket({ watchForRoomId: 99 });
 
-		buildState(YGOProRockPaperScissorState).handleJoin(makeJoinMessage(), room, socket);
+		await buildState(YGOProRockPaperScissorState).handleJoin(makeJoinMessage(), room, socket);
 
 		expectSpectated(room);
 	});
@@ -318,21 +320,21 @@ describe("mid-duel states — watch stamp never takes a seat", () => {
 
 	it.each(
 		stateBuilders,
-	)("%s: a watch-marked joiner matching a DISCONNECTED player in a casual room lands in the stands", (_name, build) => {
+	)("%s: a watch-marked joiner matching a DISCONNECTED player in a casual room lands in the stands", async (_name, build) => {
 		// Casual reconnect eligibility: same name, same remote address, socket
 		// already closed — the strongest legitimate-looking claim on the seat.
 		const victim = makeSeatedPlayer("Jaden", { closed: true, remoteAddress: "127.0.0.1" });
 		const room = makeRoom({ id: ROOM_ID, ranked: false, players: [victim] });
 		const socket = makeSocket({ watchForRoomId: ROOM_ID });
 
-		build(room).handleJoin(makeJoinMessage(), room, socket);
+		await build(room).handleJoin(makeJoinMessage(), room, socket);
 
 		expectSeatUntouched(room, victim);
 	});
 
 	it.each(
 		stateBuilders,
-	)("%s: a watch-marked joiner matching a STILL-CONNECTED player in a ranked room lands in the stands", (_name, build) => {
+	)("%s: a watch-marked joiner matching a STILL-CONNECTED player in a ranked room lands in the stands", async (_name, build) => {
 		// Ranked rooms (incl. external leagues) skip the address and liveness
 		// checks, so without the stamp this name match would take over the
 		// victim's live seat.
@@ -340,30 +342,30 @@ describe("mid-duel states — watch stamp never takes a seat", () => {
 		const room = makeRoom({ id: ROOM_ID, ranked: true, players: [victim] });
 		const socket = makeSocket({ watchForRoomId: ROOM_ID });
 
-		build(room).handleJoin(makeJoinMessage(), room, socket);
+		await build(room).handleJoin(makeJoinMessage(), room, socket);
 
 		expectSeatUntouched(room, victim);
 	});
 
 	it.each(
 		stateBuilders,
-	)("%s: a genuine (non-watch) by-name reconnect still reaches the seat", (_name, build) => {
+	)("%s: a genuine (non-watch) by-name reconnect still reaches the seat", async (_name, build) => {
 		const victim = makeSeatedPlayer("Jaden");
 		const room = makeRoom({ id: ROOM_ID, ranked: true, players: [victim] });
 		const socket = makeSocket();
 
-		build(room).handleJoin(makeJoinMessage(), room, socket);
+		await build(room).handleJoin(makeJoinMessage(), room, socket);
 
 		expect(room.reconnect).toHaveBeenCalledWith(victim, socket);
 		expect(room.createSpectatorUnsafe).not.toHaveBeenCalled();
 	});
 
-	it("a stale stamp for ANOTHER room does not suppress the reconnect", () => {
+	it("a stale stamp for ANOTHER room does not suppress the reconnect", async () => {
 		const victim = makeSeatedPlayer("Jaden");
 		const room = makeRoom({ id: ROOM_ID, ranked: true, players: [victim] });
 		const socket = makeSocket({ watchForRoomId: ROOM_ID + 1 });
 
-		buildState(YGOProDuelingState, { room }).handleJoin(makeJoinMessage(), room, socket);
+		await buildState(YGOProDuelingState, { room }).handleJoin(makeJoinMessage(), room, socket);
 
 		expect(room.reconnect).toHaveBeenCalledWith(victim, socket);
 		expect(room.createSpectatorUnsafe).not.toHaveBeenCalled();
@@ -385,21 +387,21 @@ describe("mid-duel states — watch spectating a RESERVED room (real gate)", () 
 		return room;
 	};
 
-	it("spectates a watch-stamped joiner in a reserved DUELING room without touching seats", () => {
+	it("spectates a watch-stamped joiner in a reserved DUELING room without touching seats", async () => {
 		const room = makeReservedRoom();
 		const socket = makeSocket({ watchForRoomId: ROOM_ID });
 
-		buildState(YGOProDuelingState, { room }).handleJoin(makeJoinMessage(), room, socket);
+		await buildState(YGOProDuelingState, { room }).handleJoin(makeJoinMessage(), room, socket);
 
 		expectSpectated(room);
 		expect(room.reconnect).not.toHaveBeenCalled();
 	});
 
-	it("spectates a watch-stamped joiner in a reserved RPS room", () => {
+	it("spectates a watch-stamped joiner in a reserved RPS room", async () => {
 		const room = makeReservedRoom();
 		const socket = makeSocket({ watchForRoomId: ROOM_ID });
 
-		buildState(YGOProRockPaperScissorState, { handResult: [0, 0] }).handleJoin(
+		await buildState(YGOProRockPaperScissorState, { handResult: [0, 0] }).handleJoin(
 			makeJoinMessage(),
 			room,
 			socket,
@@ -409,20 +411,20 @@ describe("mid-duel states — watch spectating a RESERVED room (real gate)", () 
 		expect(room.reconnect).not.toHaveBeenCalled();
 	});
 
-	it("still fully rejects a ticketed non-reserved third party", () => {
+	it("still fully rejects a ticketed non-reserved third party", async () => {
 		const room = makeReservedRoom();
 		const socket = makeSocket({ resolvedUserId: "u-intruder" });
 
-		buildState(YGOProDuelingState, { room }).handleJoin(makeJoinMessage(), room, socket);
+		await buildState(YGOProDuelingState, { room }).handleJoin(makeJoinMessage(), room, socket);
 
 		expectRejected(room, socket);
 	});
 
-	it("still fully rejects an anonymous guest third party", () => {
+	it("still fully rejects an anonymous guest third party", async () => {
 		const room = makeReservedRoom();
 		const socket = makeSocket();
 
-		buildState(YGOProDuelingState, { room }).handleJoin(makeJoinMessage(), room, socket);
+		await buildState(YGOProDuelingState, { room }).handleJoin(makeJoinMessage(), room, socket);
 
 		expectRejected(room, socket);
 	});

--- a/src/ygopro/room/domain/states/YGOProRockPaperScissorState.ts
+++ b/src/ygopro/room/domain/states/YGOProRockPaperScissorState.ts
@@ -6,6 +6,7 @@ import { ClientMessage } from "../../../../shared/messages/MessageProcessor";
 import { Logger } from "../../../../shared/logger/domain/Logger";
 import { ISocket } from "../../../../shared/socket/domain/ISocket";
 import { YGOProClient } from "../../../client/domain/YGOProClient";
+import { resolveJoinerIdentityWithTimeout } from "../resolveJoinerIdentityWithTimeout";
 import { YGOProRoom } from "../YGOProRoom";
 import { findMidDuelReconnectingPlayer } from "@shared/room/domain/findMidDuelReconnectingPlayer";
 import { YGOProCtosHandResult } from "ygopro-msg-encode";
@@ -71,7 +72,11 @@ export class YGOProRockPaperScissorState extends YGOProRoomState {
 		player.clearReconnecting();
 	}
 
-	private handleJoin(message: ClientMessage, room: YGOProRoom, socket: ISocket): void {
+	private async handleJoin(
+		message: ClientMessage,
+		room: YGOProRoom,
+		socket: ISocket,
+	): Promise<void> {
 		this.logger.info("handleJoin");
 
 		// Reservation gate: past WAITING, a reserved room keeps its seats closed
@@ -85,34 +90,68 @@ export class YGOProRockPaperScissorState extends YGOProRoomState {
 		}
 
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
-		// The shared seam honors the watch stamp: a "w,<roomId>" joiner asked to
-		// spectate, never to take a seat, so a name match must not reconnect it.
-		const playerAlreadyInRoom = findMidDuelReconnectingPlayer({
-			players: room.players,
-			name: playerInfoMessage.name,
-			socket,
-			roomId: room.id,
-			ranked: room.ranked,
+		// The identity resolution awaits the database, yielding the event loop,
+		// so the eligibility check and the seat change must run as ONE exclusive
+		// section — otherwise two concurrent joins could both observe the seat
+		// as reclaimable before either takes it. Same lock (and same
+		// hold-across-resolver idiom) as the WAITING admission.
+		await room.mutex.runExclusive(async () => {
+			// A ranked seat is bound to an account id, so the joiner's identity is
+			// resolved BEFORE the reconnect decision — the display name alone never
+			// identifies anyone. Casual rooms bind by address and liveness instead
+			// and never consult the resolver.
+			let joinerUserId: string | null = null;
+			if (room.ranked) {
+				try {
+					joinerUserId = await resolveJoinerIdentityWithTimeout(room, socket, playerInfoMessage);
+				} catch (error) {
+					// Fail closed: with the resolver unreachable — erroring, or hung
+					// past the bounded timeout — nobody's identity is proven, so no
+					// seat may change hands. The joiner waits in the stands (a legit
+					// player can simply rejoin once the resolver recovers) instead of
+					// hanging with no response. This catch keeps the resolver failure
+					// off the voided JOIN promise; a later synchronous throw inside
+					// this exclusive section still surfaces to the global handler
+					// (the process survives it and the mutex releases).
+					this.logger.error(`resolveJoinerIdentity failed: ${String(error)}`);
+					this.admitAsSpectator(room, socket, playerInfoMessage.name);
+					return;
+				}
+			}
+			// The shared seam honors the watch stamp: a "w,<roomId>" joiner asked to
+			// spectate, never to take a seat, so a name match must not reconnect it.
+			const playerAlreadyInRoom = findMidDuelReconnectingPlayer({
+				players: room.players,
+				name: playerInfoMessage.name,
+				socket,
+				roomId: room.id,
+				ranked: room.ranked,
+				joinerUserId,
+			});
+
+			if (!(playerAlreadyInRoom instanceof YGOProClient)) {
+				this.admitAsSpectator(room, socket, playerInfoMessage.name);
+				return;
+			}
+
+			room.reconnect(playerAlreadyInRoom, socket);
+
+			playerAlreadyInRoom.sendMessageToClient(room.messageSender.duelStartMessage());
+
+			room.sendDeckCountMessage(playerAlreadyInRoom);
+
+			const hasSelected = this.handResult[playerAlreadyInRoom.team] !== 0;
+			if (playerAlreadyInRoom.isCaptain && !hasSelected) {
+				playerAlreadyInRoom.sendMessageToClient(room.messageSender.selectHandMessage());
+			}
 		});
+	}
 
-		if (!(playerAlreadyInRoom instanceof YGOProClient)) {
-			const spectator = room.createSpectatorUnsafe(socket, playerInfoMessage.name);
-			room.addSpectatorUnsafe(spectator);
-			spectator.sendMessageToClient(room.messageSender.duelStartMessage());
-			room.sendDeckCountMessage(spectator);
-			return;
-		}
-
-		room.reconnect(playerAlreadyInRoom, socket);
-
-		playerAlreadyInRoom.sendMessageToClient(room.messageSender.duelStartMessage());
-
-		room.sendDeckCountMessage(playerAlreadyInRoom);
-
-		const hasSelected = this.handResult[playerAlreadyInRoom.team] !== 0;
-		if (playerAlreadyInRoom.isCaptain && !hasSelected) {
-			playerAlreadyInRoom.sendMessageToClient(room.messageSender.selectHandMessage());
-		}
+	private admitAsSpectator(room: YGOProRoom, socket: ISocket, name: string): void {
+		const spectator = room.createSpectatorUnsafe(socket, name);
+		room.addSpectatorUnsafe(spectator);
+		spectator.sendMessageToClient(room.messageSender.duelStartMessage());
+		room.sendDeckCountMessage(spectator);
 	}
 
 	private handleRPSChoice(message: ClientMessage, room: YGOProRoom, player: YGOProClient): void {

--- a/src/ygopro/room/domain/states/YGOProSideDeckingState.ts
+++ b/src/ygopro/room/domain/states/YGOProSideDeckingState.ts
@@ -15,6 +15,7 @@ import { Logger } from "@shared/logger/domain/Logger";
 import { ISocket } from "../../../../shared/socket/domain/ISocket";
 
 import { YGOProClient } from "../../../client/domain/YGOProClient";
+import { resolveJoinerIdentityWithTimeout } from "../resolveJoinerIdentityWithTimeout";
 import { YGOProRoom } from "../YGOProRoom";
 import { findMidDuelReconnectingPlayer } from "@shared/room/domain/findMidDuelReconnectingPlayer";
 import { config } from "../../../../config";
@@ -190,7 +191,11 @@ export class YGOProSideDeckingState extends YGOProRoomState {
 		}
 	}
 
-	private handleJoin(message: ClientMessage, room: YGOProRoom, socket: ISocket): void {
+	private async handleJoin(
+		message: ClientMessage,
+		room: YGOProRoom,
+		socket: ISocket,
+	): Promise<void> {
 		this.logger.info("handleJoin");
 
 		// Reservation gate: past WAITING, a reserved room keeps its seats closed
@@ -204,31 +209,64 @@ export class YGOProSideDeckingState extends YGOProRoomState {
 		}
 
 		const playerInfoMessage = new PlayerInfoMessage(message.previousMessage, message.data.length);
-		// The shared seam honors the watch stamp: a "w,<roomId>" joiner asked to
-		// spectate, never to take a seat, so a name match must not reconnect it.
-		const playerAlreadyInRoom = findMidDuelReconnectingPlayer({
-			players: room.players,
-			name: playerInfoMessage.name,
-			socket,
-			roomId: room.id,
-			ranked: room.ranked,
+		// The identity resolution awaits the database, yielding the event loop,
+		// so the eligibility check and the seat change must run as ONE exclusive
+		// section — otherwise two concurrent joins could both observe the seat
+		// as reclaimable before either takes it. Same lock (and same
+		// hold-across-resolver idiom) as the WAITING admission.
+		await room.mutex.runExclusive(async () => {
+			// A ranked seat is bound to an account id, so the joiner's identity is
+			// resolved BEFORE the reconnect decision — the display name alone never
+			// identifies anyone. Casual rooms bind by address and liveness instead
+			// and never consult the resolver.
+			let joinerUserId: string | null = null;
+			if (room.ranked) {
+				try {
+					joinerUserId = await resolveJoinerIdentityWithTimeout(room, socket, playerInfoMessage);
+				} catch (error) {
+					// Fail closed: with the resolver unreachable — erroring, or hung
+					// past the bounded timeout — nobody's identity is proven, so no
+					// seat may change hands. The joiner waits in the stands (a legit
+					// player can simply rejoin once the resolver recovers) instead of
+					// hanging with no response. This catch keeps the resolver failure
+					// off the voided JOIN promise; a later synchronous throw inside
+					// this exclusive section still surfaces to the global handler
+					// (the process survives it and the mutex releases).
+					this.logger.error(`resolveJoinerIdentity failed: ${String(error)}`);
+					this.admitAsSpectator(room, socket, playerInfoMessage.name);
+					return;
+				}
+			}
+			// The shared seam honors the watch stamp: a "w,<roomId>" joiner asked to
+			// spectate, never to take a seat, so a name match must not reconnect it.
+			const playerAlreadyInRoom = findMidDuelReconnectingPlayer({
+				players: room.players,
+				name: playerInfoMessage.name,
+				socket,
+				roomId: room.id,
+				ranked: room.ranked,
+				joinerUserId,
+			});
+
+			if (!(playerAlreadyInRoom instanceof YGOProClient)) {
+				this.admitAsSpectator(room, socket, playerInfoMessage.name);
+				return;
+			}
+
+			room.reconnect(playerAlreadyInRoom, socket);
+			playerAlreadyInRoom.sendMessageToClient(room.messageSender.duelStartMessage());
+			if (!playerAlreadyInRoom.isReady) {
+				playerAlreadyInRoom.sendMessageToClient(room.messageSender.changeSideMessage());
+			}
+			playerAlreadyInRoom.clearReconnecting();
 		});
+	}
 
-		if (!(playerAlreadyInRoom instanceof YGOProClient)) {
-			const spectator = room.createSpectatorUnsafe(socket, playerInfoMessage.name);
-			room.addSpectatorUnsafe(spectator);
-			spectator.sendMessageToClient(Buffer.from(new YGOProStocDuelStart().toFullPayload()));
-			spectator.sendMessageToClient(Buffer.from(new YGOProStocWaitingSide().toFullPayload()));
-
-			return;
-		}
-
-		room.reconnect(playerAlreadyInRoom, socket);
-		playerAlreadyInRoom.sendMessageToClient(room.messageSender.duelStartMessage());
-		if (!playerAlreadyInRoom.isReady) {
-			playerAlreadyInRoom.sendMessageToClient(room.messageSender.changeSideMessage());
-		}
-		playerAlreadyInRoom.clearReconnecting();
+	private admitAsSpectator(room: YGOProRoom, socket: ISocket, name: string): void {
+		const spectator = room.createSpectatorUnsafe(socket, name);
+		room.addSpectatorUnsafe(spectator);
+		spectator.sendMessageToClient(Buffer.from(new YGOProStocDuelStart().toFullPayload()));
+		spectator.sendMessageToClient(Buffer.from(new YGOProStocWaitingSide().toFullPayload()));
 	}
 
 	private async handleUpdateDeck(


### PR DESCRIPTION
> Stacked on #344 (`feat/watch-by-id`). Retarget to `main` once #344 merges.

## Why

An adversarial security audit of the room re-entry surfaces (reconnect / spectator / watch) surfaced a **pre-existing** live-seat takeover, plus a missing rate limit on the ygopro join path. This PR closes both. The seat-takeover is not introduced by the watch work — it lives in the legacy by-name reconnect path — but the audit made it concrete, so it is fixed here.

## The vulnerability

In a **ranked External (PIN) room mid-duel**, `findReconnectingPlayer` matched a seated player on **display name only** — the ranked branch deliberately skips the liveness/address checks. Since External and guest sockets are not strong-auth, an attacker (even an unauthenticated guest) who learns a seated player's public nickname could send a JOIN with that name and be reconnected into the **still-connected** victim's seat — taking board, hand, LP and host.

The liveness check was skipped for a real reason: **mobile clients go half-open** (no FIN/RST, `socket.closed` stays false forever), so requiring it locked legitimate players out of their own duel. Re-adding liveness was therefore not an option.

## The fix — bind reconnect to account identity, not the chosen name

`verified` and `external` credentials both carry the same account `userId`. The ranked mid-duel reconnect now grants a seat only when the **joiner's resolved credential userId equals the seat's** — never on name alone.
- A returning mobile PIN player re-sends their PIN → same `userId` → reconnects (half-open irrelevant, no liveness needed). **Mobile reconnection preserved.**
- A stranger knowing only the name resolves to `guest` (or a different account) → denied → lands in the stands.
- Verified/ticket seats remain token-only (unchanged). The casual address-bound branch is byte-for-byte unchanged. The edopro flavor keeps its own `CheckIfUseCanJoin` PIN gate.

## Robustness around the fix
- The joiner identity is resolved **under the room mutex** and the resolve is **bounded (5s) and fails closed to spectator** on error or hang — a slow/hung Postgres can neither seat the wrong player nor hold the room lock indefinitely. (The pre-existing WAITING-admission resolver keeps its unbounded wait — noted as a follow-up, unchanged here.)
- The pairing-reconnect **routing** predicate is split off the seating API, so the identity check cannot be bypassed by a future caller passing the routing mode.

## Rate limit (audit WARNING-2 + PIN-oracle amplification)
The ygopro socket join path had **no** rate limit (the edopro flavor does). Added a **per-IP** limiter at the top of `handleJoinGame` (before strategy resolution and any DB/id work): default **60 joins/60s**, configurable, **fails open** when Redis is unavailable. Express-reconnect (0xfd) is a different frame and is **not** counted, so a flapping mobile client's token reconnects are never throttled. This bounds room-id exhaustion, `w,<id>` room enumeration, and PIN brute-force at the join door. The HTTP rate-limit helper was extracted and shared; deployed HTTP keys/budgets are unchanged.

## Verification
- Full suite: **154 suites / 1526 tests green**; `tsc --noEmit` clean; biome clean.
- Two adversarial review rounds on the fix (identity bypass hunt + a mutex deadlock/reentrancy and rate-limit lockout audit); every finding fixed test-first.

## Deliberately out of scope (documented follow-ups)
- WAITING-admission resolver has the same unbounded-wait class (pre-existing).
- `#`-in-password truncation weakening private rooms (pre-existing, documented).
- Token express-reconnect resolve-before-rotate micro-race (needs the 128-bit secret; latent).
- Watch reject-message oracle (room existence is already public via the lobby).