### PR TITLE
feat(room): match lifecycle hooks with bounded announce capability

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -108,6 +108,50 @@ const plugin: ServerPlugin = {
 
 Payloads are identical regardless of room type — both pipelines decode to the same events, with team resolution handled server-side. Delivery is **observe-only**: a plugin cannot block, delay or mutate anything in the duel.
 
+### Match lifecycle hooks — a match started, or is about to end
+
+Declare `lifecycleHooks` to observe when a match starts (first game only) or is about to finalize, on **both** server pipelines, without touching a socket or the room:
+
+```typescript
+import { MatchLifecycleHook } from "@shared/room/domain/lifecycle/MatchLifecycleHook";
+
+const myHook: MatchLifecycleHook = {
+	name: "my-hook",
+	onMatchStarted: async (ctx) => {
+		// ctx: { roomId, ranked, banListName, season, players, announce }
+		ctx.announce("hello");
+	},
+	onMatchEnding: async (ctx) => {
+		// awaited before socket teardown — see the time budget below
+	},
+};
+
+const plugin: ServerPlugin = {
+	name: "my-plugin",
+	enabled: () => true,
+	lifecycleHooks: [myHook],
+	register: () => {
+		// delivery happens through lifecycleHooks above — no bus subscription needed
+	},
+};
+
+export default plugin;
+```
+
+| Field | Meaning |
+|-------|---------|
+| `onMatchStarted` | Optional. Fired once, fire-and-forget, from the shared duel-start hook when a match's first game begins. |
+| `onMatchEnding` | Optional. Fired once, awaited, right before either pipeline tears down sockets for a finished match. |
+| `MatchContext.announce(message)` | The only client-facing capability a hook gets — broadcasts one system chat line to every current client in the room. A hook never receives the room, a client, or a socket. |
+
+**Isolation and budgets:**
+
+- One hook throwing or rejecting never affects another hook or the match — each hook is called in its own try/catch and a failure is logged as a warning naming the hook and the phase.
+- `onMatchStarted` is fire-and-forget: the caller never waits on it, so a slow hook cannot delay anything a player sees.
+- `onMatchEnding` is awaited, but bounded by a total time budget of **1500 ms** (`MATCH_ENDING_HOOK_BUDGET_MS`, `src/shared/room/application/lifecycle/MatchLifecycleHooks.ts`) across every registered ending hook combined. The budget exists so a slow or hanging hook — a stalled query, an unresponsive downstream call — can never leave a player's socket dangling past match end; 1500 ms is short enough that no player waits noticeably longer for the duel-end sequence, long enough for a normal unlocked read plus a broadcast. Exceeding it logs a warning and lets teardown proceed; hooks already in flight are not cancelled, only no longer waited on.
+
+`bootstrapPlugins()` registers every `lifecycleHooks` entry into the shared `MatchLifecycleHooks` runner right after a plugin's own `register()` call succeeds — a plugin never touches the runner directly.
+
 ## Isolation: what happens when a plugin misbehaves
 
 Duel events reach plugins through a bounded, ordered, per-room queue (`DuelEventPluginHub`). Enqueueing is the only work on the duel's path; each plugin's queue drains off it, one event at a time, preserving per-room order. Two detectors feed one consequence — **the plugin is disconnected from that room** with an error naming the plugin and the reason:

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -108,9 +108,9 @@ const plugin: ServerPlugin = {
 
 Payloads are identical regardless of room type — both pipelines decode to the same events, with team resolution handled server-side. Delivery is **observe-only**: a plugin cannot block, delay or mutate anything in the duel.
 
-### Match lifecycle hooks — a match started, or is about to end
+### Match lifecycle hooks — a match started, is about to end, or its room closed
 
-Declare `lifecycleHooks` to observe when a match starts (first game only) or is about to finalize, on **both** server pipelines, without touching a socket or the room:
+Declare `lifecycleHooks` to observe when a match starts (first game only), is about to finalize, or its room has closed, on **both** server pipelines, without touching a socket or the room:
 
 ```typescript
 import { MatchLifecycleHook } from "@shared/room/domain/lifecycle/MatchLifecycleHook";
@@ -118,11 +118,14 @@ import { MatchLifecycleHook } from "@shared/room/domain/lifecycle/MatchLifecycle
 const myHook: MatchLifecycleHook = {
 	name: "my-hook",
 	onMatchStarted: async (ctx) => {
-		// ctx: { roomId, ranked, banListName, season, players, announce }
+		// ctx: { roomId, matchId, ranked, banListName, season, players, announce }
 		ctx.announce("hello");
 	},
 	onMatchEnding: async (ctx) => {
 		// awaited before socket teardown — see the time budget below
+	},
+	onRoomClosed: async (ctx) => {
+		// ctx: { roomId, matchId } — release any per-match state here, see below
 	},
 };
 
@@ -142,12 +145,20 @@ export default plugin;
 |-------|---------|
 | `onMatchStarted` | Optional. Fired once, fire-and-forget, from the shared duel-start hook when a match's first game begins. |
 | `onMatchEnding` | Optional. Fired once, awaited, right before either pipeline tears down sockets for a finished match. |
+| `onRoomClosed` | Optional. Fired once, fire-and-forget, from the single teardown chokepoint of each pipeline — every time a room is torn down, whether the match reached a clean end or not. |
 | `MatchContext.announce(message)` | The only client-facing capability a hook gets — broadcasts one system chat line to every current client in the room. A hook never receives the room, a client, or a socket. |
+| `MatchContext.matchId` / `RoomClosedContext.matchId` | The match's own unique identity. Unlike `roomId` — a small numeric slot the server reuses across unrelated matches once freed — `matchId` never repeats. |
+
+**Per-match state must be keyed by `matchId`, released in `onRoomClosed`:**
+
+A room's numeric id is a small, reused key space, not a match identity — the same `roomId` will eventually host an unrelated later match. A hook that caches anything from `onMatchStarted` to consume later (e.g. a start-of-match snapshot, read again in `onMatchEnding`) must key that cache by `matchId`, never by `roomId`, or a later match reusing the same room can silently read another match's leftover state.
+
+`onMatchEnding` alone is not a sufficient release point either: a match can end without ever reaching it — a player disconnecting mid-duel, a matchmaking abort, an error-fallback teardown. `onRoomClosed` fires from the room-deletion chokepoint of **both** pipelines (`RoomList.deleteRoom` for edopro, `FinalizeYGOProRoom.run` for ygopro) for every teardown, clean or not — so it is the only point a hook can rely on to release per-match state unconditionally. `onMatchEnding`'s own cleanup (if any) stays as a fast path; `onRoomClosed` is the guarantee.
 
 **Isolation and budgets:**
 
 - One hook throwing or rejecting never affects another hook or the match — each hook is called in its own try/catch and a failure is logged as a warning naming the hook and the phase.
-- `onMatchStarted` is fire-and-forget: the caller never waits on it, so a slow hook cannot delay anything a player sees.
+- `onMatchStarted` and `onRoomClosed` are both fire-and-forget: the caller never waits on either, so a slow hook cannot delay anything a player sees.
 - `onMatchEnding` is awaited, but bounded by a total time budget of **1500 ms** (`MATCH_ENDING_HOOK_BUDGET_MS`, `src/shared/room/application/lifecycle/MatchLifecycleHooks.ts`) across every registered ending hook combined. The budget exists so a slow or hanging hook — a stalled query, an unresponsive downstream call — can never leave a player's socket dangling past match end; 1500 ms is short enough that no player waits noticeably longer for the duel-end sequence, long enough for a normal unlocked read plus a broadcast. Exceeding it logs a warning and lets teardown proceed; hooks already in flight are not cancelled, only no longer waited on.
 
 `bootstrapPlugins()` registers every `lifecycleHooks` entry into the shared `MatchLifecycleHooks` runner right after a plugin's own `register()` call succeeds — a plugin never touches the runner directly.

--- a/src/bootstrap/bootstrapPlugins.test.ts
+++ b/src/bootstrap/bootstrapPlugins.test.ts
@@ -21,6 +21,13 @@ import {
 	receivedEvents,
 	resetReceivedEvents,
 } from "@test-support/plugin-fixtures/duel-events/subscriber/capture";
+import {
+	resetStartedCalls,
+	startedCalls,
+} from "@test-support/plugin-fixtures/lifecycle-hooks/provider/capture";
+
+import { container } from "@shared/dependency-injection";
+import { MatchLifecycleHooks } from "@shared/room/application/lifecycle/MatchLifecycleHooks";
 
 import { bootstrapPlugins } from "./bootstrapPlugins";
 
@@ -103,6 +110,32 @@ describe("bootstrapPlugins", () => {
 
 		expect(report.loaded).toEqual(["dup-name"]);
 		expect(report.skipped).toContain("duplicate-name-b");
+	});
+
+	describe("lifecycle-hooks root", () => {
+		const lifecycleHooksRoot = path.join(FIXTURES_ROOT, "lifecycle-hooks");
+
+		beforeEach(() => {
+			resetStartedCalls();
+		});
+
+		it("registers a plugin-declared lifecycleHooks entry into the shared MatchLifecycleHooks runner", async () => {
+			const report = await bootstrapPlugins(bus, deps, lifecycleHooksRoot);
+			expect(report.loaded).toContain("lifecycle-provider");
+			expect(startedCalls).toEqual([]);
+
+			container.get(MatchLifecycleHooks).runStarted({
+				roomId: 1,
+				ranked: true,
+				banListName: "TCG",
+				season: 1,
+				players: [],
+				announce: () => undefined,
+			});
+			await new Promise((resolve) => setImmediate(resolve));
+
+			expect(startedCalls).toEqual(["started"]);
+		});
 	});
 
 	describe("duel-events root", () => {

--- a/src/bootstrap/bootstrapPlugins.test.ts
+++ b/src/bootstrap/bootstrapPlugins.test.ts
@@ -126,6 +126,7 @@ describe("bootstrapPlugins", () => {
 
 			container.get(MatchLifecycleHooks).runStarted({
 				roomId: 1,
+				matchId: "match-1",
 				ranked: true,
 				banListName: "TCG",
 				season: 1,

--- a/src/bootstrap/bootstrapPlugins.ts
+++ b/src/bootstrap/bootstrapPlugins.ts
@@ -1,9 +1,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
+import { container } from "@shared/dependency-injection";
 import { EventBus } from "@shared/event-bus/EventBus";
 import { isServerPlugin } from "@shared/plugin/isServerPlugin";
 import { DuelEventSubscriptions, PluginDeps, ServerPlugin } from "@shared/plugin/ServerPlugin";
+import { MatchLifecycleHooks } from "@shared/room/application/lifecycle/MatchLifecycleHooks";
 import { DuelEventPluginHub } from "@shared/room/domain/duel-events/DuelEventPluginHub";
 
 export interface PluginBootstrapReport {
@@ -108,6 +110,12 @@ export async function bootstrapPlugins(
 			}
 
 			await candidate.register(bus, depsFor(candidate, deps));
+
+			if (candidate.lifecycleHooks) {
+				const hooks = container.get(MatchLifecycleHooks);
+				candidate.lifecycleHooks.forEach((hook) => hooks.register(hook));
+			}
+
 			report.loaded.push(candidate.name);
 		} catch (error) {
 			deps.logger.error(error instanceof Error ? error : String(error), { dirName });

--- a/src/plugins/elo-rating/application/EloRatingCalculator.test.ts
+++ b/src/plugins/elo-rating/application/EloRatingCalculator.test.ts
@@ -202,6 +202,43 @@ describe("EloRatingCalculator", () => {
 		});
 	});
 
+	describe("G5 — eligibility log strings are pinned across the gate refactor", () => {
+		it("logs the unranked skip reason verbatim", async () => {
+			await calculator.handle(makeEligibleEvent({ ranked: false, matchId: "match-1" }));
+
+			expect(logger.info).toHaveBeenCalledWith(
+				expect.stringContaining("Skipping rating for match match-1: match is not ranked."),
+			);
+		});
+
+		it("logs the no-ranked-banlist skip reason verbatim", async () => {
+			await calculator.handle(makeEligibleEvent({ banListName: "N/A", matchId: "match-1" }));
+
+			expect(logger.info).toHaveBeenCalledWith(
+				expect.stringContaining('Skipping rating for match match-1: no ranked banlist ("N/A").'),
+			);
+		});
+
+		it("logs the missing-account-id skip reason verbatim, including the count", async () => {
+			const winner = PlayerMother.create({ id: "player-1", team: Team.PLAYER, winner: true });
+			const noId = PlayerMother.create({ id: null, team: Team.OPPONENT, winner: false });
+			const event = GameOverDomainEventMother.create({
+				matchId: "match-1",
+				ranked: true,
+				banListName: "TCG",
+				players: [winner.toPresentation(), noId.toPresentation()],
+			});
+
+			await calculator.handle(event);
+
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining(
+					"Skipping rating for match match-1: 1 participant(s) have no account id (bot or unresolved account).",
+				),
+			);
+		});
+	});
+
 	describe("account resolution gap", () => {
 		it("writes no rating row when a player's account cannot be resolved by id", async () => {
 			userProfileRepository.findById.mockResolvedValue(null);

--- a/src/plugins/elo-rating/application/EloRatingCalculator.ts
+++ b/src/plugins/elo-rating/application/EloRatingCalculator.ts
@@ -2,6 +2,7 @@ import { Logger } from "src/shared/logger/domain/Logger";
 import { EloCalculator, RatedPlayer } from "src/shared/stats/rating/domain/EloCalculator";
 import { Rating } from "src/shared/stats/rating/domain/Rating";
 import { RatingRepository } from "src/shared/stats/rating/domain/RatingRepository";
+import { evaluateRatingEligibility } from "src/shared/stats/rating/domain/RatingEligibility";
 import { UserProfileRepository } from "src/shared/user-profile/domain/UserProfileRepository";
 
 import { DomainEventSubscriber } from "../../../shared/event-bus/EventBus";
@@ -22,28 +23,27 @@ export class EloRatingCalculator implements DomainEventSubscriber<GameOverDomain
 	async handle(event: GameOverDomainEvent): Promise<void> {
 		const { data } = event;
 
-		if (!data.ranked) {
-			this.logger.info(`Skipping rating for match ${data.matchId}: match is not ranked.`);
+		const eligibility = evaluateRatingEligibility({
+			ranked: data.ranked,
+			banListName: data.banListName,
+			players: data.players,
+		});
+
+		if (!eligibility.eligible) {
+			if (eligibility.reason === "unranked") {
+				this.logger.info(`Skipping rating for match ${data.matchId}: match is not ranked.`);
+			} else if (eligibility.reason === "no-ranked-banlist") {
+				this.logger.info(`Skipping rating for match ${data.matchId}: no ranked banlist ("N/A").`);
+			} else {
+				this.logger.warn(
+					`Skipping rating for match ${data.matchId}: ${eligibility.missingIdCount} participant(s) have no account id (bot or unresolved account).`,
+				);
+			}
 
 			return;
 		}
 
-		if (!data.banListName || data.banListName === "N/A") {
-			this.logger.info(`Skipping rating for match ${data.matchId}: no ranked banlist ("N/A").`);
-
-			return;
-		}
-
-		const missingIdCount = data.players.filter((player) => player.id === null).length;
-		if (missingIdCount > 0) {
-			this.logger.warn(
-				`Skipping rating for match ${data.matchId}: ${missingIdCount} participant(s) have no account id (bot or unresolved account).`,
-			);
-
-			return;
-		}
-
-		const playerIds = data.players.map((player) => player.id as string);
+		const playerIds = eligibility.players.map((player) => player.id);
 		const accounts = await Promise.all(
 			playerIds.map((id) => this.userProfileRepository.findById(id)),
 		);
@@ -56,12 +56,12 @@ export class EloRatingCalculator implements DomainEventSubscriber<GameOverDomain
 			return;
 		}
 
-		const ratedPlayers: RatedPlayer[] = data.players.map((player) => ({
-			id: player.id as string,
+		const ratedPlayers: RatedPlayer[] = eligibility.players.map((player) => ({
+			id: player.id,
 			team: player.team,
 			winner: player.winner,
 		}));
-		const banListName = data.banListName;
+		const banListName = eligibility.banListName;
 		const season = config.season;
 
 		await this.ratingRepository.transaction(playerIds, banListName, season, async (ratings, tx) => {

--- a/src/shared/dependency-injection/index.test.ts
+++ b/src/shared/dependency-injection/index.test.ts
@@ -1,6 +1,7 @@
 import "reflect-metadata";
 
 import { EventBus } from "../event-bus/EventBus";
+import { MatchLifecycleHooks } from "../room/application/lifecycle/MatchLifecycleHooks";
 
 import { container } from "./index";
 
@@ -13,5 +14,15 @@ describe("dependency-injection container", () => {
 
 	it("resolves EventBus as a singleton", () => {
 		expect(container.get(EventBus)).toBe(container.get(EventBus));
+	});
+
+	it("resolves MatchLifecycleHooks via the useFactory registration with no diod resolution error", () => {
+		const runner = container.get(MatchLifecycleHooks);
+
+		expect(runner).toBeInstanceOf(MatchLifecycleHooks);
+	});
+
+	it("resolves MatchLifecycleHooks as a singleton", () => {
+		expect(container.get(MatchLifecycleHooks)).toBe(container.get(MatchLifecycleHooks));
 	});
 });

--- a/src/shared/dependency-injection/index.ts
+++ b/src/shared/dependency-injection/index.ts
@@ -2,11 +2,18 @@ import { ContainerBuilder } from "diod";
 
 import LoggerFactory from "../logger/infrastructure/LoggerFactory";
 import { EventBus } from "../event-bus/EventBus";
+import { MatchLifecycleHooks } from "../room/application/lifecycle/MatchLifecycleHooks";
 
 const builder = new ContainerBuilder();
 builder
 	.register(EventBus)
 	.useFactory(() => new EventBus(LoggerFactory.getLogger({ file: "EventBus" })))
+	.asSingleton();
+builder
+	.register(MatchLifecycleHooks)
+	.useFactory(
+		() => new MatchLifecycleHooks(LoggerFactory.getLogger({ file: "MatchLifecycleHooks" })),
+	)
 	.asSingleton();
 
 export const container = builder.build();

--- a/src/shared/plugin/ServerPlugin.ts
+++ b/src/shared/plugin/ServerPlugin.ts
@@ -2,6 +2,7 @@ import { EventBus } from "@shared/event-bus/EventBus";
 import { Logger } from "@shared/logger/domain/Logger";
 import { DuelEventPayloads } from "@shared/room/domain/duel-events/DuelEventDispatcher";
 import { DuelEventKind } from "@shared/room/domain/duel-events/DuelEvents";
+import { MatchLifecycleHook } from "@shared/room/domain/lifecycle/MatchLifecycleHook";
 
 import { config } from "src/config";
 
@@ -47,4 +48,12 @@ export interface ServerPlugin {
 	 * DuelEventPluginHub).
 	 */
 	readonly duelEvents?: readonly DuelEventKind[];
+
+	/**
+	 * Match lifecycle hooks this plugin provides. bootstrapPlugins() registers
+	 * every entry into the shared MatchLifecycleHooks runner right after this
+	 * plugin's register() call succeeds — the plugin never touches the runner
+	 * itself. Omit it and the plugin observes no match lifecycle events.
+	 */
+	readonly lifecycleHooks?: readonly MatchLifecycleHook[];
 }

--- a/src/shared/plugin/isServerPlugin.test.ts
+++ b/src/shared/plugin/isServerPlugin.test.ts
@@ -29,6 +29,33 @@ describe("isServerPlugin", () => {
 		expect(isServerPlugin({ ...validPlugin, register: async () => undefined })).toBe(true);
 	});
 
+	describe("lifecycleHooks declaration", () => {
+		it("returns true when lifecycleHooks is absent", () => {
+			expect(isServerPlugin(validPlugin)).toBe(true);
+		});
+
+		it("returns true for an array of conformant hook shapes", () => {
+			expect(
+				isServerPlugin({
+					...validPlugin,
+					lifecycleHooks: [{ name: "rating-announcer" }],
+				}),
+			).toBe(true);
+		});
+
+		it("returns true for an empty declaration", () => {
+			expect(isServerPlugin({ ...validPlugin, lifecycleHooks: [] })).toBe(true);
+		});
+
+		it.each([
+			["not an array", { name: "x" }],
+			["an entry with no name", [{}]],
+			["an entry whose name is not a string", [{ name: 42 }]],
+		])("returns false when lifecycleHooks is %s", (_description, lifecycleHooks) => {
+			expect(isServerPlugin({ ...validPlugin, lifecycleHooks })).toBe(false);
+		});
+	});
+
 	describe("duelEvents declaration", () => {
 		it("returns true when duelEvents is absent", () => {
 			expect(isServerPlugin(validPlugin)).toBe(true);

--- a/src/shared/plugin/isServerPlugin.ts
+++ b/src/shared/plugin/isServerPlugin.ts
@@ -15,7 +15,8 @@ export function isServerPlugin(value: unknown): value is ServerPlugin {
 		typeof candidate.name === "string" &&
 		typeof candidate.enabled === "function" &&
 		typeof candidate.register === "function" &&
-		hasValidDuelEventsDeclaration(candidate.duelEvents)
+		hasValidDuelEventsDeclaration(candidate.duelEvents) &&
+		hasValidLifecycleHooksDeclaration(candidate.lifecycleHooks)
 	);
 }
 
@@ -27,5 +28,21 @@ function hasValidDuelEventsDeclaration(duelEvents: unknown): boolean {
 	return (
 		Array.isArray(duelEvents) &&
 		duelEvents.every((kind) => (DUEL_EVENT_KINDS as readonly string[]).includes(kind as string))
+	);
+}
+
+function hasValidLifecycleHooksDeclaration(lifecycleHooks: unknown): boolean {
+	if (lifecycleHooks === undefined) {
+		return true;
+	}
+
+	return (
+		Array.isArray(lifecycleHooks) &&
+		lifecycleHooks.every(
+			(hook) =>
+				typeof hook === "object" &&
+				hook !== null &&
+				typeof (hook as Record<string, unknown>).name === "string",
+		)
 	);
 }

--- a/src/shared/room/application/lifecycle/MatchLifecycleHooks.test.ts
+++ b/src/shared/room/application/lifecycle/MatchLifecycleHooks.test.ts
@@ -197,6 +197,43 @@ describe("MatchLifecycleHooks", () => {
 
 			await expect(runner.runEnding(makeContext())).resolves.toBeUndefined();
 		});
+
+		it("does not warn about the budget when every hook finishes well within it", async () => {
+			jest.useFakeTimers();
+			try {
+				const fastHook: MatchLifecycleHook = {
+					name: "fast",
+					onMatchEnding: async () => undefined,
+				};
+				const runner = new MatchLifecycleHooks(logger);
+				runner.register(fastHook);
+
+				await runner.runEnding(makeContext());
+				await jest.advanceTimersByTimeAsync(MATCH_ENDING_HOOK_BUDGET_MS);
+
+				expect(logger.warn).not.toHaveBeenCalled();
+			} finally {
+				jest.useRealTimers();
+			}
+		});
+
+		it("clears the budget timer once the hooks settle, leaving no dangling timer", async () => {
+			jest.useFakeTimers();
+			try {
+				const fastHook: MatchLifecycleHook = {
+					name: "fast",
+					onMatchEnding: async () => undefined,
+				};
+				const runner = new MatchLifecycleHooks(logger);
+				runner.register(fastHook);
+
+				await runner.runEnding(makeContext());
+
+				expect(jest.getTimerCount()).toBe(0);
+			} finally {
+				jest.useRealTimers();
+			}
+		});
 	});
 
 	describe("runClosed", () => {

--- a/src/shared/room/application/lifecycle/MatchLifecycleHooks.test.ts
+++ b/src/shared/room/application/lifecycle/MatchLifecycleHooks.test.ts
@@ -1,0 +1,192 @@
+import { Team } from "@shared/room/Team";
+import { MatchContext, MatchLifecycleHook } from "@shared/room/domain/lifecycle/MatchLifecycleHook";
+import { LoggerMock } from "@test-support/mocks/logger/LoggerMock";
+
+import { MATCH_ENDING_HOOK_BUDGET_MS, MatchLifecycleHooks } from "./MatchLifecycleHooks";
+
+function makeContext(): MatchContext {
+	return {
+		roomId: 1234,
+		ranked: true,
+		banListName: "TCG",
+		season: 5,
+		players: [
+			{ id: "player-1", team: Team.PLAYER, name: "Diango", winner: false },
+			{ id: "player-2", team: Team.OPPONENT, name: "Rival", winner: false },
+		],
+		announce: jest.fn(),
+	};
+}
+
+function flushMicrotasks(): Promise<void> {
+	return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("MatchLifecycleHooks", () => {
+	let logger: LoggerMock;
+
+	beforeEach(() => {
+		logger = new LoggerMock();
+		jest.spyOn(logger, "warn");
+	});
+
+	describe("runStarted", () => {
+		it("is fire-and-forget: returns before a slow hook resolves", async () => {
+			let resolved = false;
+			const slowHook: MatchLifecycleHook = {
+				name: "slow",
+				onMatchStarted: () =>
+					new Promise((resolve) =>
+						setTimeout(() => {
+							resolved = true;
+							resolve();
+						}, 50),
+					),
+			};
+			const runner = new MatchLifecycleHooks(logger);
+			runner.register(slowHook);
+
+			const returnValue = runner.runStarted(makeContext());
+
+			expect(returnValue).toBeUndefined();
+			expect(resolved).toBe(false);
+		});
+
+		it("isolates one throwing hook from the others — every registered hook still runs", async () => {
+			const calls: string[] = [];
+			const brokenHook: MatchLifecycleHook = {
+				name: "broken",
+				onMatchStarted: async () => {
+					calls.push("broken");
+					throw new Error("boom");
+				},
+			};
+			const healthyHook: MatchLifecycleHook = {
+				name: "healthy",
+				onMatchStarted: async () => {
+					calls.push("healthy");
+				},
+			};
+			const runner = new MatchLifecycleHooks(logger);
+			runner.register(brokenHook);
+			runner.register(healthyHook);
+
+			runner.runStarted(makeContext());
+			await flushMicrotasks();
+
+			expect(calls).toEqual(["broken", "healthy"]);
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining("broken"),
+				expect.anything(),
+			);
+		});
+
+		it("skips hooks that declare no onMatchStarted", async () => {
+			const endOnly: MatchLifecycleHook = {
+				name: "end-only",
+				onMatchEnding: async () => undefined,
+			};
+			const runner = new MatchLifecycleHooks(logger);
+			runner.register(endOnly);
+
+			expect(() => runner.runStarted(makeContext())).not.toThrow();
+			await flushMicrotasks();
+		});
+	});
+
+	describe("runEnding", () => {
+		it("awaits every registered hook when all finish within budget", async () => {
+			const calls: string[] = [];
+			const hookA: MatchLifecycleHook = {
+				name: "a",
+				onMatchEnding: async () => {
+					calls.push("a");
+				},
+			};
+			const hookB: MatchLifecycleHook = {
+				name: "b",
+				onMatchEnding: async () => {
+					calls.push("b");
+				},
+			};
+			const runner = new MatchLifecycleHooks(logger);
+			runner.register(hookA);
+			runner.register(hookB);
+
+			await runner.runEnding(makeContext());
+
+			expect(calls).toEqual(["a", "b"]);
+		});
+
+		it("isolates one throwing hook from the others", async () => {
+			const calls: string[] = [];
+			const brokenHook: MatchLifecycleHook = {
+				name: "broken",
+				onMatchEnding: async () => {
+					calls.push("broken");
+					throw new Error("boom");
+				},
+			};
+			const healthyHook: MatchLifecycleHook = {
+				name: "healthy",
+				onMatchEnding: async () => {
+					calls.push("healthy");
+				},
+			};
+			const runner = new MatchLifecycleHooks(logger);
+			runner.register(brokenHook);
+			runner.register(healthyHook);
+
+			await expect(runner.runEnding(makeContext())).resolves.toBeUndefined();
+
+			expect(calls).toEqual(["broken", "healthy"]);
+		});
+
+		it("never blocks teardown past the total time budget, even if a hook is still pending", async () => {
+			jest.useFakeTimers();
+			try {
+				let hookSettled = false;
+				const slowHook: MatchLifecycleHook = {
+					name: "slow",
+					onMatchEnding: () =>
+						new Promise((resolve) => {
+							setTimeout(() => {
+								hookSettled = true;
+								resolve();
+							}, MATCH_ENDING_HOOK_BUDGET_MS * 10);
+						}),
+				};
+				const runner = new MatchLifecycleHooks(logger);
+				runner.register(slowHook);
+
+				const runEnding = runner.runEnding(makeContext());
+				let settled = false;
+				void runEnding.then(() => {
+					settled = true;
+				});
+
+				await jest.advanceTimersByTimeAsync(MATCH_ENDING_HOOK_BUDGET_MS);
+
+				expect(settled).toBe(true);
+				expect(hookSettled).toBe(false);
+				expect(logger.warn).toHaveBeenCalledWith(
+					expect.stringContaining("budget"),
+					expect.anything(),
+				);
+			} finally {
+				jest.useRealTimers();
+			}
+		});
+
+		it("resolves immediately when no hook declares onMatchEnding", async () => {
+			const startOnly: MatchLifecycleHook = {
+				name: "start-only",
+				onMatchStarted: async () => undefined,
+			};
+			const runner = new MatchLifecycleHooks(logger);
+			runner.register(startOnly);
+
+			await expect(runner.runEnding(makeContext())).resolves.toBeUndefined();
+		});
+	});
+});

--- a/src/shared/room/application/lifecycle/MatchLifecycleHooks.test.ts
+++ b/src/shared/room/application/lifecycle/MatchLifecycleHooks.test.ts
@@ -1,5 +1,9 @@
 import { Team } from "@shared/room/Team";
-import { MatchContext, MatchLifecycleHook } from "@shared/room/domain/lifecycle/MatchLifecycleHook";
+import {
+	MatchContext,
+	MatchLifecycleHook,
+	RoomClosedContext,
+} from "@shared/room/domain/lifecycle/MatchLifecycleHook";
 import { LoggerMock } from "@test-support/mocks/logger/LoggerMock";
 
 import { MATCH_ENDING_HOOK_BUDGET_MS, MatchLifecycleHooks } from "./MatchLifecycleHooks";
@@ -7,6 +11,7 @@ import { MATCH_ENDING_HOOK_BUDGET_MS, MatchLifecycleHooks } from "./MatchLifecyc
 function makeContext(): MatchContext {
 	return {
 		roomId: 1234,
+		matchId: "match-1234-a",
 		ranked: true,
 		banListName: "TCG",
 		season: 5,
@@ -16,6 +21,10 @@ function makeContext(): MatchContext {
 		],
 		announce: jest.fn(),
 	};
+}
+
+function makeRoomClosedContext(): RoomClosedContext {
+	return { roomId: 1234, matchId: "match-1234-a" };
 }
 
 function flushMicrotasks(): Promise<void> {
@@ -187,6 +196,87 @@ describe("MatchLifecycleHooks", () => {
 			runner.register(startOnly);
 
 			await expect(runner.runEnding(makeContext())).resolves.toBeUndefined();
+		});
+	});
+
+	describe("runClosed", () => {
+		it("is fire-and-forget: returns before a slow hook resolves", async () => {
+			let resolved = false;
+			const slowHook: MatchLifecycleHook = {
+				name: "slow",
+				onRoomClosed: () =>
+					new Promise((resolve) =>
+						setTimeout(() => {
+							resolved = true;
+							resolve();
+						}, 50),
+					),
+			};
+			const runner = new MatchLifecycleHooks(logger);
+			runner.register(slowHook);
+
+			const returnValue = runner.runClosed(makeRoomClosedContext());
+
+			expect(returnValue).toBeUndefined();
+			expect(resolved).toBe(false);
+		});
+
+		it("isolates one throwing hook from the others — every registered hook still runs", async () => {
+			const calls: string[] = [];
+			const brokenHook: MatchLifecycleHook = {
+				name: "broken",
+				onRoomClosed: async () => {
+					calls.push("broken");
+					throw new Error("boom");
+				},
+			};
+			const healthyHook: MatchLifecycleHook = {
+				name: "healthy",
+				onRoomClosed: async () => {
+					calls.push("healthy");
+				},
+			};
+			const runner = new MatchLifecycleHooks(logger);
+			runner.register(brokenHook);
+			runner.register(healthyHook);
+
+			runner.runClosed(makeRoomClosedContext());
+			await flushMicrotasks();
+
+			expect(calls).toEqual(["broken", "healthy"]);
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining("broken"),
+				expect.anything(),
+			);
+		});
+
+		it("skips hooks that declare no onRoomClosed", async () => {
+			const startOnly: MatchLifecycleHook = {
+				name: "start-only",
+				onMatchStarted: async () => undefined,
+			};
+			const runner = new MatchLifecycleHooks(logger);
+			runner.register(startOnly);
+
+			expect(() => runner.runClosed(makeRoomClosedContext())).not.toThrow();
+			await flushMicrotasks();
+		});
+
+		it("passes roomId and matchId through to the hook", async () => {
+			const received: RoomClosedContext[] = [];
+			const hook: MatchLifecycleHook = {
+				name: "recorder",
+				onRoomClosed: async (ctx) => {
+					received.push(ctx);
+				},
+			};
+			const runner = new MatchLifecycleHooks(logger);
+			runner.register(hook);
+
+			runner.runClosed({ roomId: 777, matchId: "match-777-z" });
+			await flushMicrotasks();
+
+			expect(received).toEqual([{ roomId: 777, matchId: "match-777-z" }]);
 		});
 	});
 });

--- a/src/shared/room/application/lifecycle/MatchLifecycleHooks.ts
+++ b/src/shared/room/application/lifecycle/MatchLifecycleHooks.ts
@@ -40,7 +40,8 @@ export class MatchLifecycleHooks {
 		}
 
 		const work = Promise.allSettled(ending.map((hook) => this.invoke(hook, "onMatchEnding", ctx)));
-		await Promise.race([work, this.budget(ctx)]);
+		const { promise: budget, clear: clearBudget } = this.budget(ctx);
+		await Promise.race([work.then(clearBudget), budget]);
 	}
 
 	/**
@@ -70,9 +71,10 @@ export class MatchLifecycleHooks {
 		}
 	}
 
-	private budget(ctx: MatchContext): Promise<void> {
-		return new Promise((resolve) => {
-			const timer = setTimeout(() => {
+	private budget(ctx: MatchContext): { promise: Promise<void>; clear: () => void } {
+		let timer: NodeJS.Timeout;
+		const promise = new Promise<void>((resolve) => {
+			timer = setTimeout(() => {
 				this.logger.warn(
 					`MatchLifecycleHooks.runEnding exceeded its ${MATCH_ENDING_HOOK_BUDGET_MS}ms budget — proceeding with teardown`,
 					{ roomId: ctx.roomId },
@@ -81,6 +83,7 @@ export class MatchLifecycleHooks {
 			}, MATCH_ENDING_HOOK_BUDGET_MS);
 			timer.unref?.();
 		});
+		return { promise, clear: () => clearTimeout(timer) };
 	}
 
 	private async invoke(

--- a/src/shared/room/application/lifecycle/MatchLifecycleHooks.ts
+++ b/src/shared/room/application/lifecycle/MatchLifecycleHooks.ts
@@ -1,0 +1,70 @@
+import { Service } from "diod";
+
+import { Logger } from "@shared/logger/domain/Logger";
+import { MatchContext, MatchLifecycleHook } from "@shared/room/domain/lifecycle/MatchLifecycleHook";
+
+type LifecyclePhase = "onMatchStarted" | "onMatchEnding";
+
+export const MATCH_ENDING_HOOK_BUDGET_MS = 1500;
+
+/**
+ * Runs every registered MatchLifecycleHook. One failing hook never affects
+ * another hook or the match itself (per-hook try/catch, logged as a
+ * warning). `runStarted` never blocks its synchronous caller. `runEnding`
+ * is awaited by the caller but never blocks match teardown past
+ * MATCH_ENDING_HOOK_BUDGET_MS, regardless of how long a hook takes.
+ */
+@Service()
+export class MatchLifecycleHooks {
+	private readonly hooks: MatchLifecycleHook[] = [];
+
+	constructor(private readonly logger: Logger) {}
+
+	register(hook: MatchLifecycleHook): void {
+		this.hooks.push(hook);
+	}
+
+	runStarted(ctx: MatchContext): void {
+		const starting = this.hooks.filter((hook) => hook.onMatchStarted !== undefined);
+		void Promise.allSettled(starting.map((hook) => this.invoke(hook, "onMatchStarted", ctx)));
+	}
+
+	async runEnding(ctx: MatchContext): Promise<void> {
+		const ending = this.hooks.filter((hook) => hook.onMatchEnding !== undefined);
+		if (ending.length === 0) {
+			return;
+		}
+
+		const work = Promise.allSettled(ending.map((hook) => this.invoke(hook, "onMatchEnding", ctx)));
+		await Promise.race([work, this.budget(ctx)]);
+	}
+
+	private budget(ctx: MatchContext): Promise<void> {
+		return new Promise((resolve) => {
+			const timer = setTimeout(() => {
+				this.logger.warn(
+					`MatchLifecycleHooks.runEnding exceeded its ${MATCH_ENDING_HOOK_BUDGET_MS}ms budget — proceeding with teardown`,
+					{ roomId: ctx.roomId },
+				);
+				resolve();
+			}, MATCH_ENDING_HOOK_BUDGET_MS);
+			timer.unref?.();
+		});
+	}
+
+	private async invoke(
+		hook: MatchLifecycleHook,
+		phase: LifecyclePhase,
+		ctx: MatchContext,
+	): Promise<void> {
+		try {
+			await hook[phase]?.(ctx);
+		} catch (error) {
+			this.logger.warn(`Match lifecycle hook "${hook.name}" failed in ${phase}: ${String(error)}`, {
+				hook: hook.name,
+				phase,
+				roomId: ctx.roomId,
+			});
+		}
+	}
+}

--- a/src/shared/room/application/lifecycle/MatchLifecycleHooks.ts
+++ b/src/shared/room/application/lifecycle/MatchLifecycleHooks.ts
@@ -1,7 +1,11 @@
 import { Service } from "diod";
 
 import { Logger } from "@shared/logger/domain/Logger";
-import { MatchContext, MatchLifecycleHook } from "@shared/room/domain/lifecycle/MatchLifecycleHook";
+import {
+	MatchContext,
+	MatchLifecycleHook,
+	RoomClosedContext,
+} from "@shared/room/domain/lifecycle/MatchLifecycleHook";
 
 type LifecyclePhase = "onMatchStarted" | "onMatchEnding";
 
@@ -37,6 +41,33 @@ export class MatchLifecycleHooks {
 
 		const work = Promise.allSettled(ending.map((hook) => this.invoke(hook, "onMatchEnding", ctx)));
 		await Promise.race([work, this.budget(ctx)]);
+	}
+
+	/**
+	 * Fires when a room is torn down, whether the match reached a clean end or
+	 * not (abandoned, disconnected mid-duel, error fallback). Hooks that keep
+	 * per-match state must release it here — `onMatchEnding` alone is not a
+	 * complete release point, since teardown does not require a prior clean
+	 * finish.
+	 */
+	runClosed(ctx: RoomClosedContext): void {
+		const closing = this.hooks.filter((hook) => hook.onRoomClosed !== undefined);
+		void Promise.allSettled(closing.map((hook) => this.invokeClosed(hook, ctx)));
+	}
+
+	private async invokeClosed(hook: MatchLifecycleHook, ctx: RoomClosedContext): Promise<void> {
+		try {
+			await hook.onRoomClosed?.(ctx);
+		} catch (error) {
+			this.logger.warn(
+				`Match lifecycle hook "${hook.name}" failed in onRoomClosed: ${String(error)}`,
+				{
+					hook: hook.name,
+					phase: "onRoomClosed",
+					roomId: ctx.roomId,
+				},
+			);
+		}
 	}
 
 	private budget(ctx: MatchContext): Promise<void> {

--- a/src/shared/room/domain/lifecycle/MatchLifecycleHook.test.ts
+++ b/src/shared/room/domain/lifecycle/MatchLifecycleHook.test.ts
@@ -2,11 +2,12 @@ import { mock } from "jest-mock-extended";
 
 import { Team } from "@shared/room/Team";
 
-import { MatchContext, MatchLifecycleHook } from "./MatchLifecycleHook";
+import { MatchContext, MatchLifecycleHook, RoomClosedContext } from "./MatchLifecycleHook";
 
 function makeContext(overrides?: Partial<MatchContext>): MatchContext {
 	return {
 		roomId: 1234,
+		matchId: "match-1234-a",
 		ranked: true,
 		banListName: "TCG",
 		season: 5,
@@ -15,6 +16,14 @@ function makeContext(overrides?: Partial<MatchContext>): MatchContext {
 			{ id: "player-2", team: Team.OPPONENT, name: "Rival", winner: false },
 		],
 		announce: jest.fn(),
+		...overrides,
+	};
+}
+
+function makeRoomClosedContext(overrides?: Partial<RoomClosedContext>): RoomClosedContext {
+	return {
+		roomId: 1234,
+		matchId: "match-1234-a",
 		...overrides,
 	};
 }
@@ -51,5 +60,33 @@ describe("MatchLifecycleHook contract", () => {
 		ctx.announce("[Rating v1 start] Diango 1000 | Rival 1000");
 
 		expect(ctx.announce).toHaveBeenCalledWith("[Rating v1 start] Diango 1000 | Rival 1000");
+	});
+
+	it("MatchContext carries a matchId distinct from roomId", () => {
+		const ctx = makeContext({ roomId: 4242, matchId: "match-uuid-1" });
+
+		expect(ctx.roomId).toBe(4242);
+		expect(ctx.matchId).toBe("match-uuid-1");
+	});
+
+	it("exposes an optional onRoomClosed compatible with a mocked implementer", async () => {
+		const hook = mock<MatchLifecycleHook>();
+		const ctx = makeRoomClosedContext();
+
+		await hook.onRoomClosed?.(ctx);
+
+		expect(hook.onRoomClosed).toHaveBeenCalledWith(ctx);
+	});
+
+	it("a hook implementer may declare onRoomClosed independently of onMatchStarted/onMatchEnding", () => {
+		const closedOnly: MatchLifecycleHook = {
+			name: "closed-only",
+			onRoomClosed: async () => undefined,
+		};
+		const neither: MatchLifecycleHook = { name: "neither" };
+
+		expect(closedOnly.onMatchStarted).toBeUndefined();
+		expect(closedOnly.onMatchEnding).toBeUndefined();
+		expect(neither.onRoomClosed).toBeUndefined();
 	});
 });

--- a/src/shared/room/domain/lifecycle/MatchLifecycleHook.test.ts
+++ b/src/shared/room/domain/lifecycle/MatchLifecycleHook.test.ts
@@ -1,0 +1,55 @@
+import { mock } from "jest-mock-extended";
+
+import { Team } from "@shared/room/Team";
+
+import { MatchContext, MatchLifecycleHook } from "./MatchLifecycleHook";
+
+function makeContext(overrides?: Partial<MatchContext>): MatchContext {
+	return {
+		roomId: 1234,
+		ranked: true,
+		banListName: "TCG",
+		season: 5,
+		players: [
+			{ id: "player-1", team: Team.PLAYER, name: "Diango", winner: false },
+			{ id: "player-2", team: Team.OPPONENT, name: "Rival", winner: false },
+		],
+		announce: jest.fn(),
+		...overrides,
+	};
+}
+
+describe("MatchLifecycleHook contract", () => {
+	it("exposes optional onMatchStarted/onMatchEnding compatible with a mocked implementer", async () => {
+		const hook = mock<MatchLifecycleHook>();
+		const ctx = makeContext();
+
+		await hook.onMatchStarted?.(ctx);
+		await hook.onMatchEnding?.(ctx);
+
+		expect(hook.onMatchStarted).toHaveBeenCalledWith(ctx);
+		expect(hook.onMatchEnding).toHaveBeenCalledWith(ctx);
+	});
+
+	it("a hook implementer may declare only onMatchStarted, only onMatchEnding, or neither", () => {
+		const startOnly: MatchLifecycleHook = {
+			name: "start-only",
+			onMatchStarted: async () => undefined,
+		};
+		const endOnly: MatchLifecycleHook = { name: "end-only", onMatchEnding: async () => undefined };
+		const neither: MatchLifecycleHook = { name: "neither" };
+
+		expect(startOnly.onMatchEnding).toBeUndefined();
+		expect(endOnly.onMatchStarted).toBeUndefined();
+		expect(neither.onMatchStarted).toBeUndefined();
+		expect(neither.onMatchEnding).toBeUndefined();
+	});
+
+	it("MatchContext.announce is the only client-facing capability exposed to a hook", () => {
+		const ctx = makeContext();
+
+		ctx.announce("[Rating v1 start] Diango 1000 | Rival 1000");
+
+		expect(ctx.announce).toHaveBeenCalledWith("[Rating v1 start] Diango 1000 | Rival 1000");
+	});
+});

--- a/src/shared/room/domain/lifecycle/MatchLifecycleHook.ts
+++ b/src/shared/room/domain/lifecycle/MatchLifecycleHook.ts
@@ -18,14 +18,31 @@ export interface MatchContextPlayer {
  * Read-only view of a match handed to lifecycle hooks. Hooks never see the
  * room, a socket, or a client — `announce` is the only way a hook can reach
  * the room's clients, and it only ever sends a system chat line.
+ *
+ * `matchId` identifies the match aggregate itself (the same identity
+ * `GameOverDomainEvent.matchId` carries), distinct from `roomId`: a room's
+ * numeric id is small and gets reused across unrelated matches once freed,
+ * while `matchId` never repeats. A hook that keeps per-match state must key
+ * it by `matchId`, not `roomId`.
  */
 export interface MatchContext {
 	readonly roomId: number;
+	readonly matchId: string;
 	readonly ranked: boolean;
 	readonly banListName: string;
 	readonly season: number;
 	readonly players: readonly MatchContextPlayer[];
 	announce(message: string): void;
+}
+
+/**
+ * Identifies a room that has just been torn down, for hooks that need to
+ * release per-match state at that point rather than only on a clean match
+ * end.
+ */
+export interface RoomClosedContext {
+	readonly roomId: number;
+	readonly matchId: string;
 }
 
 /**
@@ -38,4 +55,5 @@ export interface MatchLifecycleHook {
 	readonly name: string;
 	onMatchStarted?(ctx: MatchContext): Promise<void>;
 	onMatchEnding?(ctx: MatchContext): Promise<void>;
+	onRoomClosed?(ctx: RoomClosedContext): Promise<void>;
 }

--- a/src/shared/room/domain/lifecycle/MatchLifecycleHook.ts
+++ b/src/shared/room/domain/lifecycle/MatchLifecycleHook.ts
@@ -1,0 +1,41 @@
+import { Team } from "@shared/room/Team";
+
+/**
+ * One participant as exposed to a match lifecycle hook. Shape mirrors the
+ * shared rating-eligibility gate's player type so a hook can pass
+ * `MatchContext.players` straight into it without a mapping step. `winner`
+ * is only meaningful on the ending context — a starting context still fills
+ * it (`false`) so the type stays uniform.
+ */
+export interface MatchContextPlayer {
+	readonly id: string | null;
+	readonly team: Team;
+	readonly name: string;
+	readonly winner: boolean;
+}
+
+/**
+ * Read-only view of a match handed to lifecycle hooks. Hooks never see the
+ * room, a socket, or a client — `announce` is the only way a hook can reach
+ * the room's clients, and it only ever sends a system chat line.
+ */
+export interface MatchContext {
+	readonly roomId: number;
+	readonly ranked: boolean;
+	readonly banListName: string;
+	readonly season: number;
+	readonly players: readonly MatchContextPlayer[];
+	announce(message: string): void;
+}
+
+/**
+ * Contract for a match lifecycle subscriber. Implementers register through
+ * a plugin's `lifecycleHooks` field (see ServerPlugin) and are driven by the
+ * `MatchLifecycleHooks` runner, which isolates one hook's failure from the
+ * rest and bounds how long `onMatchEnding` may block match teardown.
+ */
+export interface MatchLifecycleHook {
+	readonly name: string;
+	onMatchStarted?(ctx: MatchContext): Promise<void>;
+	onMatchEnding?(ctx: MatchContext): Promise<void>;
+}

--- a/src/shared/room/domain/lifecycle/RoomAnnounce.test.ts
+++ b/src/shared/room/domain/lifecycle/RoomAnnounce.test.ts
@@ -1,0 +1,41 @@
+import { ChatColor, YGOProStocChat } from "ygopro-msg-encode";
+
+import { YgoRoom } from "@shared/room/domain/YgoRoom";
+import { YgoClient } from "@shared/client/domain/YgoClient";
+
+import { createRoomAnnounce } from "./RoomAnnounce";
+
+function makeClient(): jest.Mocked<YgoClient> {
+	return {
+		socket: { send: jest.fn() },
+	} as unknown as jest.Mocked<YgoClient>;
+}
+
+describe("createRoomAnnounce", () => {
+	it("sends a STOC_CHAT frame with ChatColor.GRAY to every room client", () => {
+		const player = makeClient();
+		const spectator = makeClient();
+		const room = { clients: [player, spectator] } as unknown as YgoRoom;
+
+		const announce = createRoomAnnounce(room);
+		announce("[Rating v1 start] Diango 1000 | Rival 1000");
+
+		const expectedFrame = Buffer.from(
+			new YGOProStocChat()
+				.fromPartial({
+					player_type: ChatColor.GRAY,
+					msg: "[Rating v1 start] Diango 1000 | Rival 1000",
+				})
+				.toFullPayload(),
+		);
+
+		expect(player.socket.send).toHaveBeenCalledWith(expectedFrame);
+		expect(spectator.socket.send).toHaveBeenCalledWith(expectedFrame);
+	});
+
+	it("never touches sockets outside room.clients — an empty room sends nothing", () => {
+		const room = { clients: [] } as unknown as YgoRoom;
+
+		expect(() => createRoomAnnounce(room)("no clients")).not.toThrow();
+	});
+});

--- a/src/shared/room/domain/lifecycle/RoomAnnounce.ts
+++ b/src/shared/room/domain/lifecycle/RoomAnnounce.ts
@@ -1,0 +1,23 @@
+import { ChatColor, YGOProStocChat } from "ygopro-msg-encode";
+
+import { YgoRoom } from "@shared/room/domain/YgoRoom";
+
+/**
+ * Builds the `MatchContext.announce` capability for one room: a system
+ * STOC_CHAT (opcode 0x19, ChatColor.GRAY) frame sent to every current
+ * `room.clients` (players and spectators). This is the only way a match
+ * lifecycle hook reaches the room's clients — it never sees a socket.
+ */
+export function createRoomAnnounce(room: YgoRoom): (message: string) => void {
+	return (message: string) => {
+		const frame = Buffer.from(
+			new YGOProStocChat()
+				.fromPartial({ player_type: ChatColor.GRAY, msg: message })
+				.toFullPayload(),
+		);
+
+		room.clients.forEach((client) => {
+			client.socket.send(frame);
+		});
+	};
+}

--- a/src/shared/stats/rating/domain/MatchRatingSnapshot.test.ts
+++ b/src/shared/stats/rating/domain/MatchRatingSnapshot.test.ts
@@ -1,0 +1,49 @@
+import { Rating } from "./Rating";
+import { MatchRatingSnapshot } from "./MatchRatingSnapshot";
+
+describe("MatchRatingSnapshot", () => {
+	describe("create()", () => {
+		it("holds the start-time ratings, banlist, and season it was built with", () => {
+			const ratings = new Map<string, Rating>([
+				["player-1", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+				["player-2", Rating.from({ value: 980, gamesPlayed: 15, peak: 1010 })],
+			]);
+
+			const snapshot = MatchRatingSnapshot.create(ratings, "TCG", 5);
+
+			expect(snapshot.banListName).toBe("TCG");
+			expect(snapshot.season).toBe(5);
+			expect(snapshot.ratingFor("player-1")).toEqual(
+				Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 }),
+			);
+			expect(snapshot.ratingFor("player-2")).toEqual(
+				Rating.from({ value: 980, gamesPlayed: 15, peak: 1010 }),
+			);
+		});
+
+		it("returns undefined for a player that has no start-time rating recorded", () => {
+			const ratings = new Map<string, Rating>([
+				["player-1", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+			]);
+
+			const snapshot = MatchRatingSnapshot.create(ratings, "TCG", 5);
+
+			expect(snapshot.ratingFor("player-unknown")).toBeUndefined();
+		});
+
+		it("is immutable to mutation of the map passed at construction", () => {
+			const ratings = new Map<string, Rating>([
+				["player-1", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+			]);
+
+			const snapshot = MatchRatingSnapshot.create(ratings, "TCG", 5);
+			ratings.set("player-1", Rating.initialize());
+			ratings.set("player-2", Rating.initialize());
+
+			expect(snapshot.ratingFor("player-1")).toEqual(
+				Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 }),
+			);
+			expect(snapshot.ratingFor("player-2")).toBeUndefined();
+		});
+	});
+});

--- a/src/shared/stats/rating/domain/MatchRatingSnapshot.ts
+++ b/src/shared/stats/rating/domain/MatchRatingSnapshot.ts
@@ -1,0 +1,25 @@
+import { Rating } from "./Rating";
+
+export class MatchRatingSnapshot {
+	private readonly ratings: ReadonlyMap<string, Rating>;
+	public readonly banListName: string;
+	public readonly season: number;
+
+	private constructor(ratings: ReadonlyMap<string, Rating>, banListName: string, season: number) {
+		this.ratings = ratings;
+		this.banListName = banListName;
+		this.season = season;
+	}
+
+	static create(
+		ratings: ReadonlyMap<string, Rating>,
+		banListName: string,
+		season: number,
+	): MatchRatingSnapshot {
+		return new MatchRatingSnapshot(new Map(ratings), banListName, season);
+	}
+
+	ratingFor(userId: string): Rating | undefined {
+		return this.ratings.get(userId);
+	}
+}

--- a/src/shared/stats/rating/domain/RatingAnnouncement.lengthPin.test.ts
+++ b/src/shared/stats/rating/domain/RatingAnnouncement.lengthPin.test.ts
@@ -1,0 +1,23 @@
+import { YGOProStocChat } from "ygopro-msg-encode";
+
+import fixtures from "./__fixtures__/ratingAnnouncement.fixture.json";
+import { formatEnd } from "./RatingAnnouncement";
+
+describe("RatingAnnouncement length pin", () => {
+	it("keeps the worst-case 2v2 end frame within the STOC_CHAT wire limit", () => {
+		const frame = formatEnd(fixtures.worstCaseEnd.parsed.teams);
+
+		expect(frame).toBe(fixtures.worstCaseEnd.frame);
+		expect(frame.length).toBeLessThanOrEqual(YGOProStocChat.MAX_LENGTH);
+	});
+
+	it("survives the real STOC_CHAT wire encode/decode round trip untruncated", () => {
+		const frame = formatEnd(fixtures.worstCaseEnd.parsed.teams);
+
+		const encoded = new YGOProStocChat().fromPartial({ player_type: 18, msg: frame }).toPayload();
+		const decoded = new YGOProStocChat().fromPayload(encoded);
+
+		expect(decoded.msg).toBe(frame);
+		expect(decoded.msg.length).toBe(frame.length);
+	});
+});

--- a/src/shared/stats/rating/domain/RatingAnnouncement.test.ts
+++ b/src/shared/stats/rating/domain/RatingAnnouncement.test.ts
@@ -1,0 +1,134 @@
+import { MAX_LENGTH, formatEnd, formatStart } from "./RatingAnnouncement";
+
+describe("RatingAnnouncement", () => {
+	describe("formatStart", () => {
+		it("formats a 1v1 start frame with the versioned prefix and pipe-separated teams", () => {
+			const frame = formatStart([
+				[{ name: "Diango", rating: 1000 }],
+				[{ name: "Rival", rating: 980 }],
+			]);
+
+			expect(frame).toBe("[Rating v1 start] Diango 1000 | Rival 980");
+		});
+
+		it("formats a 2v2 start frame with middle-dot separated teammates in seat order", () => {
+			const frame = formatStart([
+				[
+					{ name: "Diango", rating: 1000 },
+					{ name: "Ally", rating: 1100 },
+				],
+				[
+					{ name: "Rival", rating: 980 },
+					{ name: "Foe", rating: 1200 },
+				],
+			]);
+
+			expect(frame).toBe("[Rating v1 start] Diango 1000 · Ally 1100 | Rival 980 · Foe 1200");
+		});
+
+		it("sanitizes control characters and grammar separators out of a nickname", () => {
+			const frame = formatStart([
+				[{ name: "Di\u0000an\u001fgo · | bad", rating: 1000 }],
+				[{ name: "Rival", rating: 980 }],
+			]);
+
+			expect(frame).toBe("[Rating v1 start] Diango bad 1000 | Rival 980");
+		});
+
+		it("collapses internal whitespace runs left after sanitizing and trims the result", () => {
+			const frame = formatStart([
+				[{ name: "  Di   ango  ", rating: 1000 }],
+				[{ name: "Rival", rating: 980 }],
+			]);
+
+			expect(frame).toBe("[Rating v1 start] Di ango 1000 | Rival 980");
+		});
+
+		it("truncates a name over MAX_LENGTH UTF-16 units and appends an ellipsis", () => {
+			const longName = "A".repeat(MAX_LENGTH + 5);
+
+			const frame = formatStart([
+				[{ name: longName, rating: 1000 }],
+				[{ name: "Rival", rating: 980 }],
+			]);
+
+			expect(frame).toBe(`[Rating v1 start] ${"A".repeat(MAX_LENGTH)}… 1000 | Rival 980`);
+		});
+
+		it("leaves a name exactly at MAX_LENGTH untouched — no truncation, no ellipsis", () => {
+			const exactName = "B".repeat(MAX_LENGTH);
+
+			const frame = formatStart([
+				[{ name: exactName, rating: 1000 }],
+				[{ name: "Rival", rating: 980 }],
+			]);
+
+			expect(frame).toBe(`[Rating v1 start] ${exactName} 1000 | Rival 980`);
+		});
+
+		it("never splits a surrogate pair when the truncation boundary lands mid-pair", () => {
+			// 19 "A"s (ASCII, 1 UTF-16 unit each) then one astral emoji (2 UTF-16
+			// units, a surrogate pair) whose high surrogate lands exactly at
+			// index MAX_LENGTH - 1, the truncation boundary.
+			const nameWithSurrogatePair = `${"A".repeat(MAX_LENGTH - 1)}\u{1F600}extra`;
+
+			const frame = formatStart([
+				[{ name: nameWithSurrogatePair, rating: 1000 }],
+				[{ name: "Rival", rating: 980 }],
+			]);
+
+			const entry = frame.split(" | ")[0].replace("[Rating v1 start] ", "");
+			const truncatedName = entry.slice(0, entry.lastIndexOf(" "));
+
+			expect(truncatedName).toBe(`${"A".repeat(MAX_LENGTH - 1)}…`);
+			// Well-formed UTF-16: a high surrogate is always immediately followed
+			// by its low surrogate, never truncated to a lone unit.
+			for (let i = 0; i < truncatedName.length; i++) {
+				const code = truncatedName.charCodeAt(i);
+				const isHighSurrogate = code >= 0xd800 && code <= 0xdbff;
+				if (isHighSurrogate) {
+					const next = truncatedName.charCodeAt(i + 1);
+					expect(next).toBeGreaterThanOrEqual(0xdc00);
+					expect(next).toBeLessThanOrEqual(0xdfff);
+				}
+			}
+		});
+	});
+
+	describe("formatEnd", () => {
+		it("formats a 1v1 end frame with resulting rating and signed delta per entry", () => {
+			const frame = formatEnd([
+				[{ name: "Diango", rating: 1012, delta: 12 }],
+				[{ name: "Rival", rating: 968, delta: -12 }],
+			]);
+
+			expect(frame).toBe("[Rating v1 end] Diango 1012 (+12) | Rival 968 (-12)");
+		});
+
+		it("formats a 2v2 end frame with middle-dot separated teammates and their own deltas", () => {
+			const frame = formatEnd([
+				[
+					{ name: "Diango", rating: 1012, delta: 12 },
+					{ name: "Ally", rating: 1108, delta: 8 },
+				],
+				[
+					{ name: "Rival", rating: 968, delta: -12 },
+					{ name: "Foe", rating: 1192, delta: -8 },
+				],
+			]);
+
+			expect(frame).toBe(
+				"[Rating v1 end] Diango 1012 (+12) · Ally 1108 (+8) | Rival 968 (-12) · Foe 1192 (-8)",
+			);
+		});
+
+		it("signs a zero delta as positive", () => {
+			const frame = formatEnd([
+				[{ name: "Diango", rating: 1000, delta: 0 }],
+				[{ name: "Rival", rating: 1000, delta: 0 }],
+			]);
+
+			expect(frame).toBe("[Rating v1 end] Diango 1000 (+0) | Rival 1000 (+0)");
+		});
+	});
+});

--- a/src/shared/stats/rating/domain/RatingAnnouncement.ts
+++ b/src/shared/stats/rating/domain/RatingAnnouncement.ts
@@ -1,0 +1,75 @@
+export const MAX_LENGTH = 20;
+
+const PREFIX = "[Rating v1 ";
+const TEAMMATE_SEPARATOR = " · ";
+const TEAM_SEPARATOR = " | ";
+const ELLIPSIS = "…";
+// biome-ignore lint/suspicious/noControlCharactersInRegex: strips NUL and other C0/DEL control chars from nicknames
+const CONTROL_CHARS = /[\x00-\x1f\x7f]/g;
+const GRAMMAR_SEPARATORS = /[·|]/g;
+const WHITESPACE_RUNS = /\s+/g;
+
+export type RatingAnnouncementEntry = {
+	name: string;
+	rating: number;
+};
+
+export type RatingAnnouncementDeltaEntry = RatingAnnouncementEntry & {
+	delta: number;
+};
+
+export function formatStart(teams: RatingAnnouncementEntry[][]): string {
+	return formatFrame("start", teams, formatEntry);
+}
+
+export function formatEnd(teams: RatingAnnouncementDeltaEntry[][]): string {
+	return formatFrame("end", teams, formatDeltaEntry);
+}
+
+function formatFrame<T>(
+	kind: "start" | "end",
+	teams: T[][],
+	formatOne: (entry: T) => string,
+): string {
+	const body = teams
+		.map((team) => team.map(formatOne).join(TEAMMATE_SEPARATOR))
+		.join(TEAM_SEPARATOR);
+
+	return `${PREFIX}${kind}] ${body}`;
+}
+
+function formatEntry(entry: RatingAnnouncementEntry): string {
+	return `${sanitizeName(entry.name)} ${Math.round(entry.rating)}`;
+}
+
+function formatDeltaEntry(entry: RatingAnnouncementDeltaEntry): string {
+	const sign = entry.delta >= 0 ? "+" : "-";
+	const magnitude = Math.round(Math.abs(entry.delta));
+
+	return `${formatEntry(entry)} (${sign}${magnitude})`;
+}
+
+function sanitizeName(name: string): string {
+	const cleaned = name
+		.replace(CONTROL_CHARS, "")
+		.replace(GRAMMAR_SEPARATORS, " ")
+		.replace(WHITESPACE_RUNS, " ")
+		.trim();
+
+	return truncateName(cleaned);
+}
+
+function truncateName(name: string): string {
+	if (name.length <= MAX_LENGTH) {
+		return name;
+	}
+
+	let cut = MAX_LENGTH;
+	const boundaryUnit = name.charCodeAt(cut - 1);
+	const boundaryIsHighSurrogate = boundaryUnit >= 0xd800 && boundaryUnit <= 0xdbff;
+	if (boundaryIsHighSurrogate) {
+		cut -= 1;
+	}
+
+	return `${name.slice(0, cut)}${ELLIPSIS}`;
+}

--- a/src/shared/stats/rating/domain/RatingEligibility.test.ts
+++ b/src/shared/stats/rating/domain/RatingEligibility.test.ts
@@ -1,0 +1,101 @@
+import { Team } from "@shared/room/Team";
+
+import { evaluateRatingEligibility } from "./RatingEligibility";
+
+function makePlayers(overrides?: { winnerId?: string | null; loserId?: string | null }) {
+	return [
+		{
+			id: "winnerId" in (overrides ?? {}) ? (overrides?.winnerId as string | null) : "player-1",
+			team: Team.PLAYER,
+			name: "Diango",
+			winner: true,
+		},
+		{
+			id: "loserId" in (overrides ?? {}) ? (overrides?.loserId as string | null) : "player-2",
+			team: Team.OPPONENT,
+			name: "Rival",
+			winner: false,
+		},
+	];
+}
+
+describe("evaluateRatingEligibility", () => {
+	describe("G1 — eligible ranked match", () => {
+		it("returns eligible with the banlist and players carried through", () => {
+			const result = evaluateRatingEligibility({
+				ranked: true,
+				banListName: "TCG",
+				players: makePlayers(),
+			});
+
+			expect(result).toEqual({
+				eligible: true,
+				banListName: "TCG",
+				players: [
+					{ id: "player-1", team: Team.PLAYER, name: "Diango", winner: true },
+					{ id: "player-2", team: Team.OPPONENT, name: "Rival", winner: false },
+				],
+			});
+		});
+	});
+
+	describe("G2 — unranked match excluded", () => {
+		it("returns ineligible with reason unranked", () => {
+			const result = evaluateRatingEligibility({
+				ranked: false,
+				banListName: "TCG",
+				players: makePlayers(),
+			});
+
+			expect(result).toEqual({ eligible: false, reason: "unranked" });
+		});
+	});
+
+	describe("G3 — N/A banlist excluded", () => {
+		it("returns ineligible with reason no-ranked-banlist", () => {
+			const result = evaluateRatingEligibility({
+				ranked: true,
+				banListName: "N/A",
+				players: makePlayers(),
+			});
+
+			expect(result).toEqual({ eligible: false, reason: "no-ranked-banlist" });
+		});
+	});
+
+	describe("G4 — missing account id excluded", () => {
+		it("returns ineligible with reason missing-account-id and the exact count", () => {
+			const result = evaluateRatingEligibility({
+				ranked: true,
+				banListName: "TCG",
+				players: makePlayers({ loserId: null }),
+			});
+
+			expect(result).toEqual({ eligible: false, reason: "missing-account-id", missingIdCount: 1 });
+		});
+
+		it("counts every participant missing an id, not just the first", () => {
+			const result = evaluateRatingEligibility({
+				ranked: true,
+				banListName: "TCG",
+				players: makePlayers({ winnerId: null, loserId: null }),
+			});
+
+			expect(result).toEqual({ eligible: false, reason: "missing-account-id", missingIdCount: 2 });
+		});
+	});
+
+	describe("G6 — gate consistency", () => {
+		it("is a pure function: evaluating the same eligible match twice yields equal results", () => {
+			const match = { ranked: true, banListName: "TCG", players: makePlayers() };
+
+			expect(evaluateRatingEligibility(match)).toEqual(evaluateRatingEligibility(match));
+		});
+
+		it("is a pure function: evaluating the same ineligible match twice yields equal results", () => {
+			const match = { ranked: true, banListName: "N/A", players: makePlayers() };
+
+			expect(evaluateRatingEligibility(match)).toEqual(evaluateRatingEligibility(match));
+		});
+	});
+});

--- a/src/shared/stats/rating/domain/RatingEligibility.ts
+++ b/src/shared/stats/rating/domain/RatingEligibility.ts
@@ -1,0 +1,53 @@
+import type { Team } from "@shared/room/Team";
+
+export type RatedMatchPlayer = {
+	id: string;
+	team: Team;
+	name: string;
+	winner: boolean;
+};
+
+export type RatingEligibilityMatchPlayer = {
+	id: string | null;
+	team: Team;
+	name: string;
+	winner: boolean;
+};
+
+export type RatingEligibilityMatch = {
+	ranked: boolean;
+	banListName: string;
+	players: RatingEligibilityMatchPlayer[];
+};
+
+export type RatingEligibility =
+	| { eligible: true; banListName: string; players: RatedMatchPlayer[] }
+	| { eligible: false; reason: "unranked" }
+	| { eligible: false; reason: "no-ranked-banlist" }
+	| { eligible: false; reason: "missing-account-id"; missingIdCount: number };
+
+export function evaluateRatingEligibility(match: RatingEligibilityMatch): RatingEligibility {
+	if (!match.ranked) {
+		return { eligible: false, reason: "unranked" };
+	}
+
+	if (!match.banListName || match.banListName === "N/A") {
+		return { eligible: false, reason: "no-ranked-banlist" };
+	}
+
+	const missingIdCount = match.players.filter((player) => player.id === null).length;
+	if (missingIdCount > 0) {
+		return { eligible: false, reason: "missing-account-id", missingIdCount };
+	}
+
+	return {
+		eligible: true,
+		banListName: match.banListName,
+		players: match.players.map((player) => ({
+			id: player.id as string,
+			team: player.team,
+			name: player.name,
+			winner: player.winner,
+		})),
+	};
+}

--- a/src/shared/stats/rating/domain/RatingRepository.test.ts
+++ b/src/shared/stats/rating/domain/RatingRepository.test.ts
@@ -1,0 +1,19 @@
+import { mock } from "jest-mock-extended";
+
+import { Rating } from "./Rating";
+import { RatingRepository } from "./RatingRepository";
+
+describe("RatingRepository — findMany port contract", () => {
+	it("exposes findMany(userIds, banListName, season) returning a Promise<Map<string, Rating>>", async () => {
+		const repository = mock<RatingRepository>();
+		const ratings = new Map<string, Rating>([
+			["player-1", Rating.from({ value: 1050, gamesPlayed: 12, peak: 1080 })],
+		]);
+		repository.findMany.mockResolvedValue(ratings);
+
+		const result = await repository.findMany(["player-1"], "TCG", 5);
+
+		expect(repository.findMany).toHaveBeenCalledWith(["player-1"], "TCG", 5);
+		expect(result).toBe(ratings);
+	});
+});

--- a/src/shared/stats/rating/domain/RatingRepository.ts
+++ b/src/shared/stats/rating/domain/RatingRepository.ts
@@ -42,4 +42,12 @@ export interface RatingRepository {
 		season: number,
 		work: (ratings: Map<string, Rating>, tx: RatingTransaction) => Promise<T>,
 	): Promise<T>;
+
+	/**
+	 * Reads current ratings for the given users without acquiring any row
+	 * lock, defaulting missing rows to a fresh season-start rating. Read-only
+	 * display path — must never interfere with `transaction`'s write-side
+	 * locking.
+	 */
+	findMany(userIds: string[], banListName: string, season: number): Promise<Map<string, Rating>>;
 }

--- a/src/shared/stats/rating/domain/__fixtures__/ratingAnnouncement.fixture.json
+++ b/src/shared/stats/rating/domain/__fixtures__/ratingAnnouncement.fixture.json
@@ -1,0 +1,136 @@
+{
+	"oneVOneStart": {
+		"parsed": {
+			"kind": "start",
+			"teams": [
+				[
+					{
+						"name": "Diango",
+						"rating": 1000
+					}
+				],
+				[
+					{
+						"name": "Rival",
+						"rating": 980
+					}
+				]
+			]
+		},
+		"frame": "[Rating v1 start] Diango 1000 | Rival 980"
+	},
+	"oneVOneEnd": {
+		"parsed": {
+			"kind": "end",
+			"teams": [
+				[
+					{
+						"name": "Diango",
+						"rating": 1012,
+						"delta": 12
+					}
+				],
+				[
+					{
+						"name": "Rival",
+						"rating": 968,
+						"delta": -12
+					}
+				]
+			]
+		},
+		"frame": "[Rating v1 end] Diango 1012 (+12) | Rival 968 (-12)"
+	},
+	"twoVTwoStart": {
+		"parsed": {
+			"kind": "start",
+			"teams": [
+				[
+					{
+						"name": "Diango",
+						"rating": 1000
+					},
+					{
+						"name": "Ally",
+						"rating": 1100
+					}
+				],
+				[
+					{
+						"name": "Rival",
+						"rating": 980
+					},
+					{
+						"name": "Foe",
+						"rating": 1200
+					}
+				]
+			]
+		},
+		"frame": "[Rating v1 start] Diango 1000 · Ally 1100 | Rival 980 · Foe 1200"
+	},
+	"twoVTwoEnd": {
+		"parsed": {
+			"kind": "end",
+			"teams": [
+				[
+					{
+						"name": "Diango",
+						"rating": 1012,
+						"delta": 12
+					},
+					{
+						"name": "Ally",
+						"rating": 1108,
+						"delta": 8
+					}
+				],
+				[
+					{
+						"name": "Rival",
+						"rating": 968,
+						"delta": -12
+					},
+					{
+						"name": "Foe",
+						"rating": 1192,
+						"delta": -8
+					}
+				]
+			]
+		},
+		"frame": "[Rating v1 end] Diango 1012 (+12) · Ally 1108 (+8) | Rival 968 (-12) · Foe 1192 (-8)"
+	},
+	"worstCaseEnd": {
+		"parsed": {
+			"kind": "end",
+			"teams": [
+				[
+					{
+						"name": "AAAAAAAAAAAAAAAAAAAA",
+						"rating": 999999,
+						"delta": 9999
+					},
+					{
+						"name": "BBBBBBBBBBBBBBBBBBBB",
+						"rating": 999999,
+						"delta": 9999
+					}
+				],
+				[
+					{
+						"name": "CCCCCCCCCCCCCCCCCCCC",
+						"rating": 999999,
+						"delta": -9999
+					},
+					{
+						"name": "DDDDDDDDDDDDDDDDDDDD",
+						"rating": 999999,
+						"delta": -9999
+					}
+				]
+			]
+		},
+		"frame": "[Rating v1 end] AAAAAAAAAAAAAAAAAAAA 999999 (+9999) · BBBBBBBBBBBBBBBBBBBB 999999 (+9999) | CCCCCCCCCCCCCCCCCCCC 999999 (-9999) · DDDDDDDDDDDDDDDDDDDD 999999 (-9999)"
+	}
+}

--- a/src/shared/stats/rating/infrastructure/RatingPostgresRepository.test.ts
+++ b/src/shared/stats/rating/infrastructure/RatingPostgresRepository.test.ts
@@ -11,6 +11,7 @@ import { dataSource } from "../../../../evolution-types/src/data-source";
 jest.mock("../../../../evolution-types/src/data-source", () => ({
 	dataSource: {
 		transaction: jest.fn(),
+		query: jest.fn(),
 	},
 }));
 
@@ -144,6 +145,45 @@ describe("RatingPostgresRepository", () => {
 			});
 
 			expect(inserted).toBe(false);
+		});
+	});
+
+	describe("findMany()", () => {
+		it("R1 — reads current ratings for the given users without acquiring any row lock", async () => {
+			(dataSource.query as jest.Mock).mockResolvedValueOnce([
+				{ userId: "user-a", rating: 1200, gamesPlayed: 15, peak: 1250 },
+			]);
+
+			const result = await repository.findMany(["user-a"], "TCG", 5);
+
+			expect(dataSource.query).toHaveBeenCalledTimes(1);
+			expect(dataSource.query).toHaveBeenCalledWith(expect.any(String), ["TCG", 5, ["user-a"]]);
+			expect((dataSource.query as jest.Mock).mock.calls[0][0]).not.toEqual(
+				expect.stringContaining("FOR UPDATE"),
+			);
+			expect(dataSource.transaction).not.toHaveBeenCalled();
+			expect(result.get("user-a")).toEqual(
+				Rating.from({ value: 1200, gamesPlayed: 15, peak: 1250 }),
+			);
+		});
+
+		it("R2 — defaults a user with no rating row to the season-start value (1000)", async () => {
+			(dataSource.query as jest.Mock).mockResolvedValueOnce([]);
+
+			const result = await repository.findMany(["user-a"], "TCG", 5);
+
+			expect(result.get("user-a")).toEqual(Rating.initialize());
+		});
+
+		it("R3 — reads without acquiring the advisory participant locks used by the write path", async () => {
+			(dataSource.query as jest.Mock).mockResolvedValueOnce([]);
+
+			await repository.findMany(["user-a", "user-b"], "TCG", 5);
+
+			expect(dataSource.query).toHaveBeenCalledTimes(1);
+			expect((dataSource.query as jest.Mock).mock.calls[0][0]).not.toEqual(
+				expect.stringContaining("pg_advisory_xact_lock"),
+			);
 		});
 	});
 

--- a/src/shared/stats/rating/infrastructure/RatingPostgresRepository.ts
+++ b/src/shared/stats/rating/infrastructure/RatingPostgresRepository.ts
@@ -23,6 +23,15 @@ const LOCK_RATINGS_QUERY = `
 	FOR UPDATE
 `;
 
+// Same shape as LOCK_RATINGS_QUERY minus FOR UPDATE: a display-only read must
+// never take a row lock or otherwise interfere with the write path above.
+const FIND_RATINGS_QUERY = `
+	SELECT user_id AS "userId", rating, games_played AS "gamesPlayed", peak
+	FROM player_ratings
+	WHERE ban_list_name = $1 AND season = $2 AND user_id = ANY($3)
+	ORDER BY user_id ASC
+`;
+
 const INSERT_HISTORY_QUERY = `
 	INSERT INTO rating_history (match_id, user_id, ban_list_name, season, kind, previous_rating, delta, k_factor, opponent_rating)
 	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
@@ -89,19 +98,37 @@ export class RatingPostgresRepository implements RatingRepository {
 			orderedIds,
 		]);
 
-		const ratings = new Map<string, Rating>();
-		for (const userId of orderedIds) {
-			const row = rows.find((item) => item.userId === userId);
-			ratings.set(
-				userId,
-				row
-					? Rating.from({ value: row.rating, gamesPlayed: row.gamesPlayed, peak: row.peak })
-					: Rating.initialize(),
-			);
-		}
-
-		return ratings;
+		return toRatingsMap(orderedIds, rows);
 	}
+
+	async findMany(
+		userIds: string[],
+		banListName: string,
+		season: number,
+	): Promise<Map<string, Rating>> {
+		const rows: PlayerRatingRow[] = await dataSource.query(FIND_RATINGS_QUERY, [
+			banListName,
+			season,
+			userIds,
+		]);
+
+		return toRatingsMap(userIds, rows);
+	}
+}
+
+function toRatingsMap(userIds: string[], rows: PlayerRatingRow[]): Map<string, Rating> {
+	const ratings = new Map<string, Rating>();
+	for (const userId of userIds) {
+		const row = rows.find((item) => item.userId === userId);
+		ratings.set(
+			userId,
+			row
+				? Rating.from({ value: row.rating, gamesPlayed: row.gamesPlayed, peak: row.peak })
+				: Rating.initialize(),
+		);
+	}
+
+	return ratings;
 }
 
 class RatingPostgresTransaction implements RatingTransaction {

--- a/src/test-support/plugin-fixtures/lifecycle-hooks/provider/capture.ts
+++ b/src/test-support/plugin-fixtures/lifecycle-hooks/provider/capture.ts
@@ -1,0 +1,8 @@
+// Records every onMatchStarted invocation the fixture hook receives, so the
+// bootstrapPlugins test suite can assert the plugin's declared hook actually
+// reached the shared MatchLifecycleHooks runner.
+export const startedCalls: string[] = [];
+
+export function resetStartedCalls(): void {
+	startedCalls.length = 0;
+}

--- a/src/test-support/plugin-fixtures/lifecycle-hooks/provider/index.ts
+++ b/src/test-support/plugin-fixtures/lifecycle-hooks/provider/index.ts
@@ -1,0 +1,17 @@
+import { makeTestPlugin } from "../../makeTestPlugin";
+import { startedCalls } from "./capture";
+
+// Declares one match lifecycle hook without subscribing to the event bus —
+// proves bootstrapPlugins() wires ServerPlugin.lifecycleHooks into the
+// shared MatchLifecycleHooks runner independently of register().
+export default makeTestPlugin({
+	name: "lifecycle-provider",
+	lifecycleHooks: [
+		{
+			name: "lifecycle-provider-hook",
+			onMatchStarted: async () => {
+				startedCalls.push("started");
+			},
+		},
+	],
+});


### PR DESCRIPTION
## Summary
- New `MatchLifecycleHook` contract (`onMatchStarted`, `onMatchEnding`, `onRoomClosed`) with a `MatchContext` exposing only `announce()` — hooks never touch sockets.
- `MatchLifecycleHooks` runner: per-hook isolation, fire-and-forget start/close, end awaited under a 1500 ms budget whose timer is cleared once hooks settle (no false "budget exceeded" warnings).
- Plugins register hooks through the existing `ServerPlugin` contract; `docs/plugins.md` documents the three phases and the rule that per-match state is keyed by `matchId` and released in `onRoomClosed`.

Chain 2/3, stacked on the domain PR. `size:exception` — 833 lines; the overage is one cohesive fix (timer cleanup) to a single file and its test.