### PR TITLE
feat(rating): add pure Elo domain math

### DIFF
--- a/src/shared/stats/rating/domain/EloCalculator.test.ts
+++ b/src/shared/stats/rating/domain/EloCalculator.test.ts
@@ -1,0 +1,122 @@
+import { Team } from "@shared/room/Team";
+
+import { EloCalculator } from "./EloCalculator";
+import { Rating } from "./Rating";
+
+describe("EloCalculator", () => {
+	describe("expectedScore()", () => {
+		it("returns 0.5 for both players when ratings are equal", () => {
+			expect(EloCalculator.expectedScore(1000, 1000)).toBeCloseTo(0.5);
+			expect(EloCalculator.expectedScore(1000, 1000)).toBeCloseTo(0.5);
+		});
+
+		it("favors the higher-rated player", () => {
+			const higher = EloCalculator.expectedScore(1400, 1000);
+			const lower = EloCalculator.expectedScore(1000, 1400);
+
+			expect(higher).toBeGreaterThan(0.5);
+			expect(lower).toBeLessThan(0.5);
+			expect(higher + lower).toBeCloseTo(1);
+		});
+	});
+
+	describe("kFactorFor()", () => {
+		it("uses K=40 for a provisional player regardless of rating", () => {
+			const rating = Rating.from({ value: 1050, gamesPlayed: 3, peak: 1050 });
+
+			expect(EloCalculator.kFactorFor(rating)).toBe(40);
+		});
+
+		it("uses K=10 for a non-provisional player at or above 2300, regardless of match count", () => {
+			const rating = Rating.from({ value: 2310, gamesPlayed: 20, peak: 2310 });
+
+			expect(EloCalculator.kFactorFor(rating)).toBe(10);
+		});
+
+		it("uses K=20 for a non-provisional player below 2300", () => {
+			const rating = Rating.from({ value: 1800, gamesPlayed: 20, peak: 1800 });
+
+			expect(EloCalculator.kFactorFor(rating)).toBe(20);
+		});
+	});
+
+	describe("deltasFor() — 1v1", () => {
+		it("applies a K-scaled delta to the winner and the loser using each other's rating", () => {
+			const players = [
+				{ id: "winner-1", team: Team.PLAYER, winner: true },
+				{ id: "loser-1", team: Team.OPPONENT, winner: false },
+			];
+			const ratings = new Map([
+				["winner-1", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+				["loser-1", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+			]);
+
+			const deltas = EloCalculator.deltasFor(players, ratings);
+
+			const winnerDelta = deltas.find((d) => d.userId === "winner-1");
+			const loserDelta = deltas.find((d) => d.userId === "loser-1");
+
+			expect(winnerDelta).toMatchObject({
+				previousRating: 1000,
+				delta: 10,
+				kFactor: 20,
+				opponentRating: 1000,
+			});
+			expect(loserDelta).toMatchObject({
+				previousRating: 1000,
+				delta: -10,
+				kFactor: 20,
+				opponentRating: 1000,
+			});
+		});
+	});
+
+	describe("deltasFor() — 2v2", () => {
+		it("uses the opposing team's average rating as the expected-score opponent", () => {
+			const players = [
+				{ id: "p1", team: Team.PLAYER, winner: true },
+				{ id: "p2", team: Team.PLAYER, winner: true },
+				{ id: "o1", team: Team.OPPONENT, winner: false },
+				{ id: "o2", team: Team.OPPONENT, winner: false },
+			];
+			const ratings = new Map([
+				["p1", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+				["p2", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+				["o1", Rating.from({ value: 1100, gamesPlayed: 20, peak: 1100 })],
+				["o2", Rating.from({ value: 900, gamesPlayed: 20, peak: 900 })],
+			]);
+
+			const deltas = EloCalculator.deltasFor(players, ratings);
+
+			const p1Delta = deltas.find((d) => d.userId === "p1");
+			const o1Delta = deltas.find((d) => d.userId === "o1");
+
+			// Opposing team average for p1/p2 is (1100+900)/2 = 1000 → same as 1v1 at equal rating.
+			expect(p1Delta).toMatchObject({ opponentRating: 1000, delta: 10 });
+			// Opposing team average for o1/o2 is (1000+1000)/2 = 1000; o1 (rated 1100) was
+			// favored to win against that average and lost, so it loses more than 10.
+			expect(o1Delta).toMatchObject({ opponentRating: 1000, delta: -13 });
+		});
+	});
+
+	describe("deltasFor() — rounding drift (D8)", () => {
+		it("computes each player's delta from its own K factor, so a mismatched K (e.g. one provisional) breaks zero-sum symmetry", () => {
+			const players = [
+				{ id: "winner-1", team: Team.PLAYER, winner: true },
+				{ id: "loser-1", team: Team.OPPONENT, winner: false },
+			];
+			const ratings = new Map([
+				["winner-1", Rating.from({ value: 1000, gamesPlayed: 3, peak: 1000 })], // provisional, K=40
+				["loser-1", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })], // established, K=20
+			]);
+
+			const deltas = EloCalculator.deltasFor(players, ratings);
+			const winnerDelta = deltas.find((d) => d.userId === "winner-1")?.delta;
+			const loserDelta = deltas.find((d) => d.userId === "loser-1")?.delta;
+
+			expect(winnerDelta).toBe(20);
+			expect(loserDelta).toBe(-10);
+			expect((winnerDelta as number) + (loserDelta as number)).not.toBe(0);
+		});
+	});
+});

--- a/src/shared/stats/rating/domain/EloCalculator.ts
+++ b/src/shared/stats/rating/domain/EloCalculator.ts
@@ -1,0 +1,77 @@
+import { Team } from "@shared/room/Team";
+
+import { Rating } from "./Rating";
+
+const RATING_SCALE = 400;
+const HIGH_RATED_THRESHOLD = 2300;
+
+const K_PROVISIONAL = 40;
+const K_HIGH_RATED = 10;
+const K_DEFAULT = 20;
+
+export type RatedPlayer = {
+	id: string;
+	team: Team;
+	winner: boolean;
+};
+
+export type RatingDelta = {
+	userId: string;
+	previousRating: number;
+	delta: number;
+	kFactor: number;
+	opponentRating: number;
+};
+
+export class EloCalculator {
+	static expectedScore(playerRating: number, opponentRating: number): number {
+		return 1 / (1 + 10 ** ((opponentRating - playerRating) / RATING_SCALE));
+	}
+
+	static kFactorFor(rating: Rating): number {
+		if (rating.provisional) {
+			return K_PROVISIONAL;
+		}
+		if (rating.value >= HIGH_RATED_THRESHOLD) {
+			return K_HIGH_RATED;
+		}
+
+		return K_DEFAULT;
+	}
+
+	static deltasFor(players: RatedPlayer[], ratings: Map<string, Rating>): RatingDelta[] {
+		return players.map((player) => {
+			const rating = ratings.get(player.id);
+			if (!rating) {
+				throw new Error(`No rating provided for player ${player.id}`);
+			}
+
+			const opponents = players.filter((other) => other.team !== player.team);
+			const opponentAverage = this.averageRatingOf(opponents, ratings);
+			const expected = this.expectedScore(rating.value, opponentAverage);
+			const actual = player.winner ? 1 : 0;
+			const kFactor = this.kFactorFor(rating);
+
+			return {
+				userId: player.id,
+				previousRating: rating.value,
+				delta: Math.round(kFactor * (actual - expected)),
+				kFactor,
+				opponentRating: Math.round(opponentAverage),
+			};
+		});
+	}
+
+	private static averageRatingOf(players: RatedPlayer[], ratings: Map<string, Rating>): number {
+		const total = players.reduce((sum, player) => {
+			const rating = ratings.get(player.id);
+			if (!rating) {
+				throw new Error(`No rating provided for player ${player.id}`);
+			}
+
+			return sum + rating.value;
+		}, 0);
+
+		return total / players.length;
+	}
+}

--- a/src/shared/stats/rating/domain/Rating.test.ts
+++ b/src/shared/stats/rating/domain/Rating.test.ts
@@ -1,0 +1,59 @@
+import { Rating } from "./Rating";
+
+describe("Rating", () => {
+	describe("initialize()", () => {
+		it("starts a new season rating at 1000 with zero games and peak 1000", () => {
+			const rating = Rating.initialize();
+
+			expect(rating.value).toBe(1000);
+			expect(rating.gamesPlayed).toBe(0);
+			expect(rating.peak).toBe(1000);
+		});
+	});
+
+	describe("from()", () => {
+		it("reconstructs a rating from persisted values", () => {
+			const rating = Rating.from({ value: 1450, gamesPlayed: 12, peak: 1500 });
+
+			expect(rating.value).toBe(1450);
+			expect(rating.gamesPlayed).toBe(12);
+			expect(rating.peak).toBe(1500);
+		});
+	});
+
+	describe("provisional", () => {
+		it("is provisional below the 10-game boundary", () => {
+			const rating = Rating.from({ value: 1050, gamesPlayed: 9, peak: 1050 });
+
+			expect(rating.provisional).toBe(true);
+		});
+
+		it("is no longer provisional at exactly 10 games", () => {
+			const rating = Rating.from({ value: 1050, gamesPlayed: 10, peak: 1050 });
+
+			expect(rating.provisional).toBe(false);
+		});
+	});
+
+	describe("applyDelta()", () => {
+		it("increases the value and games played, raising peak when the new value is a new high", () => {
+			const rating = Rating.from({ value: 1000, gamesPlayed: 0, peak: 1000 });
+
+			const updated = rating.applyDelta(40);
+
+			expect(updated.value).toBe(1040);
+			expect(updated.gamesPlayed).toBe(1);
+			expect(updated.peak).toBe(1040);
+		});
+
+		it("keeps peak at its running maximum when a delta lowers the value", () => {
+			const rating = Rating.from({ value: 1500, gamesPlayed: 20, peak: 1500 });
+
+			const updated = rating.applyDelta(-30);
+
+			expect(updated.value).toBe(1470);
+			expect(updated.gamesPlayed).toBe(21);
+			expect(updated.peak).toBe(1500);
+		});
+	});
+});

--- a/src/shared/stats/rating/domain/Rating.ts
+++ b/src/shared/stats/rating/domain/Rating.ts
@@ -1,0 +1,42 @@
+export type RatingProperties = {
+	value: number;
+	gamesPlayed: number;
+	peak: number;
+};
+
+const INITIAL_RATING = 1000;
+const PROVISIONAL_GAMES_THRESHOLD = 10;
+
+export class Rating {
+	public readonly value: number;
+	public readonly gamesPlayed: number;
+	public readonly peak: number;
+
+	private constructor(data: RatingProperties) {
+		this.value = data.value;
+		this.gamesPlayed = data.gamesPlayed;
+		this.peak = data.peak;
+	}
+
+	static initialize(): Rating {
+		return new Rating({ value: INITIAL_RATING, gamesPlayed: 0, peak: INITIAL_RATING });
+	}
+
+	static from(data: RatingProperties): Rating {
+		return new Rating(data);
+	}
+
+	get provisional(): boolean {
+		return this.gamesPlayed < PROVISIONAL_GAMES_THRESHOLD;
+	}
+
+	applyDelta(delta: number): Rating {
+		const value = this.value + delta;
+
+		return new Rating({
+			value,
+			gamesPlayed: this.gamesPlayed + 1,
+			peak: Math.max(this.peak, value),
+		});
+	}
+}


### PR DESCRIPTION
## Summary
- `Rating` value object (value, games played, peak, provisional < 10 games) and pure `EloCalculator`: expected score, dynamic K (40 provisional / 20 default / 10 at ≥2300), per-player deltas, 2v2 via opposing-team average.
- No I/O; fully covered by RED-first unit tests.

Chain 2/3 — stacked on the schema bump PR.
