### PR TITLE
fix(ygopro): send the room-creation notice on the ygopro pipeline

### DIFF
--- a/src/edopro/room/application/GameCreatorHandler.ts
+++ b/src/edopro/room/application/GameCreatorHandler.ts
@@ -2,12 +2,10 @@ import { UserAuth } from "src/shared/user-auth/application/UserAuth";
 import { UserProfile } from "src/shared/user-profile/domain/UserProfile";
 import { EventEmitter } from "stream";
 
-import { ChatColor } from "ygopro-msg-encode";
-
 import { config } from "../../../config";
 import { Logger } from "../../../shared/logger/domain/Logger";
 import { GameCreatorMessageHandler } from "../../../shared/room/domain/GameCreatorMessageHandler";
-import { createSystemChat } from "../../../shared/room/domain/chat/SystemChat";
+import { roomCreationNotice } from "../../../shared/room/domain/chat/RoomCreationNotice";
 import { ISocket } from "../../../shared/socket/domain/ISocket";
 import { CreateGameMessage } from "../../messages/client-to-server/CreateGameMessage";
 import { PlayerInfoMessage } from "../../messages/client-to-server/PlayerInfoMessage";
@@ -95,31 +93,11 @@ export class GameCreatorHandler implements GameCreatorMessageHandler {
 
 	/**
 	 * One-line, colored room-creation notice replacing the old three-clause
-	 * WELCOME banner. Ranking-disabled takes priority only for a room that
-	 * would otherwise be unranked — a room the client already flagged
-	 * ranked (via the password convention) still gets the ranked notice,
-	 * matching the pre-existing branch order.
+	 * WELCOME banner.
 	 */
 	private sendRoomCreationNotice(room: Room): void {
-		if (room.ranked) {
-			this.socket.send(
-				createSystemChat(ChatColor.GREEN, "Ranked room — results count toward your rating."),
-			);
-			return;
-		}
-
-		if (!config.ranking.enabled) {
-			this.socket.send(
-				createSystemChat(
-					ChatColor.YELLOW,
-					"Ranking is temporarily unavailable — this match won't be rated.",
-				),
-			);
-			return;
-		}
-
 		this.socket.send(
-			createSystemChat(ChatColor.WHITE, "Casual room — results won't affect your rating."),
+			roomCreationNotice({ ranked: room.ranked, rankingEnabled: config.ranking.enabled }),
 		);
 	}
 }

--- a/src/shared/room/domain/chat/RoomCreationNotice.test.ts
+++ b/src/shared/room/domain/chat/RoomCreationNotice.test.ts
@@ -1,0 +1,49 @@
+import { ChatColor, YGOProStocChat } from "ygopro-msg-encode";
+
+import { roomCreationNotice } from "./RoomCreationNotice";
+
+const expectedFrame = (color: ChatColor, text: string): Buffer =>
+	Buffer.from(new YGOProStocChat().fromPartial({ player_type: color, msg: text }).toFullPayload());
+
+describe("roomCreationNotice", () => {
+	it("returns a GREEN notice for a ranked room while ranking is enabled", () => {
+		const frame = roomCreationNotice({ ranked: true, rankingEnabled: true });
+
+		expect(frame).toEqual(
+			expectedFrame(ChatColor.GREEN, "Ranked room — results count toward your rating."),
+		);
+	});
+
+	it("returns a WHITE notice for a casual room while ranking is enabled", () => {
+		const frame = roomCreationNotice({ ranked: false, rankingEnabled: true });
+
+		expect(frame).toEqual(
+			expectedFrame(ChatColor.WHITE, "Casual room — results won't affect your rating."),
+		);
+	});
+
+	// Ranking-disabled takes priority over the ranked flag: a room that was
+	// flagged ranked before the global toggle flipped off must still fall
+	// back to the disabled notice, not a stale GREEN one.
+	it("returns a YELLOW notice when ranking is globally disabled, even for a ranked room", () => {
+		const frame = roomCreationNotice({ ranked: true, rankingEnabled: false });
+
+		expect(frame).toEqual(
+			expectedFrame(
+				ChatColor.YELLOW,
+				"Ranking is temporarily unavailable — this match won't be rated.",
+			),
+		);
+	});
+
+	it("returns a YELLOW notice for a casual room when ranking is globally disabled", () => {
+		const frame = roomCreationNotice({ ranked: false, rankingEnabled: false });
+
+		expect(frame).toEqual(
+			expectedFrame(
+				ChatColor.YELLOW,
+				"Ranking is temporarily unavailable — this match won't be rated.",
+			),
+		);
+	});
+});

--- a/src/shared/room/domain/chat/RoomCreationNotice.ts
+++ b/src/shared/room/domain/chat/RoomCreationNotice.ts
@@ -1,0 +1,34 @@
+import { ChatColor } from "ygopro-msg-encode";
+
+import { createSystemChat } from "./SystemChat";
+
+/**
+ * The room-creation notice both pipelines show their host: a single colored
+ * line stating whether the room counts toward rating. Ranking-disabled is
+ * checked before the ranked flag — on edopro a room can never be flagged
+ * ranked while ranking is globally off (Room.isRanked already forces it
+ * false), so this order is a no-op there, but on the ygopro/Mercury
+ * pipeline the league never consults the ranking toggle at all, so without
+ * this order a verified/external room would show a false GREEN instead of
+ * the disabled-ranking warning.
+ */
+export function roomCreationNotice({
+	ranked,
+	rankingEnabled,
+}: {
+	ranked: boolean;
+	rankingEnabled: boolean;
+}): Buffer {
+	if (!rankingEnabled) {
+		return createSystemChat(
+			ChatColor.YELLOW,
+			"Ranking is temporarily unavailable — this match won't be rated.",
+		);
+	}
+
+	if (ranked) {
+		return createSystemChat(ChatColor.GREEN, "Ranked room — results count toward your rating.");
+	}
+
+	return createSystemChat(ChatColor.WHITE, "Casual room — results won't affect your rating.");
+}

--- a/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.test.ts
@@ -16,7 +16,10 @@ import { AdmitToRoom } from "../../admission/application/AdmitToRoom";
 import { ISocket } from "@shared/socket/domain/ISocket";
 import { RoomLeague } from "@shared/room/admission/domain/RoomLeague";
 import { PlayerCredential } from "@shared/room/admission/domain/PlayerCredential";
+import { roomCreationNotice } from "@shared/room/domain/chat/RoomCreationNotice";
 import { ErrorMessageType } from "ygopro-msg-encode";
+
+import { config } from "../../../../config";
 
 // ---- helpers ----
 
@@ -254,6 +257,8 @@ describe("YGOProWaitingState.handleJoin", () => {
 		({
 			ranked: false,
 			players: [],
+			league: RoomLeague.Casual,
+			createdBySocketId: "sock-test",
 			mutex: {
 				runExclusive: jest.fn().mockImplementation(async (fn: () => Promise<void>) => fn()),
 			},
@@ -464,6 +469,70 @@ describe("YGOProWaitingState.handleJoin", () => {
 
 			expect(mockAdmitToRoom.run).toHaveBeenCalled();
 			expect(mockSocket.close).not.toHaveBeenCalled();
+		});
+	});
+
+	// The edopro pipeline sends this via GameCreatorHandler right after room
+	// creation; the ygopro/Mercury pipeline creates the room inside the JOIN
+	// flow and only seats the creator once admission succeeds here, so this
+	// is the one place that path can send it.
+	describe("room creation notice", () => {
+		const originalRankingEnabled = config.ranking.enabled;
+
+		afterEach(() => {
+			config.ranking.enabled = originalRankingEnabled;
+		});
+
+		it("sends the creator's room-creation notice once they are seated as the first player", async () => {
+			config.ranking.enabled = true;
+			(mockRoom as unknown as { league: RoomLeague }).league = RoomLeague.External;
+			(mockRoom as unknown as { players: unknown[] }).players = [{}];
+			mockAdmitToRoom.run.mockResolvedValue({
+				kind: "player",
+				credential: { kind: "external", userId: "u" } as PlayerCredential,
+				seat: { position: 0, team: 0 },
+			});
+
+			await emitJoin(mockRoom, mockSocket);
+
+			expect(mockSocket.send).toHaveBeenCalledWith(
+				roomCreationNotice({ ranked: true, rankingEnabled: true }),
+			);
+		});
+
+		it("does not send the notice when a second player is seated", async () => {
+			config.ranking.enabled = true;
+			(mockRoom as unknown as { league: RoomLeague }).league = RoomLeague.Casual;
+			(mockRoom as unknown as { createdBySocketId: string }).createdBySocketId = "creator-socket";
+			(mockRoom as unknown as { players: unknown[] }).players = [{}, {}];
+			mockAdmitToRoom.run.mockResolvedValue({
+				kind: "player",
+				credential: { kind: "guest", name: "Jaden" } as PlayerCredential,
+				seat: { position: 1, team: 0 },
+			});
+
+			await emitJoin(mockRoom, mockSocket);
+
+			expect(mockSocket.send).not.toHaveBeenCalled();
+		});
+
+		it("does not send the notice when the creator's socket is only admitted as a spectator", async () => {
+			mockAdmitToRoom.run.mockResolvedValue({ kind: "spectator" });
+
+			await emitJoin(mockRoom, mockSocket);
+
+			expect(mockSocket.send).not.toHaveBeenCalled();
+		});
+
+		it("does not send the notice when admission rejects the creator's socket", async () => {
+			mockAdmitToRoom.run.mockResolvedValue({
+				kind: "rejected",
+				reason: "ranked-requires-account",
+			});
+
+			await emitJoin(mockRoom, mockSocket);
+
+			expect(mockSocket.send).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/ygopro/room/domain/states/YGOProWaitingState.ts
+++ b/src/ygopro/room/domain/states/YGOProWaitingState.ts
@@ -8,8 +8,10 @@ import { YgoClient } from "@shared/client/domain/YgoClient";
 import { Logger } from "@shared/logger/domain/Logger";
 import { ISocket } from "@shared/socket/domain/ISocket";
 import { ReconnectionTokenIssuer } from "@shared/room/application/reconnect/ReconnectionTokenIssuer";
+import { Admission } from "@shared/room/admission/domain/Admission";
 import { isNameTaken } from "@shared/room/domain/isNameTaken";
 import { createSystemChat } from "@shared/room/domain/chat/SystemChat";
+import { roomCreationNotice } from "@shared/room/domain/chat/RoomCreationNotice";
 
 import { YGOProClient } from "../../../client/domain/YGOProClient";
 import { YGOProRoom } from "../YGOProRoom";
@@ -23,6 +25,7 @@ import { encodeDeckErrorCode } from "@shared/deck/domain/errors/encodeDeckErrorC
 import { YGOProRoomState } from "../YGOProRoomState";
 import MercuryBanListMemoryRepository from "@ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository";
 import { mercuryConfig } from "@ygopro/config";
+import { config } from "../../../../config";
 import { YGOProJoinGameMessage } from "@ygopro/messages/YGOProJoinGameMessage";
 
 export class YGOProWaitingState extends YGOProRoomState {
@@ -94,12 +97,40 @@ export class YGOProWaitingState extends YGOProRoomState {
 		}
 
 		await room.mutex.runExclusive(async () => {
-			await this.admitToRoom.run(
+			const result = await this.admitToRoom.run(
 				socket,
 				playerInfoMessage,
 				room.admissionTarget(socket, playerInfoMessage),
 			);
+
+			this.sendRoomCreationNoticeToCreator(room, socket, result);
 		});
+	}
+
+	/**
+	 * The edopro pipeline sends this right after CREATE_GAME. This pipeline
+	 * instead creates the room inside the JOIN flow (findOrCreateRoom) and
+	 * only seats the creator once admission succeeds here — so this is the
+	 * one point that can fire it, guarded to the creator's own first seat so
+	 * later joiners, spectators, rejections and reconnects never see it.
+	 */
+	private sendRoomCreationNoticeToCreator(
+		room: YGOProRoom,
+		socket: ISocket,
+		result: Admission | undefined,
+	): void {
+		if (
+			result?.kind === "player" &&
+			socket.id === room.createdBySocketId &&
+			room.players.length === 1
+		) {
+			socket.send(
+				roomCreationNotice({
+					ranked: room.league.isRanked,
+					rankingEnabled: config.ranking.enabled,
+				}),
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary
The colored room-creation notice added in #353 only fired on the edopro pipeline (`GameCreatorHandler`); ygopro/Mercury rooms are created inside the JOIN flow and never sent it.

- Extracts the three notice lines into a shared `roomCreationNotice()` builder next to `SystemChat`, now used by both pipelines — texts live once.
- ygopro hook: the notice is sent when the creator's JOIN succeeds as a player, triple-guarded (admission result is `player`, socket is `createdBySocketId`, first seat) so later joiners, spectators, rejections and reconnects never see it.
- Branch-order fix baked into the helper: ranking-disabled is checked before the ranked flag — on ygopro the league never consults the ranking toggle, so a verified/external room with ranking off now gets the YELLOW warning instead of a false GREEN. No-op on edopro, where `Room.isRanked` already forces false.

8 new tests (RED-first); full suite 1698/1698 green, build and lint clean.