### PR TITLE
feat(rating): add elo-rating persistence plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ src/plugins/*
 !src/plugins/basic-stats/
 !src/plugins/big-damage-log/
 !src/plugins/unranked-match/
+!src/plugins/elo-rating/

--- a/src/bootstrap/bootstrapPlugins.realPlugins.test.ts
+++ b/src/bootstrap/bootstrapPlugins.realPlugins.test.ts
@@ -30,7 +30,7 @@ describe("bootstrapPlugins against the real src/plugins directory", () => {
 		DuelEventPluginHub.resetInstance();
 	});
 
-	it("skips both stats plugins when ranking is disabled (zero-argument default pluginsRoot)", async () => {
+	it("skips all ranking-gated plugins when ranking is disabled (zero-argument default pluginsRoot)", async () => {
 		const bus = { subscribe: jest.fn() } as unknown as EventBus;
 
 		const report = await bootstrapPlugins(bus, makeDeps(false));
@@ -38,19 +38,21 @@ describe("bootstrapPlugins against the real src/plugins directory", () => {
 		// big-damage-log is ranking-independent and observes duel events only,
 		// so it loads without ever touching the event bus.
 		expect(report.loaded).toEqual(["big-damage-log"]);
-		expect(report.skipped).toEqual(expect.arrayContaining(["basic-stats", "unranked-match"]));
+		expect(report.skipped).toEqual(
+			expect.arrayContaining(["basic-stats", "unranked-match", "elo-rating"]),
+		);
 		expect(bus.subscribe).not.toHaveBeenCalled();
 	});
 
-	it("registers both stats plugins when ranking is enabled (zero-argument default pluginsRoot)", async () => {
+	it("registers all ranking-gated plugins when ranking is enabled (zero-argument default pluginsRoot)", async () => {
 		const bus = { subscribe: jest.fn() } as unknown as EventBus;
 
 		const report = await bootstrapPlugins(bus, makeDeps(true));
 
 		expect(report.loaded).toEqual(
-			expect.arrayContaining(["basic-stats", "big-damage-log", "unranked-match"]),
+			expect.arrayContaining(["basic-stats", "big-damage-log", "unranked-match", "elo-rating"]),
 		);
-		expect(bus.subscribe).toHaveBeenCalledTimes(2);
+		expect(bus.subscribe).toHaveBeenCalledTimes(3);
 	});
 
 	it("issues zero Postgres queries when ranking is disabled and GAME_OVER is published", async () => {

--- a/src/plugins/elo-rating/application/EloRatingCalculator.test.ts
+++ b/src/plugins/elo-rating/application/EloRatingCalculator.test.ts
@@ -1,0 +1,215 @@
+import { mock, MockProxy } from "jest-mock-extended";
+import { Logger } from "@shared/logger/domain/Logger";
+import { Team } from "@shared/room/Team";
+import { Rating } from "@shared/stats/rating/domain/Rating";
+import { RatingRepository, RatingTransaction } from "@shared/stats/rating/domain/RatingRepository";
+import { UserProfileRepository } from "@shared/user-profile/domain/UserProfileRepository";
+import { GameOverDomainEventMother } from "@test-support/mothers/player/GameOverDomainEventMother";
+import { PlayerMother } from "@test-support/mothers/player/PlayerMother";
+import { RatingMother } from "@test-support/mothers/player/RatingMother";
+import { UserProfileMother } from "@test-support/mothers/user-profile/UserProfileMother";
+
+import { config } from "../../../config/index";
+import { EloRatingCalculator } from "./EloRatingCalculator";
+
+describe("EloRatingCalculator", () => {
+	let calculator: EloRatingCalculator;
+	let logger: MockProxy<Logger>;
+	let userProfileRepository: MockProxy<UserProfileRepository>;
+	let ratingRepository: MockProxy<RatingRepository>;
+	let tx: MockProxy<RatingTransaction>;
+
+	beforeEach(() => {
+		logger = mock<Logger>();
+		logger.child.mockReturnValue(logger);
+		userProfileRepository = mock<UserProfileRepository>();
+		ratingRepository = mock<RatingRepository>();
+		tx = mock<RatingTransaction>();
+		tx.insertHistory.mockResolvedValue(true);
+
+		calculator = new EloRatingCalculator(logger, userProfileRepository, ratingRepository);
+	});
+
+	function makeEligibleEvent(overrides?: Parameters<typeof GameOverDomainEventMother.create>[0]) {
+		const winner = PlayerMother.create({ id: "player-1", team: Team.PLAYER, winner: true });
+		const loser = PlayerMother.create({ id: "player-2", team: Team.OPPONENT, winner: false });
+
+		return GameOverDomainEventMother.create({
+			matchId: "match-1",
+			ranked: true,
+			banListName: "TCG",
+			players: [winner.toPresentation(), loser.toPresentation()],
+			...overrides,
+		});
+	}
+
+	describe("S7 — eligible ranked match", () => {
+		it("resolves accounts by player.id only, then writes one applied history row and updated rating per player", async () => {
+			const winnerProfile = UserProfileMother.create({ id: "player-1" });
+			const loserProfile = UserProfileMother.create({ id: "player-2" });
+			userProfileRepository.findById.mockImplementation(async (id) =>
+				id === "player-1" ? winnerProfile : loserProfile,
+			);
+			const ratings = new Map<string, Rating>([
+				["player-1", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+				["player-2", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+			]);
+			ratingRepository.transaction.mockImplementation(async (_userIds, _banList, _season, work) =>
+				work(ratings, tx),
+			);
+
+			await calculator.handle(makeEligibleEvent());
+
+			expect(userProfileRepository.findById).toHaveBeenCalledWith("player-1");
+			expect(userProfileRepository.findById).toHaveBeenCalledWith("player-2");
+			expect(userProfileRepository.findByUsername).not.toHaveBeenCalled();
+
+			expect(ratingRepository.transaction).toHaveBeenCalledWith(
+				expect.arrayContaining(["player-1", "player-2"]),
+				"TCG",
+				config.season,
+				expect.any(Function),
+			);
+
+			expect(tx.insertHistory).toHaveBeenCalledWith(
+				expect.objectContaining({
+					matchId: "match-1",
+					userId: "player-1",
+					banListName: "TCG",
+					season: config.season,
+					kind: "applied",
+					delta: 10,
+				}),
+			);
+			expect(tx.insertHistory).toHaveBeenCalledWith(
+				expect.objectContaining({
+					matchId: "match-1",
+					userId: "player-2",
+					kind: "applied",
+					delta: -10,
+				}),
+			);
+
+			expect(tx.saveRating).toHaveBeenCalledWith(
+				"player-1",
+				"TCG",
+				config.season,
+				Rating.from({ value: 1010, gamesPlayed: 21, peak: 1010 }),
+			);
+			expect(tx.saveRating).toHaveBeenCalledWith(
+				"player-2",
+				"TCG",
+				config.season,
+				Rating.from({ value: 990, gamesPlayed: 21, peak: 1000 }),
+			);
+		});
+	});
+
+	describe("S8 — unranked match excluded", () => {
+		it("writes no rating row when the match is not ranked", async () => {
+			await calculator.handle(makeEligibleEvent({ ranked: false }));
+
+			expect(ratingRepository.transaction).not.toHaveBeenCalled();
+			expect(userProfileRepository.findById).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("S9 — bot participant excluded", () => {
+		it("writes no rating row for the whole match when a participant has no account id (a bot)", async () => {
+			const winner = PlayerMother.create({ id: "player-1", team: Team.PLAYER, winner: true });
+			const bot = PlayerMother.create({ id: null, team: Team.OPPONENT, winner: false });
+			const event = GameOverDomainEventMother.create({
+				matchId: "match-1",
+				ranked: true,
+				banListName: "TCG",
+				players: [winner.toPresentation(), bot.toPresentation()],
+			});
+
+			await calculator.handle(event);
+
+			expect(ratingRepository.transaction).not.toHaveBeenCalled();
+			expect(logger.warn).toHaveBeenCalled();
+		});
+	});
+
+	describe("S10 — N/A banlist excluded", () => {
+		it("writes no rating row when banListName is N/A", async () => {
+			await calculator.handle(makeEligibleEvent({ banListName: "N/A" }));
+
+			expect(ratingRepository.transaction).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("S11 — missing player.id excluded and logged", () => {
+		it("writes no rating row and logs the skip when a player lacks player.id", async () => {
+			const winner = PlayerMother.create({ id: "player-1", team: Team.PLAYER, winner: true });
+			const noId = PlayerMother.create({ id: null, team: Team.OPPONENT, winner: false });
+			const event = GameOverDomainEventMother.create({
+				matchId: "match-1",
+				ranked: true,
+				banListName: "TCG",
+				players: [winner.toPresentation(), noId.toPresentation()],
+			});
+
+			await calculator.handle(event);
+
+			expect(ratingRepository.transaction).not.toHaveBeenCalled();
+			expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("match-1"));
+		});
+	});
+
+	describe("S12 — one row per player per match", () => {
+		it("writes exactly one history row per player, never duplicated", async () => {
+			const winnerProfile = UserProfileMother.create({ id: "player-1" });
+			const loserProfile = UserProfileMother.create({ id: "player-2" });
+			userProfileRepository.findById.mockImplementation(async (id) =>
+				id === "player-1" ? winnerProfile : loserProfile,
+			);
+			const ratings = new Map<string, Rating>([
+				["player-1", RatingMother.create()],
+				["player-2", RatingMother.create()],
+			]);
+			ratingRepository.transaction.mockImplementation(async (_userIds, _banList, _season, work) =>
+				work(ratings, tx),
+			);
+
+			await calculator.handle(makeEligibleEvent());
+
+			expect(tx.insertHistory).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe("S13 — replayed GAME_OVER is a no-op", () => {
+		it("does not update player_ratings when insertHistory reports the row already exists", async () => {
+			const winnerProfile = UserProfileMother.create({ id: "player-1" });
+			const loserProfile = UserProfileMother.create({ id: "player-2" });
+			userProfileRepository.findById.mockImplementation(async (id) =>
+				id === "player-1" ? winnerProfile : loserProfile,
+			);
+			const ratings = new Map<string, Rating>([
+				["player-1", RatingMother.create()],
+				["player-2", RatingMother.create()],
+			]);
+			tx.insertHistory.mockResolvedValue(false);
+			ratingRepository.transaction.mockImplementation(async (_userIds, _banList, _season, work) =>
+				work(ratings, tx),
+			);
+
+			await calculator.handle(makeEligibleEvent());
+
+			expect(tx.insertHistory).toHaveBeenCalledTimes(2);
+			expect(tx.saveRating).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("account resolution gap", () => {
+		it("writes no rating row when a player's account cannot be resolved by id", async () => {
+			userProfileRepository.findById.mockResolvedValue(null);
+
+			await calculator.handle(makeEligibleEvent());
+
+			expect(ratingRepository.transaction).not.toHaveBeenCalled();
+			expect(logger.warn).toHaveBeenCalled();
+		});
+	});
+});

--- a/src/plugins/elo-rating/application/EloRatingCalculator.ts
+++ b/src/plugins/elo-rating/application/EloRatingCalculator.ts
@@ -1,0 +1,96 @@
+import { Logger } from "src/shared/logger/domain/Logger";
+import { EloCalculator, RatedPlayer } from "src/shared/stats/rating/domain/EloCalculator";
+import { Rating } from "src/shared/stats/rating/domain/Rating";
+import { RatingRepository } from "src/shared/stats/rating/domain/RatingRepository";
+import { UserProfileRepository } from "src/shared/user-profile/domain/UserProfileRepository";
+
+import { DomainEventSubscriber } from "../../../shared/event-bus/EventBus";
+import { GameOverDomainEvent } from "../../../shared/room/domain/match/domain/domain-events/GameOverDomainEvent";
+import { config } from "../../../config/index";
+
+export class EloRatingCalculator implements DomainEventSubscriber<GameOverDomainEvent> {
+	static readonly ListenTo = GameOverDomainEvent.DOMAIN_EVENT;
+
+	constructor(
+		private readonly logger: Logger,
+		private readonly userProfileRepository: UserProfileRepository,
+		private readonly ratingRepository: RatingRepository,
+	) {
+		this.logger = logger.child({ file: "EloRatingCalculator" });
+	}
+
+	async handle(event: GameOverDomainEvent): Promise<void> {
+		const { data } = event;
+
+		if (!data.ranked) {
+			this.logger.info(`Skipping rating for match ${data.matchId}: match is not ranked.`);
+
+			return;
+		}
+
+		if (!data.banListName || data.banListName === "N/A") {
+			this.logger.info(`Skipping rating for match ${data.matchId}: no ranked banlist ("N/A").`);
+
+			return;
+		}
+
+		const missingIdCount = data.players.filter((player) => player.id === null).length;
+		if (missingIdCount > 0) {
+			this.logger.warn(
+				`Skipping rating for match ${data.matchId}: ${missingIdCount} participant(s) have no account id (bot or unresolved account).`,
+			);
+
+			return;
+		}
+
+		const playerIds = data.players.map((player) => player.id as string);
+		const accounts = await Promise.all(
+			playerIds.map((id) => this.userProfileRepository.findById(id)),
+		);
+		const unresolvedCount = accounts.filter((account) => account === null).length;
+		if (unresolvedCount > 0) {
+			this.logger.warn(
+				`Skipping rating for match ${data.matchId}: ${unresolvedCount} participant(s) could not be resolved to an account.`,
+			);
+
+			return;
+		}
+
+		const ratedPlayers: RatedPlayer[] = data.players.map((player) => ({
+			id: player.id as string,
+			team: player.team,
+			winner: player.winner,
+		}));
+		const banListName = data.banListName;
+		const season = config.season;
+
+		await this.ratingRepository.transaction(playerIds, banListName, season, async (ratings, tx) => {
+			const deltas = EloCalculator.deltasFor(ratedPlayers, ratings);
+
+			for (const delta of deltas) {
+				const inserted = await tx.insertHistory({
+					matchId: data.matchId,
+					userId: delta.userId,
+					banListName,
+					season,
+					kind: "applied",
+					previousRating: delta.previousRating,
+					delta: delta.delta,
+					kFactor: delta.kFactor,
+					opponentRating: delta.opponentRating,
+				});
+
+				if (!inserted) {
+					this.logger.info(
+						`Rating for match ${data.matchId} / user ${delta.userId} was already recorded — replay no-op.`,
+					);
+					continue;
+				}
+
+				const currentRating = ratings.get(delta.userId) as Rating;
+				const updatedRating = currentRating.applyDelta(delta.delta);
+				await tx.saveRating(delta.userId, banListName, season, updatedRating);
+			}
+		});
+	}
+}

--- a/src/plugins/elo-rating/index.test.ts
+++ b/src/plugins/elo-rating/index.test.ts
@@ -1,0 +1,38 @@
+import { EventBus } from "@shared/event-bus/EventBus";
+import { AppConfig, PluginDeps } from "@shared/plugin/ServerPlugin";
+import { GameOverDomainEvent } from "@shared/room/domain/match/domain/domain-events/GameOverDomainEvent";
+import { LoggerMock } from "@test-support/mocks/logger/LoggerMock";
+import { expectServerPluginContract } from "@test-support/plugin/expectServerPluginContract";
+
+import plugin from "./index";
+
+function makeConfig(rankingEnabled: boolean): AppConfig {
+	return { ranking: { enabled: rankingEnabled } } as unknown as AppConfig;
+}
+
+function makeDeps(): PluginDeps {
+	return { logger: new LoggerMock(), config: makeConfig(true) };
+}
+
+describe("elo-rating plugin", () => {
+	it("conforms to the ServerPlugin contract", () => {
+		expectServerPluginContract(plugin);
+	});
+
+	it("is disabled when ranking is disabled", () => {
+		expect(plugin.enabled(makeConfig(false))).toBe(false);
+	});
+
+	it("is enabled when ranking is enabled", () => {
+		expect(plugin.enabled(makeConfig(true))).toBe(true);
+	});
+
+	it("subscribes to GAME_OVER exactly once on register", () => {
+		const bus = { subscribe: jest.fn() } as unknown as EventBus;
+
+		plugin.register(bus, makeDeps());
+
+		expect(bus.subscribe).toHaveBeenCalledTimes(1);
+		expect(bus.subscribe).toHaveBeenCalledWith(GameOverDomainEvent.DOMAIN_EVENT, expect.anything());
+	});
+});

--- a/src/plugins/elo-rating/index.ts
+++ b/src/plugins/elo-rating/index.ts
@@ -1,0 +1,26 @@
+import { EventBus } from "@shared/event-bus/EventBus";
+import { PluginDeps, ServerPlugin } from "@shared/plugin/ServerPlugin";
+import { RatingPostgresRepository } from "@shared/stats/rating/infrastructure/RatingPostgresRepository";
+import { UserProfilePostgresRepository } from "@shared/user-profile/infrastructure/postgres/UserProfilePostgresRepository";
+
+import { EloRatingCalculator } from "./application/EloRatingCalculator";
+
+// Ranking-gated: with config.ranking.enabled === false this plugin never
+// registers, so no Postgres query is issued on GAME_OVER (see spec
+// "Ranking-gated persistence plugins").
+const plugin: ServerPlugin = {
+	name: "elo-rating",
+	enabled: (config) => config.ranking.enabled,
+	register: (bus: EventBus, deps: PluginDeps) => {
+		bus.subscribe(
+			EloRatingCalculator.ListenTo,
+			new EloRatingCalculator(
+				deps.logger,
+				new UserProfilePostgresRepository(),
+				new RatingPostgresRepository(),
+			),
+		);
+	},
+};
+
+export default plugin;

--- a/src/shared/stats/rating/domain/EloCalculator.test.ts
+++ b/src/shared/stats/rating/domain/EloCalculator.test.ts
@@ -1,0 +1,122 @@
+import { Team } from "@shared/room/Team";
+
+import { EloCalculator } from "./EloCalculator";
+import { Rating } from "./Rating";
+
+describe("EloCalculator", () => {
+	describe("expectedScore()", () => {
+		it("returns 0.5 for both players when ratings are equal", () => {
+			expect(EloCalculator.expectedScore(1000, 1000)).toBeCloseTo(0.5);
+			expect(EloCalculator.expectedScore(1000, 1000)).toBeCloseTo(0.5);
+		});
+
+		it("favors the higher-rated player", () => {
+			const higher = EloCalculator.expectedScore(1400, 1000);
+			const lower = EloCalculator.expectedScore(1000, 1400);
+
+			expect(higher).toBeGreaterThan(0.5);
+			expect(lower).toBeLessThan(0.5);
+			expect(higher + lower).toBeCloseTo(1);
+		});
+	});
+
+	describe("kFactorFor()", () => {
+		it("uses K=40 for a provisional player regardless of rating", () => {
+			const rating = Rating.from({ value: 1050, gamesPlayed: 3, peak: 1050 });
+
+			expect(EloCalculator.kFactorFor(rating)).toBe(40);
+		});
+
+		it("uses K=10 for a non-provisional player at or above 2300, regardless of match count", () => {
+			const rating = Rating.from({ value: 2310, gamesPlayed: 20, peak: 2310 });
+
+			expect(EloCalculator.kFactorFor(rating)).toBe(10);
+		});
+
+		it("uses K=20 for a non-provisional player below 2300", () => {
+			const rating = Rating.from({ value: 1800, gamesPlayed: 20, peak: 1800 });
+
+			expect(EloCalculator.kFactorFor(rating)).toBe(20);
+		});
+	});
+
+	describe("deltasFor() — 1v1", () => {
+		it("applies a K-scaled delta to the winner and the loser using each other's rating", () => {
+			const players = [
+				{ id: "winner-1", team: Team.PLAYER, winner: true },
+				{ id: "loser-1", team: Team.OPPONENT, winner: false },
+			];
+			const ratings = new Map([
+				["winner-1", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+				["loser-1", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+			]);
+
+			const deltas = EloCalculator.deltasFor(players, ratings);
+
+			const winnerDelta = deltas.find((d) => d.userId === "winner-1");
+			const loserDelta = deltas.find((d) => d.userId === "loser-1");
+
+			expect(winnerDelta).toMatchObject({
+				previousRating: 1000,
+				delta: 10,
+				kFactor: 20,
+				opponentRating: 1000,
+			});
+			expect(loserDelta).toMatchObject({
+				previousRating: 1000,
+				delta: -10,
+				kFactor: 20,
+				opponentRating: 1000,
+			});
+		});
+	});
+
+	describe("deltasFor() — 2v2", () => {
+		it("uses the opposing team's average rating as the expected-score opponent", () => {
+			const players = [
+				{ id: "p1", team: Team.PLAYER, winner: true },
+				{ id: "p2", team: Team.PLAYER, winner: true },
+				{ id: "o1", team: Team.OPPONENT, winner: false },
+				{ id: "o2", team: Team.OPPONENT, winner: false },
+			];
+			const ratings = new Map([
+				["p1", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+				["p2", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+				["o1", Rating.from({ value: 1100, gamesPlayed: 20, peak: 1100 })],
+				["o2", Rating.from({ value: 900, gamesPlayed: 20, peak: 900 })],
+			]);
+
+			const deltas = EloCalculator.deltasFor(players, ratings);
+
+			const p1Delta = deltas.find((d) => d.userId === "p1");
+			const o1Delta = deltas.find((d) => d.userId === "o1");
+
+			// Opposing team average for p1/p2 is (1100+900)/2 = 1000 → same as 1v1 at equal rating.
+			expect(p1Delta).toMatchObject({ opponentRating: 1000, delta: 10 });
+			// Opposing team average for o1/o2 is (1000+1000)/2 = 1000; o1 (rated 1100) was
+			// favored to win against that average and lost, so it loses more than 10.
+			expect(o1Delta).toMatchObject({ opponentRating: 1000, delta: -13 });
+		});
+	});
+
+	describe("deltasFor() — rounding drift (D8)", () => {
+		it("computes each player's delta from its own K factor, so a mismatched K (e.g. one provisional) breaks zero-sum symmetry", () => {
+			const players = [
+				{ id: "winner-1", team: Team.PLAYER, winner: true },
+				{ id: "loser-1", team: Team.OPPONENT, winner: false },
+			];
+			const ratings = new Map([
+				["winner-1", Rating.from({ value: 1000, gamesPlayed: 3, peak: 1000 })], // provisional, K=40
+				["loser-1", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })], // established, K=20
+			]);
+
+			const deltas = EloCalculator.deltasFor(players, ratings);
+			const winnerDelta = deltas.find((d) => d.userId === "winner-1")?.delta;
+			const loserDelta = deltas.find((d) => d.userId === "loser-1")?.delta;
+
+			expect(winnerDelta).toBe(20);
+			expect(loserDelta).toBe(-10);
+			expect((winnerDelta as number) + (loserDelta as number)).not.toBe(0);
+		});
+	});
+});

--- a/src/shared/stats/rating/domain/EloCalculator.ts
+++ b/src/shared/stats/rating/domain/EloCalculator.ts
@@ -1,0 +1,77 @@
+import { Team } from "@shared/room/Team";
+
+import { Rating } from "./Rating";
+
+const RATING_SCALE = 400;
+const HIGH_RATED_THRESHOLD = 2300;
+
+const K_PROVISIONAL = 40;
+const K_HIGH_RATED = 10;
+const K_DEFAULT = 20;
+
+export type RatedPlayer = {
+	id: string;
+	team: Team;
+	winner: boolean;
+};
+
+export type RatingDelta = {
+	userId: string;
+	previousRating: number;
+	delta: number;
+	kFactor: number;
+	opponentRating: number;
+};
+
+export class EloCalculator {
+	static expectedScore(playerRating: number, opponentRating: number): number {
+		return 1 / (1 + 10 ** ((opponentRating - playerRating) / RATING_SCALE));
+	}
+
+	static kFactorFor(rating: Rating): number {
+		if (rating.provisional) {
+			return K_PROVISIONAL;
+		}
+		if (rating.value >= HIGH_RATED_THRESHOLD) {
+			return K_HIGH_RATED;
+		}
+
+		return K_DEFAULT;
+	}
+
+	static deltasFor(players: RatedPlayer[], ratings: Map<string, Rating>): RatingDelta[] {
+		return players.map((player) => {
+			const rating = ratings.get(player.id);
+			if (!rating) {
+				throw new Error(`No rating provided for player ${player.id}`);
+			}
+
+			const opponents = players.filter((other) => other.team !== player.team);
+			const opponentAverage = this.averageRatingOf(opponents, ratings);
+			const expected = this.expectedScore(rating.value, opponentAverage);
+			const actual = player.winner ? 1 : 0;
+			const kFactor = this.kFactorFor(rating);
+
+			return {
+				userId: player.id,
+				previousRating: rating.value,
+				delta: Math.round(kFactor * (actual - expected)),
+				kFactor,
+				opponentRating: Math.round(opponentAverage),
+			};
+		});
+	}
+
+	private static averageRatingOf(players: RatedPlayer[], ratings: Map<string, Rating>): number {
+		const total = players.reduce((sum, player) => {
+			const rating = ratings.get(player.id);
+			if (!rating) {
+				throw new Error(`No rating provided for player ${player.id}`);
+			}
+
+			return sum + rating.value;
+		}, 0);
+
+		return total / players.length;
+	}
+}

--- a/src/shared/stats/rating/domain/Rating.test.ts
+++ b/src/shared/stats/rating/domain/Rating.test.ts
@@ -1,0 +1,59 @@
+import { Rating } from "./Rating";
+
+describe("Rating", () => {
+	describe("initialize()", () => {
+		it("starts a new season rating at 1000 with zero games and peak 1000", () => {
+			const rating = Rating.initialize();
+
+			expect(rating.value).toBe(1000);
+			expect(rating.gamesPlayed).toBe(0);
+			expect(rating.peak).toBe(1000);
+		});
+	});
+
+	describe("from()", () => {
+		it("reconstructs a rating from persisted values", () => {
+			const rating = Rating.from({ value: 1450, gamesPlayed: 12, peak: 1500 });
+
+			expect(rating.value).toBe(1450);
+			expect(rating.gamesPlayed).toBe(12);
+			expect(rating.peak).toBe(1500);
+		});
+	});
+
+	describe("provisional", () => {
+		it("is provisional below the 10-game boundary", () => {
+			const rating = Rating.from({ value: 1050, gamesPlayed: 9, peak: 1050 });
+
+			expect(rating.provisional).toBe(true);
+		});
+
+		it("is no longer provisional at exactly 10 games", () => {
+			const rating = Rating.from({ value: 1050, gamesPlayed: 10, peak: 1050 });
+
+			expect(rating.provisional).toBe(false);
+		});
+	});
+
+	describe("applyDelta()", () => {
+		it("increases the value and games played, raising peak when the new value is a new high", () => {
+			const rating = Rating.from({ value: 1000, gamesPlayed: 0, peak: 1000 });
+
+			const updated = rating.applyDelta(40);
+
+			expect(updated.value).toBe(1040);
+			expect(updated.gamesPlayed).toBe(1);
+			expect(updated.peak).toBe(1040);
+		});
+
+		it("keeps peak at its running maximum when a delta lowers the value", () => {
+			const rating = Rating.from({ value: 1500, gamesPlayed: 20, peak: 1500 });
+
+			const updated = rating.applyDelta(-30);
+
+			expect(updated.value).toBe(1470);
+			expect(updated.gamesPlayed).toBe(21);
+			expect(updated.peak).toBe(1500);
+		});
+	});
+});

--- a/src/shared/stats/rating/domain/Rating.ts
+++ b/src/shared/stats/rating/domain/Rating.ts
@@ -1,0 +1,42 @@
+export type RatingProperties = {
+	value: number;
+	gamesPlayed: number;
+	peak: number;
+};
+
+const INITIAL_RATING = 1000;
+const PROVISIONAL_GAMES_THRESHOLD = 10;
+
+export class Rating {
+	public readonly value: number;
+	public readonly gamesPlayed: number;
+	public readonly peak: number;
+
+	private constructor(data: RatingProperties) {
+		this.value = data.value;
+		this.gamesPlayed = data.gamesPlayed;
+		this.peak = data.peak;
+	}
+
+	static initialize(): Rating {
+		return new Rating({ value: INITIAL_RATING, gamesPlayed: 0, peak: INITIAL_RATING });
+	}
+
+	static from(data: RatingProperties): Rating {
+		return new Rating(data);
+	}
+
+	get provisional(): boolean {
+		return this.gamesPlayed < PROVISIONAL_GAMES_THRESHOLD;
+	}
+
+	applyDelta(delta: number): Rating {
+		const value = this.value + delta;
+
+		return new Rating({
+			value,
+			gamesPlayed: this.gamesPlayed + 1,
+			peak: Math.max(this.peak, value),
+		});
+	}
+}

--- a/src/shared/stats/rating/domain/RatingRepository.ts
+++ b/src/shared/stats/rating/domain/RatingRepository.ts
@@ -1,0 +1,45 @@
+import { Rating } from "./Rating";
+
+export type RatingHistoryEntry = {
+	matchId: string;
+	userId: string;
+	banListName: string;
+	season: number;
+	kind: "applied" | "reversal";
+	previousRating: number;
+	delta: number;
+	kFactor: number;
+	opponentRating: number;
+};
+
+/**
+ * Write-side handle bound to one open transaction. All operations happen
+ * against the row-locked ratings acquired by `RatingRepository.transaction`.
+ */
+export interface RatingTransaction {
+	/**
+	 * Inserts one rating_history row. Returns false instead of throwing when
+	 * the row already exists for (matchId, userId, kind) — the UNIQUE
+	 * constraint makes a replayed write a no-op the caller can detect and
+	 * skip projecting.
+	 */
+	insertHistory(entry: RatingHistoryEntry): Promise<boolean>;
+
+	/** Upserts the derived player_ratings projection for one player. */
+	saveRating(userId: string, banListName: string, season: number, rating: Rating): Promise<void>;
+}
+
+export interface RatingRepository {
+	/**
+	 * Locks every `player_ratings` row for the given users (ordered by
+	 * user_id ascending to avoid lock-order deadlocks between concurrent
+	 * matches sharing a player), defaulting missing rows to a fresh
+	 * season-start rating, then runs `work` inside that same transaction.
+	 */
+	transaction<T>(
+		userIds: string[],
+		banListName: string,
+		season: number,
+		work: (ratings: Map<string, Rating>, tx: RatingTransaction) => Promise<T>,
+	): Promise<T>;
+}

--- a/src/shared/stats/rating/infrastructure/RatingPostgresRepository.test.ts
+++ b/src/shared/stats/rating/infrastructure/RatingPostgresRepository.test.ts
@@ -29,9 +29,10 @@ describe("RatingPostgresRepository", () => {
 
 	describe("transaction()", () => {
 		it("locks player_ratings rows ordered by user_id ascending, defaulting missing rows to a fresh rating", async () => {
-			manager.query.mockResolvedValueOnce([
-				{ userId: "user-b", rating: 1200, gamesPlayed: 15, peak: 1250 },
-			]);
+			manager.query
+				.mockResolvedValueOnce([]) // advisory lock user-a
+				.mockResolvedValueOnce([]) // advisory lock user-b
+				.mockResolvedValueOnce([{ userId: "user-b", rating: 1200, gamesPlayed: 15, peak: 1250 }]); // FOR UPDATE row lock
 
 			const result = await repository.transaction(
 				["user-b", "user-a"],
@@ -55,6 +56,42 @@ describe("RatingPostgresRepository", () => {
 				Rating.from({ value: 1200, gamesPlayed: 15, peak: 1250 }),
 			);
 			expect(result.get("user-a")).toEqual(Rating.initialize());
+		});
+
+		it("acquires a pg_advisory_xact_lock per participant, ordered by user_id ascending, before the FOR UPDATE row lock", async () => {
+			manager.query.mockResolvedValue([]);
+
+			await repository.transaction(["user-b", "user-a"], "TCG", 5, async (ratings) => ratings);
+
+			const calls = manager.query.mock.calls;
+
+			expect(calls[0]).toEqual([
+				expect.stringContaining("pg_advisory_xact_lock"),
+				["user-a", "TCG", 5],
+			]);
+			expect(calls[1]).toEqual([
+				expect.stringContaining("pg_advisory_xact_lock"),
+				["user-b", "TCG", 5],
+			]);
+			expect(calls[2][0]).toEqual(expect.stringContaining("FOR UPDATE"));
+
+			// hashtextextended over a length-prefixed encoding stays injective even
+			// when a field's value contains the delimiter, unlike a plain "a|b|c" join.
+			expect(calls[0][0]).toEqual(expect.stringContaining("hashtextextended"));
+			expect(calls[0][0]).toEqual(expect.stringContaining("length($2)"));
+		});
+
+		it("skips advisory locking entirely when there are no participants", async () => {
+			manager.query.mockResolvedValueOnce([]); // FOR UPDATE row lock
+
+			await repository.transaction([], "TCG", 5, async (ratings) => ratings);
+
+			expect(manager.query).toHaveBeenCalledTimes(1);
+			expect(manager.query).toHaveBeenCalledWith(expect.stringContaining("FOR UPDATE"), [
+				"TCG",
+				5,
+				[],
+			]);
 		});
 	});
 

--- a/src/shared/stats/rating/infrastructure/RatingPostgresRepository.test.ts
+++ b/src/shared/stats/rating/infrastructure/RatingPostgresRepository.test.ts
@@ -1,0 +1,132 @@
+import { Rating } from "../domain/Rating";
+import { RatingPostgresRepository } from "./RatingPostgresRepository";
+import { dataSource } from "../../../../evolution-types/src/data-source";
+
+// This suite mocks TypeORM's `dataSource` (same pattern as
+// `UserProfilePostgresRepository.test.ts`): the repo has no real-Postgres
+// jest harness. It proves the exact SQL/parameter contract issued to
+// Postgres (ON CONFLICT target, row-lock ordering) but not that Postgres
+// enforces it — the UNIQUE(match_id, user_id, kind) index this adapter
+// targets is created and exercised by the CreateRatingTables migration.
+jest.mock("../../../../evolution-types/src/data-source", () => ({
+	dataSource: {
+		transaction: jest.fn(),
+	},
+}));
+
+describe("RatingPostgresRepository", () => {
+	let repository: RatingPostgresRepository;
+	let manager: { query: jest.Mock };
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		manager = { query: jest.fn() };
+		(dataSource.transaction as jest.Mock).mockImplementation(
+			async (work: (manager: unknown) => Promise<unknown>) => work(manager),
+		);
+		repository = new RatingPostgresRepository();
+	});
+
+	describe("transaction()", () => {
+		it("locks player_ratings rows ordered by user_id ascending, defaulting missing rows to a fresh rating", async () => {
+			manager.query.mockResolvedValueOnce([
+				{ userId: "user-b", rating: 1200, gamesPlayed: 15, peak: 1250 },
+			]);
+
+			const result = await repository.transaction(
+				["user-b", "user-a"],
+				"TCG",
+				5,
+				async (ratings) => ratings,
+			);
+
+			expect(manager.query).toHaveBeenCalledWith(expect.stringContaining("ORDER BY user_id ASC"), [
+				"TCG",
+				5,
+				["user-a", "user-b"],
+			]);
+			expect(manager.query).toHaveBeenCalledWith(expect.stringContaining("FOR UPDATE"), [
+				"TCG",
+				5,
+				["user-a", "user-b"],
+			]);
+
+			expect(result.get("user-b")).toEqual(
+				Rating.from({ value: 1200, gamesPlayed: 15, peak: 1250 }),
+			);
+			expect(result.get("user-a")).toEqual(Rating.initialize());
+		});
+	});
+
+	describe("RatingTransaction.insertHistory()", () => {
+		it("returns true when the ON CONFLICT DO NOTHING insert produced a row", async () => {
+			manager.query
+				.mockResolvedValueOnce([]) // lock query
+				.mockResolvedValueOnce([{ id: "history-row-1" }]); // insert
+
+			let inserted = false;
+			await repository.transaction([], "TCG", 5, async (_ratings, tx) => {
+				inserted = await tx.insertHistory({
+					matchId: "match-1",
+					userId: "user-a",
+					banListName: "TCG",
+					season: 5,
+					kind: "applied",
+					previousRating: 1000,
+					delta: 10,
+					kFactor: 20,
+					opponentRating: 1000,
+				});
+			});
+
+			expect(inserted).toBe(true);
+			expect(manager.query).toHaveBeenCalledWith(
+				expect.stringContaining("ON CONFLICT (match_id, user_id, kind) DO NOTHING"),
+				["match-1", "user-a", "TCG", 5, "applied", 1000, 10, 20, 1000],
+			);
+		});
+
+		it("returns false — a no-op — when the row already exists for (match_id, user_id, kind)", async () => {
+			manager.query
+				.mockResolvedValueOnce([]) // lock query
+				.mockResolvedValueOnce([]); // conflicting insert returns no rows
+
+			let inserted = true;
+			await repository.transaction([], "TCG", 5, async (_ratings, tx) => {
+				inserted = await tx.insertHistory({
+					matchId: "match-1",
+					userId: "user-a",
+					banListName: "TCG",
+					season: 5,
+					kind: "applied",
+					previousRating: 1000,
+					delta: 10,
+					kFactor: 20,
+					opponentRating: 1000,
+				});
+			});
+
+			expect(inserted).toBe(false);
+		});
+	});
+
+	describe("RatingTransaction.saveRating()", () => {
+		it("upserts the player_ratings projection keyed by (user_id, ban_list_name, season)", async () => {
+			manager.query.mockResolvedValueOnce([]); // lock query
+
+			await repository.transaction([], "TCG", 5, async (_ratings, tx) => {
+				await tx.saveRating(
+					"user-a",
+					"TCG",
+					5,
+					Rating.from({ value: 1010, gamesPlayed: 21, peak: 1010 }),
+				);
+			});
+
+			expect(manager.query).toHaveBeenCalledWith(
+				expect.stringContaining("ON CONFLICT (user_id, ban_list_name, season)"),
+				["user-a", "TCG", 5, 1010, 21, 1010],
+			);
+		});
+	});
+});

--- a/src/shared/stats/rating/infrastructure/RatingPostgresRepository.ts
+++ b/src/shared/stats/rating/infrastructure/RatingPostgresRepository.ts
@@ -1,0 +1,112 @@
+import { EntityManager } from "typeorm";
+
+import { Rating } from "../domain/Rating";
+import {
+	RatingHistoryEntry,
+	RatingRepository,
+	RatingTransaction,
+} from "../domain/RatingRepository";
+import { dataSource } from "../../../../evolution-types/src/data-source";
+
+const LOCK_RATINGS_QUERY = `
+	SELECT user_id AS "userId", rating, games_played AS "gamesPlayed", peak
+	FROM player_ratings
+	WHERE ban_list_name = $1 AND season = $2 AND user_id = ANY($3)
+	ORDER BY user_id ASC
+	FOR UPDATE
+`;
+
+const INSERT_HISTORY_QUERY = `
+	INSERT INTO rating_history (match_id, user_id, ban_list_name, season, kind, previous_rating, delta, k_factor, opponent_rating)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+	ON CONFLICT (match_id, user_id, kind) DO NOTHING
+	RETURNING id
+`;
+
+const UPSERT_RATING_QUERY = `
+	INSERT INTO player_ratings (user_id, ban_list_name, season, rating, games_played, peak)
+	VALUES ($1, $2, $3, $4, $5, $6)
+	ON CONFLICT (user_id, ban_list_name, season)
+	DO UPDATE SET rating = EXCLUDED.rating, games_played = EXCLUDED.games_played, peak = EXCLUDED.peak, updated_at = now()
+`;
+
+type PlayerRatingRow = { userId: string; rating: number; gamesPlayed: number; peak: number };
+
+export class RatingPostgresRepository implements RatingRepository {
+	async transaction<T>(
+		userIds: string[],
+		banListName: string,
+		season: number,
+		work: (ratings: Map<string, Rating>, tx: RatingTransaction) => Promise<T>,
+	): Promise<T> {
+		return dataSource.transaction(async (manager) => {
+			const ratings = await this.lockRatings(manager, userIds, banListName, season);
+			const tx = new RatingPostgresTransaction(manager);
+
+			return work(ratings, tx);
+		});
+	}
+
+	private async lockRatings(
+		manager: EntityManager,
+		userIds: string[],
+		banListName: string,
+		season: number,
+	): Promise<Map<string, Rating>> {
+		const orderedIds = [...userIds].sort();
+		const rows: PlayerRatingRow[] = await manager.query(LOCK_RATINGS_QUERY, [
+			banListName,
+			season,
+			orderedIds,
+		]);
+
+		const ratings = new Map<string, Rating>();
+		for (const userId of orderedIds) {
+			const row = rows.find((item) => item.userId === userId);
+			ratings.set(
+				userId,
+				row
+					? Rating.from({ value: row.rating, gamesPlayed: row.gamesPlayed, peak: row.peak })
+					: Rating.initialize(),
+			);
+		}
+
+		return ratings;
+	}
+}
+
+class RatingPostgresTransaction implements RatingTransaction {
+	constructor(private readonly manager: EntityManager) {}
+
+	async insertHistory(entry: RatingHistoryEntry): Promise<boolean> {
+		const rows = await this.manager.query(INSERT_HISTORY_QUERY, [
+			entry.matchId,
+			entry.userId,
+			entry.banListName,
+			entry.season,
+			entry.kind,
+			entry.previousRating,
+			entry.delta,
+			entry.kFactor,
+			entry.opponentRating,
+		]);
+
+		return rows.length > 0;
+	}
+
+	async saveRating(
+		userId: string,
+		banListName: string,
+		season: number,
+		rating: Rating,
+	): Promise<void> {
+		await this.manager.query(UPSERT_RATING_QUERY, [
+			userId,
+			banListName,
+			season,
+			rating.value,
+			rating.gamesPlayed,
+			rating.peak,
+		]);
+	}
+}

--- a/src/shared/stats/rating/infrastructure/RatingPostgresRepository.ts
+++ b/src/shared/stats/rating/infrastructure/RatingPostgresRepository.ts
@@ -8,6 +8,13 @@ import {
 } from "../domain/RatingRepository";
 import { dataSource } from "../../../../evolution-types/src/data-source";
 
+// Encodes (user_id, ban_list_name, season) with a length-prefixed field so
+// the concatenation stays injective even when a value contains the
+// delimiter — a plain "a|b|c" join can collide for two different inputs.
+const ADVISORY_LOCK_QUERY = `
+	SELECT pg_advisory_xact_lock(hashtextextended($1 || ':' || length($2)::text || ':' || $2 || ':' || $3, 0))
+`;
+
 const LOCK_RATINGS_QUERY = `
 	SELECT user_id AS "userId", rating, games_played AS "gamesPlayed", peak
 	FROM player_ratings
@@ -40,20 +47,42 @@ export class RatingPostgresRepository implements RatingRepository {
 		work: (ratings: Map<string, Rating>, tx: RatingTransaction) => Promise<T>,
 	): Promise<T> {
 		return dataSource.transaction(async (manager) => {
-			const ratings = await this.lockRatings(manager, userIds, banListName, season);
+			const orderedIds = [...userIds].sort();
+
+			await this.acquireParticipantLocks(manager, orderedIds, banListName, season);
+			const ratings = await this.lockRatings(manager, orderedIds, banListName, season);
 			const tx = new RatingPostgresTransaction(manager);
 
 			return work(ratings, tx);
 		});
 	}
 
+	// SELECT ... FOR UPDATE cannot lock a row that does not exist yet: for a
+	// player's first rated match in a (ban list, season), two concurrent
+	// GAME_OVER transactions can both see "no row", both default to
+	// Rating.initialize(), and the later UPSERT overwrites the earlier one —
+	// the projection drops a match while rating_history keeps both. A
+	// session-scoped advisory lock per participant, acquired sequentially in
+	// the same sorted order used below for the row lock, closes that window
+	// before either transaction reads anything and keeps the lock order
+	// consistent across matches that share a player, avoiding deadlocks.
+	private async acquireParticipantLocks(
+		manager: EntityManager,
+		orderedIds: string[],
+		banListName: string,
+		season: number,
+	): Promise<void> {
+		for (const userId of orderedIds) {
+			await manager.query(ADVISORY_LOCK_QUERY, [userId, banListName, season]);
+		}
+	}
+
 	private async lockRatings(
 		manager: EntityManager,
-		userIds: string[],
+		orderedIds: string[],
 		banListName: string,
 		season: number,
 	): Promise<Map<string, Rating>> {
-		const orderedIds = [...userIds].sort();
 		const rows: PlayerRatingRow[] = await manager.query(LOCK_RATINGS_QUERY, [
 			banListName,
 			season,

--- a/src/test-support/mothers/player/RatingMother.ts
+++ b/src/test-support/mothers/player/RatingMother.ts
@@ -1,0 +1,13 @@
+import { faker } from "@faker-js/faker";
+import { Rating, RatingProperties } from "@shared/stats/rating/domain/Rating";
+
+export class RatingMother {
+	static create(params?: Partial<RatingProperties>): Rating {
+		return Rating.from({
+			value: faker.number.int({ min: 800, max: 2400 }),
+			gamesPlayed: faker.number.int({ min: 10, max: 100 }),
+			peak: faker.number.int({ min: 800, max: 2400 }),
+			...params,
+		});
+	}
+}


### PR DESCRIPTION
## Summary
- New `elo-rating` plugin (mirrors `basic-stats`): subscribes to `GAME_OVER` from both pipelines, gated on `config.ranking.enabled`.
- Eligibility: ranked matches where every player carries an id (resolution by id, never username), banlist set and not "N/A"; bots never rate.
- `RatingPostgresRepository`: single transaction, per-participant `pg_advisory_xact_lock` (injective length-prefixed key, sorted order) before `FOR UPDATE`, history inserted first with `ON CONFLICT (match_id, user_id, kind) DO NOTHING` so replayed events are no-ops.
- Reviewed via blind dual adversarial review; the first-rated-match lost-update race found there is fixed here (advisory locks cover rows that don't exist yet).

Chain 3/3 — stacked on the math PR. Full suite: 1578 tests green, lint clean.
