### PR TITLE
feat(rating): shared eligibility gate, unlocked read and chat announcement format

### DIFF
--- a/src/plugins/elo-rating/application/EloRatingCalculator.test.ts
+++ b/src/plugins/elo-rating/application/EloRatingCalculator.test.ts
@@ -202,6 +202,43 @@ describe("EloRatingCalculator", () => {
 		});
 	});
 
+	describe("G5 — eligibility log strings are pinned across the gate refactor", () => {
+		it("logs the unranked skip reason verbatim", async () => {
+			await calculator.handle(makeEligibleEvent({ ranked: false, matchId: "match-1" }));
+
+			expect(logger.info).toHaveBeenCalledWith(
+				expect.stringContaining("Skipping rating for match match-1: match is not ranked."),
+			);
+		});
+
+		it("logs the no-ranked-banlist skip reason verbatim", async () => {
+			await calculator.handle(makeEligibleEvent({ banListName: "N/A", matchId: "match-1" }));
+
+			expect(logger.info).toHaveBeenCalledWith(
+				expect.stringContaining('Skipping rating for match match-1: no ranked banlist ("N/A").'),
+			);
+		});
+
+		it("logs the missing-account-id skip reason verbatim, including the count", async () => {
+			const winner = PlayerMother.create({ id: "player-1", team: Team.PLAYER, winner: true });
+			const noId = PlayerMother.create({ id: null, team: Team.OPPONENT, winner: false });
+			const event = GameOverDomainEventMother.create({
+				matchId: "match-1",
+				ranked: true,
+				banListName: "TCG",
+				players: [winner.toPresentation(), noId.toPresentation()],
+			});
+
+			await calculator.handle(event);
+
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining(
+					"Skipping rating for match match-1: 1 participant(s) have no account id (bot or unresolved account).",
+				),
+			);
+		});
+	});
+
 	describe("account resolution gap", () => {
 		it("writes no rating row when a player's account cannot be resolved by id", async () => {
 			userProfileRepository.findById.mockResolvedValue(null);

--- a/src/plugins/elo-rating/application/EloRatingCalculator.ts
+++ b/src/plugins/elo-rating/application/EloRatingCalculator.ts
@@ -2,6 +2,7 @@ import { Logger } from "src/shared/logger/domain/Logger";
 import { EloCalculator, RatedPlayer } from "src/shared/stats/rating/domain/EloCalculator";
 import { Rating } from "src/shared/stats/rating/domain/Rating";
 import { RatingRepository } from "src/shared/stats/rating/domain/RatingRepository";
+import { evaluateRatingEligibility } from "src/shared/stats/rating/domain/RatingEligibility";
 import { UserProfileRepository } from "src/shared/user-profile/domain/UserProfileRepository";
 
 import { DomainEventSubscriber } from "../../../shared/event-bus/EventBus";
@@ -22,28 +23,27 @@ export class EloRatingCalculator implements DomainEventSubscriber<GameOverDomain
 	async handle(event: GameOverDomainEvent): Promise<void> {
 		const { data } = event;
 
-		if (!data.ranked) {
-			this.logger.info(`Skipping rating for match ${data.matchId}: match is not ranked.`);
+		const eligibility = evaluateRatingEligibility({
+			ranked: data.ranked,
+			banListName: data.banListName,
+			players: data.players,
+		});
+
+		if (!eligibility.eligible) {
+			if (eligibility.reason === "unranked") {
+				this.logger.info(`Skipping rating for match ${data.matchId}: match is not ranked.`);
+			} else if (eligibility.reason === "no-ranked-banlist") {
+				this.logger.info(`Skipping rating for match ${data.matchId}: no ranked banlist ("N/A").`);
+			} else {
+				this.logger.warn(
+					`Skipping rating for match ${data.matchId}: ${eligibility.missingIdCount} participant(s) have no account id (bot or unresolved account).`,
+				);
+			}
 
 			return;
 		}
 
-		if (!data.banListName || data.banListName === "N/A") {
-			this.logger.info(`Skipping rating for match ${data.matchId}: no ranked banlist ("N/A").`);
-
-			return;
-		}
-
-		const missingIdCount = data.players.filter((player) => player.id === null).length;
-		if (missingIdCount > 0) {
-			this.logger.warn(
-				`Skipping rating for match ${data.matchId}: ${missingIdCount} participant(s) have no account id (bot or unresolved account).`,
-			);
-
-			return;
-		}
-
-		const playerIds = data.players.map((player) => player.id as string);
+		const playerIds = eligibility.players.map((player) => player.id);
 		const accounts = await Promise.all(
 			playerIds.map((id) => this.userProfileRepository.findById(id)),
 		);
@@ -56,12 +56,12 @@ export class EloRatingCalculator implements DomainEventSubscriber<GameOverDomain
 			return;
 		}
 
-		const ratedPlayers: RatedPlayer[] = data.players.map((player) => ({
-			id: player.id as string,
+		const ratedPlayers: RatedPlayer[] = eligibility.players.map((player) => ({
+			id: player.id,
 			team: player.team,
 			winner: player.winner,
 		}));
-		const banListName = data.banListName;
+		const banListName = eligibility.banListName;
 		const season = config.season;
 
 		await this.ratingRepository.transaction(playerIds, banListName, season, async (ratings, tx) => {

--- a/src/shared/stats/rating/domain/MatchRatingSnapshot.test.ts
+++ b/src/shared/stats/rating/domain/MatchRatingSnapshot.test.ts
@@ -1,0 +1,49 @@
+import { Rating } from "./Rating";
+import { MatchRatingSnapshot } from "./MatchRatingSnapshot";
+
+describe("MatchRatingSnapshot", () => {
+	describe("create()", () => {
+		it("holds the start-time ratings, banlist, and season it was built with", () => {
+			const ratings = new Map<string, Rating>([
+				["player-1", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+				["player-2", Rating.from({ value: 980, gamesPlayed: 15, peak: 1010 })],
+			]);
+
+			const snapshot = MatchRatingSnapshot.create(ratings, "TCG", 5);
+
+			expect(snapshot.banListName).toBe("TCG");
+			expect(snapshot.season).toBe(5);
+			expect(snapshot.ratingFor("player-1")).toEqual(
+				Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 }),
+			);
+			expect(snapshot.ratingFor("player-2")).toEqual(
+				Rating.from({ value: 980, gamesPlayed: 15, peak: 1010 }),
+			);
+		});
+
+		it("returns undefined for a player that has no start-time rating recorded", () => {
+			const ratings = new Map<string, Rating>([
+				["player-1", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+			]);
+
+			const snapshot = MatchRatingSnapshot.create(ratings, "TCG", 5);
+
+			expect(snapshot.ratingFor("player-unknown")).toBeUndefined();
+		});
+
+		it("is immutable to mutation of the map passed at construction", () => {
+			const ratings = new Map<string, Rating>([
+				["player-1", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+			]);
+
+			const snapshot = MatchRatingSnapshot.create(ratings, "TCG", 5);
+			ratings.set("player-1", Rating.initialize());
+			ratings.set("player-2", Rating.initialize());
+
+			expect(snapshot.ratingFor("player-1")).toEqual(
+				Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 }),
+			);
+			expect(snapshot.ratingFor("player-2")).toBeUndefined();
+		});
+	});
+});

--- a/src/shared/stats/rating/domain/MatchRatingSnapshot.ts
+++ b/src/shared/stats/rating/domain/MatchRatingSnapshot.ts
@@ -1,0 +1,25 @@
+import { Rating } from "./Rating";
+
+export class MatchRatingSnapshot {
+	private readonly ratings: ReadonlyMap<string, Rating>;
+	public readonly banListName: string;
+	public readonly season: number;
+
+	private constructor(ratings: ReadonlyMap<string, Rating>, banListName: string, season: number) {
+		this.ratings = ratings;
+		this.banListName = banListName;
+		this.season = season;
+	}
+
+	static create(
+		ratings: ReadonlyMap<string, Rating>,
+		banListName: string,
+		season: number,
+	): MatchRatingSnapshot {
+		return new MatchRatingSnapshot(new Map(ratings), banListName, season);
+	}
+
+	ratingFor(userId: string): Rating | undefined {
+		return this.ratings.get(userId);
+	}
+}

--- a/src/shared/stats/rating/domain/RatingAnnouncement.lengthPin.test.ts
+++ b/src/shared/stats/rating/domain/RatingAnnouncement.lengthPin.test.ts
@@ -1,0 +1,23 @@
+import { YGOProStocChat } from "ygopro-msg-encode";
+
+import fixtures from "./__fixtures__/ratingAnnouncement.fixture.json";
+import { formatEnd } from "./RatingAnnouncement";
+
+describe("RatingAnnouncement length pin", () => {
+	it("keeps the worst-case 2v2 end frame within the STOC_CHAT wire limit", () => {
+		const frame = formatEnd(fixtures.worstCaseEnd.parsed.teams);
+
+		expect(frame).toBe(fixtures.worstCaseEnd.frame);
+		expect(frame.length).toBeLessThanOrEqual(YGOProStocChat.MAX_LENGTH);
+	});
+
+	it("survives the real STOC_CHAT wire encode/decode round trip untruncated", () => {
+		const frame = formatEnd(fixtures.worstCaseEnd.parsed.teams);
+
+		const encoded = new YGOProStocChat().fromPartial({ player_type: 18, msg: frame }).toPayload();
+		const decoded = new YGOProStocChat().fromPayload(encoded);
+
+		expect(decoded.msg).toBe(frame);
+		expect(decoded.msg.length).toBe(frame.length);
+	});
+});

--- a/src/shared/stats/rating/domain/RatingAnnouncement.test.ts
+++ b/src/shared/stats/rating/domain/RatingAnnouncement.test.ts
@@ -1,0 +1,134 @@
+import { MAX_LENGTH, formatEnd, formatStart } from "./RatingAnnouncement";
+
+describe("RatingAnnouncement", () => {
+	describe("formatStart", () => {
+		it("formats a 1v1 start frame with the versioned prefix and pipe-separated teams", () => {
+			const frame = formatStart([
+				[{ name: "Diango", rating: 1000 }],
+				[{ name: "Rival", rating: 980 }],
+			]);
+
+			expect(frame).toBe("[Rating v1 start] Diango 1000 | Rival 980");
+		});
+
+		it("formats a 2v2 start frame with middle-dot separated teammates in seat order", () => {
+			const frame = formatStart([
+				[
+					{ name: "Diango", rating: 1000 },
+					{ name: "Ally", rating: 1100 },
+				],
+				[
+					{ name: "Rival", rating: 980 },
+					{ name: "Foe", rating: 1200 },
+				],
+			]);
+
+			expect(frame).toBe("[Rating v1 start] Diango 1000 · Ally 1100 | Rival 980 · Foe 1200");
+		});
+
+		it("sanitizes control characters and grammar separators out of a nickname", () => {
+			const frame = formatStart([
+				[{ name: "Di\u0000an\u001fgo · | bad", rating: 1000 }],
+				[{ name: "Rival", rating: 980 }],
+			]);
+
+			expect(frame).toBe("[Rating v1 start] Diango bad 1000 | Rival 980");
+		});
+
+		it("collapses internal whitespace runs left after sanitizing and trims the result", () => {
+			const frame = formatStart([
+				[{ name: "  Di   ango  ", rating: 1000 }],
+				[{ name: "Rival", rating: 980 }],
+			]);
+
+			expect(frame).toBe("[Rating v1 start] Di ango 1000 | Rival 980");
+		});
+
+		it("truncates a name over MAX_LENGTH UTF-16 units and appends an ellipsis", () => {
+			const longName = "A".repeat(MAX_LENGTH + 5);
+
+			const frame = formatStart([
+				[{ name: longName, rating: 1000 }],
+				[{ name: "Rival", rating: 980 }],
+			]);
+
+			expect(frame).toBe(`[Rating v1 start] ${"A".repeat(MAX_LENGTH)}… 1000 | Rival 980`);
+		});
+
+		it("leaves a name exactly at MAX_LENGTH untouched — no truncation, no ellipsis", () => {
+			const exactName = "B".repeat(MAX_LENGTH);
+
+			const frame = formatStart([
+				[{ name: exactName, rating: 1000 }],
+				[{ name: "Rival", rating: 980 }],
+			]);
+
+			expect(frame).toBe(`[Rating v1 start] ${exactName} 1000 | Rival 980`);
+		});
+
+		it("never splits a surrogate pair when the truncation boundary lands mid-pair", () => {
+			// 19 "A"s (ASCII, 1 UTF-16 unit each) then one astral emoji (2 UTF-16
+			// units, a surrogate pair) whose high surrogate lands exactly at
+			// index MAX_LENGTH - 1, the truncation boundary.
+			const nameWithSurrogatePair = `${"A".repeat(MAX_LENGTH - 1)}\u{1F600}extra`;
+
+			const frame = formatStart([
+				[{ name: nameWithSurrogatePair, rating: 1000 }],
+				[{ name: "Rival", rating: 980 }],
+			]);
+
+			const entry = frame.split(" | ")[0].replace("[Rating v1 start] ", "");
+			const truncatedName = entry.slice(0, entry.lastIndexOf(" "));
+
+			expect(truncatedName).toBe(`${"A".repeat(MAX_LENGTH - 1)}…`);
+			// Well-formed UTF-16: a high surrogate is always immediately followed
+			// by its low surrogate, never truncated to a lone unit.
+			for (let i = 0; i < truncatedName.length; i++) {
+				const code = truncatedName.charCodeAt(i);
+				const isHighSurrogate = code >= 0xd800 && code <= 0xdbff;
+				if (isHighSurrogate) {
+					const next = truncatedName.charCodeAt(i + 1);
+					expect(next).toBeGreaterThanOrEqual(0xdc00);
+					expect(next).toBeLessThanOrEqual(0xdfff);
+				}
+			}
+		});
+	});
+
+	describe("formatEnd", () => {
+		it("formats a 1v1 end frame with resulting rating and signed delta per entry", () => {
+			const frame = formatEnd([
+				[{ name: "Diango", rating: 1012, delta: 12 }],
+				[{ name: "Rival", rating: 968, delta: -12 }],
+			]);
+
+			expect(frame).toBe("[Rating v1 end] Diango 1012 (+12) | Rival 968 (-12)");
+		});
+
+		it("formats a 2v2 end frame with middle-dot separated teammates and their own deltas", () => {
+			const frame = formatEnd([
+				[
+					{ name: "Diango", rating: 1012, delta: 12 },
+					{ name: "Ally", rating: 1108, delta: 8 },
+				],
+				[
+					{ name: "Rival", rating: 968, delta: -12 },
+					{ name: "Foe", rating: 1192, delta: -8 },
+				],
+			]);
+
+			expect(frame).toBe(
+				"[Rating v1 end] Diango 1012 (+12) · Ally 1108 (+8) | Rival 968 (-12) · Foe 1192 (-8)",
+			);
+		});
+
+		it("signs a zero delta as positive", () => {
+			const frame = formatEnd([
+				[{ name: "Diango", rating: 1000, delta: 0 }],
+				[{ name: "Rival", rating: 1000, delta: 0 }],
+			]);
+
+			expect(frame).toBe("[Rating v1 end] Diango 1000 (+0) | Rival 1000 (+0)");
+		});
+	});
+});

--- a/src/shared/stats/rating/domain/RatingAnnouncement.ts
+++ b/src/shared/stats/rating/domain/RatingAnnouncement.ts
@@ -1,0 +1,75 @@
+export const MAX_LENGTH = 20;
+
+const PREFIX = "[Rating v1 ";
+const TEAMMATE_SEPARATOR = " · ";
+const TEAM_SEPARATOR = " | ";
+const ELLIPSIS = "…";
+// biome-ignore lint/suspicious/noControlCharactersInRegex: strips NUL and other C0/DEL control chars from nicknames
+const CONTROL_CHARS = /[\x00-\x1f\x7f]/g;
+const GRAMMAR_SEPARATORS = /[·|]/g;
+const WHITESPACE_RUNS = /\s+/g;
+
+export type RatingAnnouncementEntry = {
+	name: string;
+	rating: number;
+};
+
+export type RatingAnnouncementDeltaEntry = RatingAnnouncementEntry & {
+	delta: number;
+};
+
+export function formatStart(teams: RatingAnnouncementEntry[][]): string {
+	return formatFrame("start", teams, formatEntry);
+}
+
+export function formatEnd(teams: RatingAnnouncementDeltaEntry[][]): string {
+	return formatFrame("end", teams, formatDeltaEntry);
+}
+
+function formatFrame<T>(
+	kind: "start" | "end",
+	teams: T[][],
+	formatOne: (entry: T) => string,
+): string {
+	const body = teams
+		.map((team) => team.map(formatOne).join(TEAMMATE_SEPARATOR))
+		.join(TEAM_SEPARATOR);
+
+	return `${PREFIX}${kind}] ${body}`;
+}
+
+function formatEntry(entry: RatingAnnouncementEntry): string {
+	return `${sanitizeName(entry.name)} ${Math.round(entry.rating)}`;
+}
+
+function formatDeltaEntry(entry: RatingAnnouncementDeltaEntry): string {
+	const sign = entry.delta >= 0 ? "+" : "-";
+	const magnitude = Math.round(Math.abs(entry.delta));
+
+	return `${formatEntry(entry)} (${sign}${magnitude})`;
+}
+
+function sanitizeName(name: string): string {
+	const cleaned = name
+		.replace(CONTROL_CHARS, "")
+		.replace(GRAMMAR_SEPARATORS, " ")
+		.replace(WHITESPACE_RUNS, " ")
+		.trim();
+
+	return truncateName(cleaned);
+}
+
+function truncateName(name: string): string {
+	if (name.length <= MAX_LENGTH) {
+		return name;
+	}
+
+	let cut = MAX_LENGTH;
+	const boundaryUnit = name.charCodeAt(cut - 1);
+	const boundaryIsHighSurrogate = boundaryUnit >= 0xd800 && boundaryUnit <= 0xdbff;
+	if (boundaryIsHighSurrogate) {
+		cut -= 1;
+	}
+
+	return `${name.slice(0, cut)}${ELLIPSIS}`;
+}

--- a/src/shared/stats/rating/domain/RatingEligibility.test.ts
+++ b/src/shared/stats/rating/domain/RatingEligibility.test.ts
@@ -1,0 +1,101 @@
+import { Team } from "@shared/room/Team";
+
+import { evaluateRatingEligibility } from "./RatingEligibility";
+
+function makePlayers(overrides?: { winnerId?: string | null; loserId?: string | null }) {
+	return [
+		{
+			id: "winnerId" in (overrides ?? {}) ? (overrides?.winnerId as string | null) : "player-1",
+			team: Team.PLAYER,
+			name: "Diango",
+			winner: true,
+		},
+		{
+			id: "loserId" in (overrides ?? {}) ? (overrides?.loserId as string | null) : "player-2",
+			team: Team.OPPONENT,
+			name: "Rival",
+			winner: false,
+		},
+	];
+}
+
+describe("evaluateRatingEligibility", () => {
+	describe("G1 — eligible ranked match", () => {
+		it("returns eligible with the banlist and players carried through", () => {
+			const result = evaluateRatingEligibility({
+				ranked: true,
+				banListName: "TCG",
+				players: makePlayers(),
+			});
+
+			expect(result).toEqual({
+				eligible: true,
+				banListName: "TCG",
+				players: [
+					{ id: "player-1", team: Team.PLAYER, name: "Diango", winner: true },
+					{ id: "player-2", team: Team.OPPONENT, name: "Rival", winner: false },
+				],
+			});
+		});
+	});
+
+	describe("G2 — unranked match excluded", () => {
+		it("returns ineligible with reason unranked", () => {
+			const result = evaluateRatingEligibility({
+				ranked: false,
+				banListName: "TCG",
+				players: makePlayers(),
+			});
+
+			expect(result).toEqual({ eligible: false, reason: "unranked" });
+		});
+	});
+
+	describe("G3 — N/A banlist excluded", () => {
+		it("returns ineligible with reason no-ranked-banlist", () => {
+			const result = evaluateRatingEligibility({
+				ranked: true,
+				banListName: "N/A",
+				players: makePlayers(),
+			});
+
+			expect(result).toEqual({ eligible: false, reason: "no-ranked-banlist" });
+		});
+	});
+
+	describe("G4 — missing account id excluded", () => {
+		it("returns ineligible with reason missing-account-id and the exact count", () => {
+			const result = evaluateRatingEligibility({
+				ranked: true,
+				banListName: "TCG",
+				players: makePlayers({ loserId: null }),
+			});
+
+			expect(result).toEqual({ eligible: false, reason: "missing-account-id", missingIdCount: 1 });
+		});
+
+		it("counts every participant missing an id, not just the first", () => {
+			const result = evaluateRatingEligibility({
+				ranked: true,
+				banListName: "TCG",
+				players: makePlayers({ winnerId: null, loserId: null }),
+			});
+
+			expect(result).toEqual({ eligible: false, reason: "missing-account-id", missingIdCount: 2 });
+		});
+	});
+
+	describe("G6 — gate consistency", () => {
+		it("is a pure function: evaluating the same eligible match twice yields equal results", () => {
+			const match = { ranked: true, banListName: "TCG", players: makePlayers() };
+
+			expect(evaluateRatingEligibility(match)).toEqual(evaluateRatingEligibility(match));
+		});
+
+		it("is a pure function: evaluating the same ineligible match twice yields equal results", () => {
+			const match = { ranked: true, banListName: "N/A", players: makePlayers() };
+
+			expect(evaluateRatingEligibility(match)).toEqual(evaluateRatingEligibility(match));
+		});
+	});
+});

--- a/src/shared/stats/rating/domain/RatingEligibility.ts
+++ b/src/shared/stats/rating/domain/RatingEligibility.ts
@@ -1,0 +1,53 @@
+import type { Team } from "@shared/room/Team";
+
+export type RatedMatchPlayer = {
+	id: string;
+	team: Team;
+	name: string;
+	winner: boolean;
+};
+
+export type RatingEligibilityMatchPlayer = {
+	id: string | null;
+	team: Team;
+	name: string;
+	winner: boolean;
+};
+
+export type RatingEligibilityMatch = {
+	ranked: boolean;
+	banListName: string;
+	players: RatingEligibilityMatchPlayer[];
+};
+
+export type RatingEligibility =
+	| { eligible: true; banListName: string; players: RatedMatchPlayer[] }
+	| { eligible: false; reason: "unranked" }
+	| { eligible: false; reason: "no-ranked-banlist" }
+	| { eligible: false; reason: "missing-account-id"; missingIdCount: number };
+
+export function evaluateRatingEligibility(match: RatingEligibilityMatch): RatingEligibility {
+	if (!match.ranked) {
+		return { eligible: false, reason: "unranked" };
+	}
+
+	if (!match.banListName || match.banListName === "N/A") {
+		return { eligible: false, reason: "no-ranked-banlist" };
+	}
+
+	const missingIdCount = match.players.filter((player) => player.id === null).length;
+	if (missingIdCount > 0) {
+		return { eligible: false, reason: "missing-account-id", missingIdCount };
+	}
+
+	return {
+		eligible: true,
+		banListName: match.banListName,
+		players: match.players.map((player) => ({
+			id: player.id as string,
+			team: player.team,
+			name: player.name,
+			winner: player.winner,
+		})),
+	};
+}

--- a/src/shared/stats/rating/domain/RatingRepository.test.ts
+++ b/src/shared/stats/rating/domain/RatingRepository.test.ts
@@ -1,0 +1,19 @@
+import { mock } from "jest-mock-extended";
+
+import { Rating } from "./Rating";
+import { RatingRepository } from "./RatingRepository";
+
+describe("RatingRepository — findMany port contract", () => {
+	it("exposes findMany(userIds, banListName, season) returning a Promise<Map<string, Rating>>", async () => {
+		const repository = mock<RatingRepository>();
+		const ratings = new Map<string, Rating>([
+			["player-1", Rating.from({ value: 1050, gamesPlayed: 12, peak: 1080 })],
+		]);
+		repository.findMany.mockResolvedValue(ratings);
+
+		const result = await repository.findMany(["player-1"], "TCG", 5);
+
+		expect(repository.findMany).toHaveBeenCalledWith(["player-1"], "TCG", 5);
+		expect(result).toBe(ratings);
+	});
+});

--- a/src/shared/stats/rating/domain/RatingRepository.ts
+++ b/src/shared/stats/rating/domain/RatingRepository.ts
@@ -42,4 +42,12 @@ export interface RatingRepository {
 		season: number,
 		work: (ratings: Map<string, Rating>, tx: RatingTransaction) => Promise<T>,
 	): Promise<T>;
+
+	/**
+	 * Reads current ratings for the given users without acquiring any row
+	 * lock, defaulting missing rows to a fresh season-start rating. Read-only
+	 * display path — must never interfere with `transaction`'s write-side
+	 * locking.
+	 */
+	findMany(userIds: string[], banListName: string, season: number): Promise<Map<string, Rating>>;
 }

--- a/src/shared/stats/rating/domain/__fixtures__/ratingAnnouncement.fixture.json
+++ b/src/shared/stats/rating/domain/__fixtures__/ratingAnnouncement.fixture.json
@@ -1,0 +1,136 @@
+{
+	"oneVOneStart": {
+		"parsed": {
+			"kind": "start",
+			"teams": [
+				[
+					{
+						"name": "Diango",
+						"rating": 1000
+					}
+				],
+				[
+					{
+						"name": "Rival",
+						"rating": 980
+					}
+				]
+			]
+		},
+		"frame": "[Rating v1 start] Diango 1000 | Rival 980"
+	},
+	"oneVOneEnd": {
+		"parsed": {
+			"kind": "end",
+			"teams": [
+				[
+					{
+						"name": "Diango",
+						"rating": 1012,
+						"delta": 12
+					}
+				],
+				[
+					{
+						"name": "Rival",
+						"rating": 968,
+						"delta": -12
+					}
+				]
+			]
+		},
+		"frame": "[Rating v1 end] Diango 1012 (+12) | Rival 968 (-12)"
+	},
+	"twoVTwoStart": {
+		"parsed": {
+			"kind": "start",
+			"teams": [
+				[
+					{
+						"name": "Diango",
+						"rating": 1000
+					},
+					{
+						"name": "Ally",
+						"rating": 1100
+					}
+				],
+				[
+					{
+						"name": "Rival",
+						"rating": 980
+					},
+					{
+						"name": "Foe",
+						"rating": 1200
+					}
+				]
+			]
+		},
+		"frame": "[Rating v1 start] Diango 1000 · Ally 1100 | Rival 980 · Foe 1200"
+	},
+	"twoVTwoEnd": {
+		"parsed": {
+			"kind": "end",
+			"teams": [
+				[
+					{
+						"name": "Diango",
+						"rating": 1012,
+						"delta": 12
+					},
+					{
+						"name": "Ally",
+						"rating": 1108,
+						"delta": 8
+					}
+				],
+				[
+					{
+						"name": "Rival",
+						"rating": 968,
+						"delta": -12
+					},
+					{
+						"name": "Foe",
+						"rating": 1192,
+						"delta": -8
+					}
+				]
+			]
+		},
+		"frame": "[Rating v1 end] Diango 1012 (+12) · Ally 1108 (+8) | Rival 968 (-12) · Foe 1192 (-8)"
+	},
+	"worstCaseEnd": {
+		"parsed": {
+			"kind": "end",
+			"teams": [
+				[
+					{
+						"name": "AAAAAAAAAAAAAAAAAAAA",
+						"rating": 999999,
+						"delta": 9999
+					},
+					{
+						"name": "BBBBBBBBBBBBBBBBBBBB",
+						"rating": 999999,
+						"delta": 9999
+					}
+				],
+				[
+					{
+						"name": "CCCCCCCCCCCCCCCCCCCC",
+						"rating": 999999,
+						"delta": -9999
+					},
+					{
+						"name": "DDDDDDDDDDDDDDDDDDDD",
+						"rating": 999999,
+						"delta": -9999
+					}
+				]
+			]
+		},
+		"frame": "[Rating v1 end] AAAAAAAAAAAAAAAAAAAA 999999 (+9999) · BBBBBBBBBBBBBBBBBBBB 999999 (+9999) | CCCCCCCCCCCCCCCCCCCC 999999 (-9999) · DDDDDDDDDDDDDDDDDDDD 999999 (-9999)"
+	}
+}

--- a/src/shared/stats/rating/infrastructure/RatingPostgresRepository.test.ts
+++ b/src/shared/stats/rating/infrastructure/RatingPostgresRepository.test.ts
@@ -11,6 +11,7 @@ import { dataSource } from "../../../../evolution-types/src/data-source";
 jest.mock("../../../../evolution-types/src/data-source", () => ({
 	dataSource: {
 		transaction: jest.fn(),
+		query: jest.fn(),
 	},
 }));
 
@@ -144,6 +145,45 @@ describe("RatingPostgresRepository", () => {
 			});
 
 			expect(inserted).toBe(false);
+		});
+	});
+
+	describe("findMany()", () => {
+		it("R1 — reads current ratings for the given users without acquiring any row lock", async () => {
+			(dataSource.query as jest.Mock).mockResolvedValueOnce([
+				{ userId: "user-a", rating: 1200, gamesPlayed: 15, peak: 1250 },
+			]);
+
+			const result = await repository.findMany(["user-a"], "TCG", 5);
+
+			expect(dataSource.query).toHaveBeenCalledTimes(1);
+			expect(dataSource.query).toHaveBeenCalledWith(expect.any(String), ["TCG", 5, ["user-a"]]);
+			expect((dataSource.query as jest.Mock).mock.calls[0][0]).not.toEqual(
+				expect.stringContaining("FOR UPDATE"),
+			);
+			expect(dataSource.transaction).not.toHaveBeenCalled();
+			expect(result.get("user-a")).toEqual(
+				Rating.from({ value: 1200, gamesPlayed: 15, peak: 1250 }),
+			);
+		});
+
+		it("R2 — defaults a user with no rating row to the season-start value (1000)", async () => {
+			(dataSource.query as jest.Mock).mockResolvedValueOnce([]);
+
+			const result = await repository.findMany(["user-a"], "TCG", 5);
+
+			expect(result.get("user-a")).toEqual(Rating.initialize());
+		});
+
+		it("R3 — reads without acquiring the advisory participant locks used by the write path", async () => {
+			(dataSource.query as jest.Mock).mockResolvedValueOnce([]);
+
+			await repository.findMany(["user-a", "user-b"], "TCG", 5);
+
+			expect(dataSource.query).toHaveBeenCalledTimes(1);
+			expect((dataSource.query as jest.Mock).mock.calls[0][0]).not.toEqual(
+				expect.stringContaining("pg_advisory_xact_lock"),
+			);
 		});
 	});
 

--- a/src/shared/stats/rating/infrastructure/RatingPostgresRepository.ts
+++ b/src/shared/stats/rating/infrastructure/RatingPostgresRepository.ts
@@ -23,6 +23,15 @@ const LOCK_RATINGS_QUERY = `
 	FOR UPDATE
 `;
 
+// Same shape as LOCK_RATINGS_QUERY minus FOR UPDATE: a display-only read must
+// never take a row lock or otherwise interfere with the write path above.
+const FIND_RATINGS_QUERY = `
+	SELECT user_id AS "userId", rating, games_played AS "gamesPlayed", peak
+	FROM player_ratings
+	WHERE ban_list_name = $1 AND season = $2 AND user_id = ANY($3)
+	ORDER BY user_id ASC
+`;
+
 const INSERT_HISTORY_QUERY = `
 	INSERT INTO rating_history (match_id, user_id, ban_list_name, season, kind, previous_rating, delta, k_factor, opponent_rating)
 	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
@@ -89,19 +98,37 @@ export class RatingPostgresRepository implements RatingRepository {
 			orderedIds,
 		]);
 
-		const ratings = new Map<string, Rating>();
-		for (const userId of orderedIds) {
-			const row = rows.find((item) => item.userId === userId);
-			ratings.set(
-				userId,
-				row
-					? Rating.from({ value: row.rating, gamesPlayed: row.gamesPlayed, peak: row.peak })
-					: Rating.initialize(),
-			);
-		}
-
-		return ratings;
+		return toRatingsMap(orderedIds, rows);
 	}
+
+	async findMany(
+		userIds: string[],
+		banListName: string,
+		season: number,
+	): Promise<Map<string, Rating>> {
+		const rows: PlayerRatingRow[] = await dataSource.query(FIND_RATINGS_QUERY, [
+			banListName,
+			season,
+			userIds,
+		]);
+
+		return toRatingsMap(userIds, rows);
+	}
+}
+
+function toRatingsMap(userIds: string[], rows: PlayerRatingRow[]): Map<string, Rating> {
+	const ratings = new Map<string, Rating>();
+	for (const userId of userIds) {
+		const row = rows.find((item) => item.userId === userId);
+		ratings.set(
+			userId,
+			row
+				? Rating.from({ value: row.rating, gamesPlayed: row.gamesPlayed, peak: row.peak })
+				: Rating.initialize(),
+		);
+	}
+
+	return ratings;
 }
 
 class RatingPostgresTransaction implements RatingTransaction {


### PR DESCRIPTION
## Summary
- Extracts the rating eligibility gate into a pure shared domain function (used by the elo-rating plugin; its tests are unchanged) so any announcer agrees exactly with what gets persisted.
- Adds `RatingRepository.findMany` — an unlocked read for duel-start lookups (no `FOR UPDATE`, no advisory lock), defaulting missing rows to the season start value.
- Adds the pure `[Rating v1 …]` chat announcement format (START/END frames, 1v1 and 2v2, nickname truncation) with canonical JSON fixtures shared byte-identical with the web client, plus a length-pin test against the real STOC_CHAT 256 UTF-16 limit.

Chain 1/3 of the live rating announcements (follows the merged #349).