### PR TITLE
feat(rank): key player stats and ratings by rank_id

### DIFF
--- a/src/plugins/basic-stats/application/BasicStatsCalculator.test.ts
+++ b/src/plugins/basic-stats/application/BasicStatsCalculator.test.ts
@@ -7,12 +7,15 @@ import { MatchResumeCreator } from "@shared/stats/match-resume/application/Match
 import { DuelResumeCreator } from "@shared/stats/match-resume/duel-resume/application/DuelResumeCreator";
 import { PlayerStats } from "@shared/stats/player-stats/domain/PlayerStats";
 import { PlayerStatsRepository } from "@shared/stats/player-stats/domain/PlayerStatsRepository";
+import { Rank } from "@shared/rank/domain/Rank";
+import { RankRepository } from "@shared/rank/domain/RankRepository";
 import { UserProfile } from "@shared/user-profile/domain/UserProfile";
 import { UserProfileRepository } from "@shared/user-profile/domain/UserProfileRepository";
 import { GameMother } from "@test-support/mothers/player/GameMother";
 import { GameOverDomainEventMother } from "@test-support/mothers/player/GameOverDomainEventMother";
 import { PlayerMother } from "@test-support/mothers/player/PlayerMother";
 import { PlayerStatsMother } from "@test-support/mothers/player/PlayerStatsMother";
+import { RankMother } from "@test-support/mothers/rank/RankMother";
 import { UserProfileMother } from "@test-support/mothers/user-profile/UserProfileMother";
 
 import { BasicStatsCalculator } from "./BasicStatsCalculator";
@@ -25,6 +28,7 @@ describe("BasicStatsCalculator", () => {
 	let logger: MockProxy<Logger>;
 	let userProfileRepository: MockProxy<UserProfileRepository>;
 	let playerStatsRepository: MockProxy<PlayerStatsRepository>;
+	let rankRepository: MockProxy<RankRepository>;
 	let matchResumeCreator: MockProxy<MatchResumeCreator>;
 	let duelResumeCreator: MockProxy<DuelResumeCreator>;
 	let playerUserProfile: UserProfile;
@@ -32,12 +36,15 @@ describe("BasicStatsCalculator", () => {
 	let playerStats: PlayerStats;
 	let opponentStats: PlayerStats;
 	let matchId: string;
+	let globalRank: Rank;
+	let formatRank: Rank;
 
 	beforeEach(() => {
 		logger = mock<Logger>();
 		logger.child.mockReturnValue(logger);
 		userProfileRepository = mock();
 		playerStatsRepository = mock<PlayerStatsRepository>();
+		rankRepository = mock<RankRepository>();
 		matchResumeCreator = mock();
 		duelResumeCreator = mock();
 		playerUserProfile = UserProfileMother.create();
@@ -45,6 +52,11 @@ describe("BasicStatsCalculator", () => {
 		playerStats = PlayerStatsMother.create();
 		opponentStats = PlayerStatsMother.create();
 		matchId = faker.string.uuid();
+		globalRank = RankMother.create({ name: "Global", type: "global" });
+		formatRank = RankMother.create();
+		rankRepository.findOrCreateByName.mockImplementation(async (name) =>
+			name === "Global" ? globalRank : { ...formatRank, name },
+		);
 	});
 
 	beforeEach(() => {
@@ -52,6 +64,7 @@ describe("BasicStatsCalculator", () => {
 			logger,
 			userProfileRepository,
 			playerStatsRepository,
+			rankRepository,
 			matchResumeCreator,
 			duelResumeCreator,
 		);
@@ -78,7 +91,7 @@ describe("BasicStatsCalculator", () => {
 			.mockResolvedValueOnce(playerUserProfile)
 			.mockResolvedValueOnce(opponentUserProfile);
 
-		playerStatsRepository.findByUserIdAndBanListName
+		playerStatsRepository.findByUserIdAndRankId
 			.mockResolvedValueOnce(playerStats)
 			.mockResolvedValueOnce(opponentStats);
 
@@ -119,18 +132,18 @@ describe("BasicStatsCalculator", () => {
 
 		await basicStatsCalculator.handle(event);
 
-		expect(playerStatsRepository.findByUserIdAndBanListName).toHaveBeenCalledTimes(2);
+		expect(playerStatsRepository.findByUserIdAndRankId).toHaveBeenCalledTimes(2);
 		expect(playerStatsRepository.save).toHaveBeenCalledTimes(2);
 
-		expect(playerStatsRepository.findByUserIdAndBanListName).toHaveBeenNthCalledWith(
+		expect(playerStatsRepository.findByUserIdAndRankId).toHaveBeenNthCalledWith(
 			1,
 			playerUserProfile.id,
-			"Global",
+			globalRank.id,
 		);
-		expect(playerStatsRepository.findByUserIdAndBanListName).toHaveBeenNthCalledWith(
+		expect(playerStatsRepository.findByUserIdAndRankId).toHaveBeenNthCalledWith(
 			2,
 			opponentUserProfile.id,
-			"Global",
+			globalRank.id,
 		);
 		expect(playerStatsRepository.save).toHaveBeenNthCalledWith(1, PlayerStats.from(playerStats));
 		expect(playerStatsRepository.save).toHaveBeenNthCalledWith(2, PlayerStats.from(opponentStats));
@@ -197,7 +210,7 @@ describe("BasicStatsCalculator", () => {
 
 	it("Should use banListName from event data (not from hash lookup) for per-format rank", async () => {
 		const edisonBanListName = "2010.03 Edison";
-		playerStatsRepository.findByUserIdAndBanListName
+		playerStatsRepository.findByUserIdAndRankId
 			.mockResolvedValueOnce(playerStats) // per-format lookup for player
 			.mockResolvedValueOnce(playerStats) // Global lookup for player
 			.mockResolvedValueOnce(opponentStats) // per-format lookup for opponent
@@ -212,14 +225,15 @@ describe("BasicStatsCalculator", () => {
 
 		await basicStatsCalculator.handle(event);
 
-		// Per-format lookup must use the name from event.data.banListName
-		expect(playerStatsRepository.findByUserIdAndBanListName).toHaveBeenCalledWith(
+		// Per-format rank must be resolved from the name in event.data.banListName
+		expect(rankRepository.findOrCreateByName).toHaveBeenCalledWith(edisonBanListName);
+		expect(playerStatsRepository.findByUserIdAndRankId).toHaveBeenCalledWith(
 			playerUserProfile.id,
-			edisonBanListName,
+			formatRank.id,
 		);
-		expect(playerStatsRepository.findByUserIdAndBanListName).toHaveBeenCalledWith(
+		expect(playerStatsRepository.findByUserIdAndRankId).toHaveBeenCalledWith(
 			opponentUserProfile.id,
-			edisonBanListName,
+			formatRank.id,
 		);
 	});
 
@@ -233,9 +247,50 @@ describe("BasicStatsCalculator", () => {
 
 		await basicStatsCalculator.handle(event);
 
-		// Only Global calls — no per-format call with "N/A"
-		const calls = playerStatsRepository.findByUserIdAndBanListName.mock.calls;
-		const perFormatCalls = calls.filter(([, name]) => name !== "Global");
+		// Only Global-rank calls — no rank resolution and no row for "N/A"
+		expect(rankRepository.findOrCreateByName).not.toHaveBeenCalledWith("N/A");
+		const calls = playerStatsRepository.findByUserIdAndRankId.mock.calls;
+		const perFormatCalls = calls.filter(([, rankId]) => rankId !== globalRank.id);
 		expect(perFormatCalls).toHaveLength(0);
+	});
+
+	it("writes one row for the banlist rank and one for the Global rank per player", async () => {
+		playerStatsRepository.findByUserIdAndRankId
+			.mockReset()
+			.mockResolvedValueOnce(playerStats) // per-format row for player
+			.mockResolvedValueOnce(playerStats) // Global row for player
+			.mockResolvedValueOnce(opponentStats) // per-format row for opponent
+			.mockResolvedValueOnce(opponentStats); // Global row for opponent
+		const event = GameOverDomainEventMother.create({
+			players: [player.toPresentation(), opponent.toPresentation()],
+			ranked: true,
+			banListName: "TCG",
+		});
+
+		await basicStatsCalculator.handle(event);
+
+		expect(rankRepository.findOrCreateByName).toHaveBeenCalledWith("TCG");
+		expect(rankRepository.findOrCreateByName).toHaveBeenCalledWith("Global");
+		expect(playerStatsRepository.findByUserIdAndRankId).toHaveBeenNthCalledWith(
+			1,
+			playerUserProfile.id,
+			formatRank.id,
+		);
+		expect(playerStatsRepository.findByUserIdAndRankId).toHaveBeenNthCalledWith(
+			2,
+			playerUserProfile.id,
+			globalRank.id,
+		);
+		expect(playerStatsRepository.findByUserIdAndRankId).toHaveBeenNthCalledWith(
+			3,
+			opponentUserProfile.id,
+			formatRank.id,
+		);
+		expect(playerStatsRepository.findByUserIdAndRankId).toHaveBeenNthCalledWith(
+			4,
+			opponentUserProfile.id,
+			globalRank.id,
+		);
+		expect(playerStatsRepository.save).toHaveBeenCalledTimes(4);
 	});
 });

--- a/src/plugins/basic-stats/application/BasicStatsCalculator.ts
+++ b/src/plugins/basic-stats/application/BasicStatsCalculator.ts
@@ -1,5 +1,6 @@
 import { Logger } from "src/shared/logger/domain/Logger";
 import { Player } from "src/shared/player/domain/Player";
+import { RankRepository } from "src/shared/rank/domain/RankRepository";
 import { UserProfileRepository } from "src/shared/user-profile/domain/UserProfileRepository";
 
 import { DomainEventSubscriber } from "../../../shared/event-bus/EventBus";
@@ -16,6 +17,7 @@ export class BasicStatsCalculator implements DomainEventSubscriber<GameOverDomai
 		private readonly logger: Logger,
 		private readonly userProfileRepository: UserProfileRepository,
 		private readonly playerStatsRepository: PlayerStatsRepository,
+		private readonly rankRepository: RankRepository,
 		private readonly matchResumeCreator: MatchResumeCreator,
 		private readonly duelResumeCreator: DuelResumeCreator,
 	) {
@@ -38,6 +40,12 @@ export class BasicStatsCalculator implements DomainEventSubscriber<GameOverDomai
 
 		const gameId = event.data.matchId;
 
+		const banListRank =
+			banListName && banListName !== "N/A"
+				? await this.rankRepository.findOrCreateByName(banListName)
+				: null;
+		const globalRank = await this.rankRepository.findOrCreateByName("Global");
+
 		for (const player of players) {
 			const userProfile = await this.userProfileRepository.findByUsername(player.name);
 			if (!userProfile) {
@@ -57,19 +65,19 @@ export class BasicStatsCalculator implements DomainEventSubscriber<GameOverDomai
 				.map((element) => element.id);
 			const points = player.calculateMatchPoints();
 			this.logger.info(`Player ${player.name} and id: ${userProfile.id} gain ${points} points`);
-			if (banListName && banListName !== "N/A") {
-				const playerStats = await this.playerStatsRepository.findByUserIdAndBanListName(
+			if (banListRank) {
+				const playerStats = await this.playerStatsRepository.findByUserIdAndRankId(
 					userProfile.id,
-					banListName,
+					banListRank.id,
 				);
 				playerStats.addPoints(points);
 				player.winner ? playerStats.increaseWins() : playerStats.increaseLosses();
 				void this.playerStatsRepository.save(playerStats);
 			}
 
-			const globalPlayerStats = await this.playerStatsRepository.findByUserIdAndBanListName(
+			const globalPlayerStats = await this.playerStatsRepository.findByUserIdAndRankId(
 				userProfile.id,
-				"Global",
+				globalRank.id,
 			);
 			globalPlayerStats.addPoints(points);
 			player.winner ? globalPlayerStats.increaseWins() : globalPlayerStats.increaseLosses();

--- a/src/plugins/basic-stats/index.ts
+++ b/src/plugins/basic-stats/index.ts
@@ -3,6 +3,7 @@ import { PluginDeps, ServerPlugin } from "@shared/plugin/ServerPlugin";
 import { MatchResumeCreator } from "@shared/stats/match-resume/application/MatchResumeCreator";
 import { DuelResumeCreator } from "@shared/stats/match-resume/duel-resume/application/DuelResumeCreator";
 import { MatchResumePostgresRepository } from "@shared/stats/match-resume/infrastructure/postgres/MatchResumePostgresRepository";
+import { RankPostgresRepository } from "@shared/rank/infrastructure/RankPostgresRepository";
 import { PlayerStatsPostgresRepository } from "@shared/stats/player-stats/infrastructure/PlayerStatsPostgresRepository";
 import { UserProfilePostgresRepository } from "@shared/user-profile/infrastructure/postgres/UserProfilePostgresRepository";
 
@@ -21,6 +22,7 @@ const plugin: ServerPlugin = {
 				deps.logger,
 				new UserProfilePostgresRepository(),
 				new PlayerStatsPostgresRepository(),
+				new RankPostgresRepository(),
 				new MatchResumeCreator(new MatchResumePostgresRepository()),
 				new DuelResumeCreator(new MatchResumePostgresRepository()),
 			),

--- a/src/plugins/elo-rating/application/EloRatingCalculator.test.ts
+++ b/src/plugins/elo-rating/application/EloRatingCalculator.test.ts
@@ -1,11 +1,14 @@
 import { mock, MockProxy } from "jest-mock-extended";
 import { Logger } from "@shared/logger/domain/Logger";
+import { Rank } from "@shared/rank/domain/Rank";
+import { RankRepository } from "@shared/rank/domain/RankRepository";
 import { Team } from "@shared/room/Team";
 import { Rating } from "@shared/stats/rating/domain/Rating";
 import { RatingRepository, RatingTransaction } from "@shared/stats/rating/domain/RatingRepository";
 import { UserProfileRepository } from "@shared/user-profile/domain/UserProfileRepository";
 import { GameOverDomainEventMother } from "@test-support/mothers/player/GameOverDomainEventMother";
 import { PlayerMother } from "@test-support/mothers/player/PlayerMother";
+import { RankMother } from "@test-support/mothers/rank/RankMother";
 import { RatingMother } from "@test-support/mothers/player/RatingMother";
 import { UserProfileMother } from "@test-support/mothers/user-profile/UserProfileMother";
 
@@ -17,6 +20,8 @@ describe("EloRatingCalculator", () => {
 	let logger: MockProxy<Logger>;
 	let userProfileRepository: MockProxy<UserProfileRepository>;
 	let ratingRepository: MockProxy<RatingRepository>;
+	let rankRepository: MockProxy<RankRepository>;
+	let rank: Rank;
 	let tx: MockProxy<RatingTransaction>;
 
 	beforeEach(() => {
@@ -24,10 +29,18 @@ describe("EloRatingCalculator", () => {
 		logger.child.mockReturnValue(logger);
 		userProfileRepository = mock<UserProfileRepository>();
 		ratingRepository = mock<RatingRepository>();
+		rankRepository = mock<RankRepository>();
+		rank = RankMother.create({ name: "TCG" });
+		rankRepository.findOrCreateByName.mockResolvedValue(rank);
 		tx = mock<RatingTransaction>();
 		tx.insertHistory.mockResolvedValue(true);
 
-		calculator = new EloRatingCalculator(logger, userProfileRepository, ratingRepository);
+		calculator = new EloRatingCalculator(
+			logger,
+			userProfileRepository,
+			ratingRepository,
+			rankRepository,
+		);
 	});
 
 	function makeEligibleEvent(overrides?: Parameters<typeof GameOverDomainEventMother.create>[0]) {
@@ -64,9 +77,10 @@ describe("EloRatingCalculator", () => {
 			expect(userProfileRepository.findById).toHaveBeenCalledWith("player-2");
 			expect(userProfileRepository.findByUsername).not.toHaveBeenCalled();
 
+			expect(rankRepository.findOrCreateByName).toHaveBeenCalledWith("TCG");
 			expect(ratingRepository.transaction).toHaveBeenCalledWith(
 				expect.arrayContaining(["player-1", "player-2"]),
-				"TCG",
+				rank.id,
 				config.season,
 				expect.any(Function),
 			);
@@ -75,7 +89,7 @@ describe("EloRatingCalculator", () => {
 				expect.objectContaining({
 					matchId: "match-1",
 					userId: "player-1",
-					banListName: "TCG",
+					rankId: rank.id,
 					season: config.season,
 					kind: "applied",
 					delta: 10,
@@ -92,13 +106,13 @@ describe("EloRatingCalculator", () => {
 
 			expect(tx.saveRating).toHaveBeenCalledWith(
 				"player-1",
-				"TCG",
+				rank.id,
 				config.season,
 				Rating.from({ value: 1010, gamesPlayed: 21, peak: 1010 }),
 			);
 			expect(tx.saveRating).toHaveBeenCalledWith(
 				"player-2",
-				"TCG",
+				rank.id,
 				config.season,
 				Rating.from({ value: 990, gamesPlayed: 21, peak: 1000 }),
 			);
@@ -110,6 +124,7 @@ describe("EloRatingCalculator", () => {
 			await calculator.handle(makeEligibleEvent({ ranked: false }));
 
 			expect(ratingRepository.transaction).not.toHaveBeenCalled();
+			expect(rankRepository.findOrCreateByName).not.toHaveBeenCalled();
 			expect(userProfileRepository.findById).not.toHaveBeenCalled();
 		});
 	});
@@ -137,6 +152,7 @@ describe("EloRatingCalculator", () => {
 			await calculator.handle(makeEligibleEvent({ banListName: "N/A" }));
 
 			expect(ratingRepository.transaction).not.toHaveBeenCalled();
+			expect(rankRepository.findOrCreateByName).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/plugins/elo-rating/application/EloRatingCalculator.ts
+++ b/src/plugins/elo-rating/application/EloRatingCalculator.ts
@@ -1,4 +1,5 @@
 import { Logger } from "src/shared/logger/domain/Logger";
+import { RankRepository } from "src/shared/rank/domain/RankRepository";
 import { EloCalculator, RatedPlayer } from "src/shared/stats/rating/domain/EloCalculator";
 import { Rating } from "src/shared/stats/rating/domain/Rating";
 import { RatingRepository } from "src/shared/stats/rating/domain/RatingRepository";
@@ -16,6 +17,7 @@ export class EloRatingCalculator implements DomainEventSubscriber<GameOverDomain
 		private readonly logger: Logger,
 		private readonly userProfileRepository: UserProfileRepository,
 		private readonly ratingRepository: RatingRepository,
+		private readonly rankRepository: RankRepository,
 	) {
 		this.logger = logger.child({ file: "EloRatingCalculator" });
 	}
@@ -63,15 +65,18 @@ export class EloRatingCalculator implements DomainEventSubscriber<GameOverDomain
 		}));
 		const banListName = eligibility.banListName;
 		const season = config.season;
+		// Eligibility stays keyed on the banlist name; persistence is keyed by
+		// the rank resolved (or created) for that name, once per match.
+		const rank = await this.rankRepository.findOrCreateByName(banListName);
 
-		await this.ratingRepository.transaction(playerIds, banListName, season, async (ratings, tx) => {
+		await this.ratingRepository.transaction(playerIds, rank.id, season, async (ratings, tx) => {
 			const deltas = EloCalculator.deltasFor(ratedPlayers, ratings);
 
 			for (const delta of deltas) {
 				const inserted = await tx.insertHistory({
 					matchId: data.matchId,
 					userId: delta.userId,
-					banListName,
+					rankId: rank.id,
 					season,
 					kind: "applied",
 					previousRating: delta.previousRating,
@@ -89,7 +94,7 @@ export class EloRatingCalculator implements DomainEventSubscriber<GameOverDomain
 
 				const currentRating = ratings.get(delta.userId) as Rating;
 				const updatedRating = currentRating.applyDelta(delta.delta);
-				await tx.saveRating(delta.userId, banListName, season, updatedRating);
+				await tx.saveRating(delta.userId, rank.id, season, updatedRating);
 			}
 		});
 	}

--- a/src/plugins/elo-rating/index.ts
+++ b/src/plugins/elo-rating/index.ts
@@ -1,5 +1,6 @@
 import { EventBus } from "@shared/event-bus/EventBus";
 import { PluginDeps, ServerPlugin } from "@shared/plugin/ServerPlugin";
+import { RankPostgresRepository } from "@shared/rank/infrastructure/RankPostgresRepository";
 import { RatingPostgresRepository } from "@shared/stats/rating/infrastructure/RatingPostgresRepository";
 import { UserProfilePostgresRepository } from "@shared/user-profile/infrastructure/postgres/UserProfilePostgresRepository";
 
@@ -18,6 +19,7 @@ const plugin: ServerPlugin = {
 				deps.logger,
 				new UserProfilePostgresRepository(),
 				new RatingPostgresRepository(),
+				new RankPostgresRepository(),
 			),
 		);
 	},

--- a/src/plugins/rating-announcer/index.ts
+++ b/src/plugins/rating-announcer/index.ts
@@ -1,4 +1,5 @@
 import LoggerFactory from "@shared/logger/infrastructure/LoggerFactory";
+import { RankPostgresRepository } from "@shared/rank/infrastructure/RankPostgresRepository";
 import { ServerPlugin } from "@shared/plugin/ServerPlugin";
 import { RatingAnnouncer } from "@shared/stats/rating/application/RatingAnnouncer";
 import { RatingPostgresRepository } from "@shared/stats/rating/infrastructure/RatingPostgresRepository";
@@ -14,6 +15,7 @@ const plugin: ServerPlugin = {
 	lifecycleHooks: [
 		new RatingAnnouncer(
 			new RatingPostgresRepository(),
+			new RankPostgresRepository(),
 			LoggerFactory.getLogger({ file: "RatingAnnouncer" }),
 		),
 	],

--- a/src/shared/rank/domain/Rank.ts
+++ b/src/shared/rank/domain/Rank.ts
@@ -1,0 +1,8 @@
+export type RankType = "banlist" | "group" | "global";
+
+export type Rank = {
+	id: string;
+	name: string;
+	type: RankType;
+	enabled: boolean;
+};

--- a/src/shared/rank/domain/RankRepository.ts
+++ b/src/shared/rank/domain/RankRepository.ts
@@ -1,0 +1,14 @@
+import { Rank } from "./Rank";
+
+export interface RankRepository {
+	/**
+	 * Looks a rank up by its unique name, creating it when missing. Safe
+	 * under concurrency: two callers racing on the same missing name must
+	 * both end up with the same persisted rank row.
+	 *
+	 * A rank created on the fly is `type: "banlist"` and enabled, except the
+	 * literal name "Global", which is `type: "global"`. An explicit `type`
+	 * argument overrides that default.
+	 */
+	findOrCreateByName(name: string, type?: "banlist" | "global"): Promise<Rank>;
+}

--- a/src/shared/rank/infrastructure/RankPostgresRepository.test.ts
+++ b/src/shared/rank/infrastructure/RankPostgresRepository.test.ts
@@ -1,0 +1,88 @@
+import { RankPostgresRepository } from "./RankPostgresRepository";
+import { dataSource } from "../../../evolution-types/src/data-source";
+
+// Mocks TypeORM's `dataSource` (same pattern as
+// `RatingPostgresRepository.test.ts`): proves the exact SQL/parameter
+// contract issued to Postgres — the concurrency-safe
+// INSERT ... ON CONFLICT (name) DO NOTHING + SELECT sequence — not that
+// Postgres enforces the UNIQUE(name) constraint itself.
+jest.mock("../../../evolution-types/src/data-source", () => ({
+	dataSource: {
+		query: jest.fn(),
+	},
+}));
+
+describe("RankPostgresRepository", () => {
+	let repository: RankPostgresRepository;
+	let query: jest.Mock;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		query = dataSource.query as jest.Mock;
+		repository = new RankPostgresRepository();
+	});
+
+	it("inserts with ON CONFLICT (name) DO NOTHING and then selects the row by name", async () => {
+		query
+			.mockResolvedValueOnce([]) // insert
+			.mockResolvedValueOnce([{ id: "rank-1", name: "TCG", type: "banlist", enabled: true }]);
+
+		const rank = await repository.findOrCreateByName("TCG");
+
+		expect(query).toHaveBeenCalledTimes(2);
+		expect(query).toHaveBeenNthCalledWith(
+			1,
+			expect.stringContaining("ON CONFLICT (name) DO NOTHING"),
+			["TCG", "banlist", true],
+		);
+		expect(query).toHaveBeenNthCalledWith(2, expect.stringContaining("WHERE name = $1"), ["TCG"]);
+		expect(rank).toEqual({ id: "rank-1", name: "TCG", type: "banlist", enabled: true });
+	});
+
+	it("returns the already-existing rank when the insert conflicts (concurrent creation)", async () => {
+		query
+			.mockResolvedValueOnce([]) // insert was a conflict no-op
+			.mockResolvedValueOnce([{ id: "rank-9", name: "TCG", type: "banlist", enabled: false }]);
+
+		const rank = await repository.findOrCreateByName("TCG");
+
+		expect(rank).toEqual({ id: "rank-9", name: "TCG", type: "banlist", enabled: false });
+	});
+
+	it('creates the literal "Global" name with type "global"', async () => {
+		query
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([{ id: "rank-g", name: "Global", type: "global", enabled: true }]);
+
+		const rank = await repository.findOrCreateByName("Global");
+
+		expect(query).toHaveBeenNthCalledWith(1, expect.stringContaining("INSERT INTO ranks"), [
+			"Global",
+			"global",
+			true,
+		]);
+		expect(rank.type).toBe("global");
+	});
+
+	it("honors an explicitly passed type over the name-based default", async () => {
+		query
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([{ id: "rank-2", name: "Custom", type: "global", enabled: true }]);
+
+		await repository.findOrCreateByName("Custom", "global");
+
+		expect(query).toHaveBeenNthCalledWith(1, expect.stringContaining("INSERT INTO ranks"), [
+			"Custom",
+			"global",
+			true,
+		]);
+	});
+
+	it("throws when the rank can neither be created nor found", async () => {
+		query.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+		await expect(repository.findOrCreateByName("TCG")).rejects.toThrow(
+			'Rank "TCG" could not be found or created',
+		);
+	});
+});

--- a/src/shared/rank/infrastructure/RankPostgresRepository.ts
+++ b/src/shared/rank/infrastructure/RankPostgresRepository.ts
@@ -1,0 +1,38 @@
+import { Rank, RankType } from "../domain/Rank";
+import { RankRepository } from "../domain/RankRepository";
+import { dataSource } from "../../../evolution-types/src/data-source";
+
+const GLOBAL_RANK_NAME = "Global";
+
+// INSERT ... ON CONFLICT (name) DO NOTHING followed by a plain SELECT keeps
+// find-or-create safe under concurrency: two racing callers both reach the
+// SELECT with the row guaranteed to exist, whichever INSERT won.
+const INSERT_RANK_QUERY = `
+	INSERT INTO ranks (name, type, enabled)
+	VALUES ($1, $2, $3)
+	ON CONFLICT (name) DO NOTHING
+`;
+
+const SELECT_RANK_QUERY = `
+	SELECT id, name, type, enabled
+	FROM ranks
+	WHERE name = $1
+`;
+
+type RankRow = { id: string; name: string; type: RankType; enabled: boolean };
+
+export class RankPostgresRepository implements RankRepository {
+	async findOrCreateByName(name: string, type?: "banlist" | "global"): Promise<Rank> {
+		const effectiveType: RankType = type ?? (name === GLOBAL_RANK_NAME ? "global" : "banlist");
+
+		await dataSource.query(INSERT_RANK_QUERY, [name, effectiveType, true]);
+		const rows: RankRow[] = await dataSource.query(SELECT_RANK_QUERY, [name]);
+
+		const row = rows[0];
+		if (!row) {
+			throw new Error(`Rank "${name}" could not be found or created`);
+		}
+
+		return { id: row.id, name: row.name, type: row.type, enabled: row.enabled };
+	}
+}

--- a/src/shared/stats/player-stats/domain/PlayerStats.ts
+++ b/src/shared/stats/player-stats/domain/PlayerStats.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "crypto";
 
 export type PlayerStatsProperties = {
 	id: string;
-	banListName: string;
+	rankId: string;
 	wins: number;
 	losses: number;
 	points: number;
@@ -12,7 +12,7 @@ export type PlayerStatsProperties = {
 
 export class PlayerStats {
 	public readonly id: string;
-	public readonly banListName: string;
+	public readonly rankId: string;
 	public readonly userId: string;
 	public readonly season: number;
 	private _points: number;
@@ -21,7 +21,7 @@ export class PlayerStats {
 
 	private constructor(data: PlayerStatsProperties) {
 		this.id = data.id;
-		this.banListName = data.banListName;
+		this.rankId = data.rankId;
 		this._wins = data.wins;
 		this._losses = data.losses;
 		this._points = data.points;
@@ -41,7 +41,7 @@ export class PlayerStats {
 		return this._losses;
 	}
 
-	static initialize(data: { banListName: string; userId: string; season: number }): PlayerStats {
+	static initialize(data: { rankId: string; userId: string; season: number }): PlayerStats {
 		return new PlayerStats({ ...data, wins: 0, losses: 0, points: 0, id: randomUUID() });
 	}
 

--- a/src/shared/stats/player-stats/domain/PlayerStatsRepository.ts
+++ b/src/shared/stats/player-stats/domain/PlayerStatsRepository.ts
@@ -1,6 +1,6 @@
 import { PlayerStats } from "./PlayerStats";
 
 export interface PlayerStatsRepository {
-	findByUserIdAndBanListName(userId: string, banListName: string): Promise<PlayerStats>;
+	findByUserIdAndRankId(userId: string, rankId: string): Promise<PlayerStats>;
 	save(playerStats: PlayerStats): Promise<void>;
 }

--- a/src/shared/stats/player-stats/infrastructure/PlayerStatsPostgresRepository.ts
+++ b/src/shared/stats/player-stats/infrastructure/PlayerStatsPostgresRepository.ts
@@ -5,16 +5,16 @@ import { PlayerStatsRepository } from "../domain/PlayerStatsRepository";
 import { config } from "./../../../../config/index";
 
 export class PlayerStatsPostgresRepository implements PlayerStatsRepository {
-	async findByUserIdAndBanListName(userId: string, banListName: string): Promise<PlayerStats> {
+	async findByUserIdAndRankId(userId: string, rankId: string): Promise<PlayerStats> {
 		const repository = dataSource.getRepository(PlayerStatsEntity);
 		const playerStatsResponse = await repository.findOneBy({
-			banListName,
+			rankId,
 			userId,
 			season: config.season,
 		});
 		if (!playerStatsResponse) {
 			return PlayerStats.initialize({
-				banListName,
+				rankId,
 				userId,
 				season: config.season,
 			});
@@ -28,7 +28,7 @@ export class PlayerStatsPostgresRepository implements PlayerStatsRepository {
 
 		const playerStatsEntity = repository.create({
 			id: playerStats.id,
-			banListName: playerStats.banListName,
+			rankId: playerStats.rankId,
 			wins: playerStats.wins,
 			losses: playerStats.losses,
 			points: playerStats.points,

--- a/src/shared/stats/rating/application/RatingAnnouncer.test.ts
+++ b/src/shared/stats/rating/application/RatingAnnouncer.test.ts
@@ -1,10 +1,13 @@
 import { mock } from "jest-mock-extended";
 
+import { Rank } from "@shared/rank/domain/Rank";
+import { RankRepository } from "@shared/rank/domain/RankRepository";
 import { Team } from "@shared/room/Team";
 import { MatchContext } from "@shared/room/domain/lifecycle/MatchLifecycleHook";
 import { Rating } from "@shared/stats/rating/domain/Rating";
 import { RatingRepository } from "@shared/stats/rating/domain/RatingRepository";
 import { LoggerMock } from "@test-support/mocks/logger/LoggerMock";
+import { RankMother } from "@test-support/mothers/rank/RankMother";
 
 import { RatingAnnouncer } from "./RatingAnnouncer";
 
@@ -26,13 +29,18 @@ function makeContext(overrides?: Partial<MatchContext>): MatchContext {
 
 describe("RatingAnnouncer", () => {
 	let repository: ReturnType<typeof mock<RatingRepository>>;
+	let rankRepository: ReturnType<typeof mock<RankRepository>>;
+	let rank: Rank;
 	let logger: LoggerMock;
 	let announcer: RatingAnnouncer;
 
 	beforeEach(() => {
 		repository = mock<RatingRepository>();
+		rankRepository = mock<RankRepository>();
+		rank = RankMother.create({ name: "TCG" });
+		rankRepository.findOrCreateByName.mockResolvedValue(rank);
 		logger = new LoggerMock();
-		announcer = new RatingAnnouncer(repository, logger);
+		announcer = new RatingAnnouncer(repository, rankRepository, logger);
 	});
 
 	describe("onMatchStarted", () => {
@@ -47,7 +55,8 @@ describe("RatingAnnouncer", () => {
 
 			await announcer.onMatchStarted(ctx);
 
-			expect(repository.findMany).toHaveBeenCalledWith(["p1", "p2"], "TCG", 5);
+			expect(rankRepository.findOrCreateByName).toHaveBeenCalledWith("TCG");
+			expect(repository.findMany).toHaveBeenCalledWith(["p1", "p2"], rank.id, 5);
 			expect(ctx.announce).toHaveBeenCalledWith("[Rating v1 start] Diango 1050 | Rival 950");
 		});
 
@@ -65,6 +74,7 @@ describe("RatingAnnouncer", () => {
 
 			await announcer.onMatchStarted(ctx);
 
+			expect(rankRepository.findOrCreateByName).not.toHaveBeenCalled();
 			expect(repository.findMany).not.toHaveBeenCalled();
 			expect(ctx.announce).not.toHaveBeenCalled();
 		});
@@ -74,6 +84,7 @@ describe("RatingAnnouncer", () => {
 
 			await announcer.onMatchStarted(ctx);
 
+			expect(rankRepository.findOrCreateByName).not.toHaveBeenCalled();
 			expect(repository.findMany).not.toHaveBeenCalled();
 			expect(ctx.announce).not.toHaveBeenCalled();
 		});
@@ -88,6 +99,7 @@ describe("RatingAnnouncer", () => {
 
 			await announcer.onMatchStarted(ctx);
 
+			expect(rankRepository.findOrCreateByName).not.toHaveBeenCalled();
 			expect(repository.findMany).not.toHaveBeenCalled();
 			expect(ctx.announce).not.toHaveBeenCalled();
 		});
@@ -109,6 +121,27 @@ describe("RatingAnnouncer", () => {
 
 			await expect(announcer.onMatchStarted(ctx)).resolves.toBeUndefined();
 
+			expect(ctx.announce).not.toHaveBeenCalled();
+		});
+
+		it("resolves the rank by banlist name exactly once per match", async () => {
+			repository.findMany.mockResolvedValue(new Map());
+			const ctx = makeContext();
+
+			await announcer.onMatchStarted(ctx);
+			await announcer.onMatchEnding(ctx);
+
+			expect(rankRepository.findOrCreateByName).toHaveBeenCalledTimes(1);
+			expect(rankRepository.findOrCreateByName).toHaveBeenCalledWith("TCG");
+		});
+
+		it("does not throw and sends no frame when rank resolution fails", async () => {
+			rankRepository.findOrCreateByName.mockRejectedValue(new Error("db down"));
+			const ctx = makeContext();
+
+			await expect(announcer.onMatchStarted(ctx)).resolves.toBeUndefined();
+
+			expect(repository.findMany).not.toHaveBeenCalled();
 			expect(ctx.announce).not.toHaveBeenCalled();
 		});
 	});

--- a/src/shared/stats/rating/application/RatingAnnouncer.ts
+++ b/src/shared/stats/rating/application/RatingAnnouncer.ts
@@ -1,4 +1,5 @@
 import { Logger } from "@shared/logger/domain/Logger";
+import { RankRepository } from "@shared/rank/domain/RankRepository";
 import { Team } from "@shared/room/Team";
 import {
 	MatchContext,
@@ -46,6 +47,7 @@ export class RatingAnnouncer implements MatchLifecycleHook {
 
 	constructor(
 		private readonly ratingRepository: RatingRepository,
+		private readonly rankRepository: RankRepository,
 		private readonly logger: Logger,
 	) {}
 
@@ -68,26 +70,28 @@ export class RatingAnnouncer implements MatchLifecycleHook {
 			return;
 		}
 
+		// Eligibility stays keyed on the banlist name; the rank is resolved
+		// exactly once per match, here at start, and carried in the snapshot.
+		let rankId: string;
 		let ratings: Map<string, Rating>;
 		try {
+			const rank = await this.rankRepository.findOrCreateByName(eligibility.banListName);
+			rankId = rank.id;
 			ratings = await this.ratingRepository.findMany(
 				eligibility.players.map((player) => player.id),
-				eligibility.banListName,
+				rankId,
 				ctx.season,
 			);
 		} catch (error) {
 			this.logger.warn(
-				`RatingAnnouncer: findMany failed for room ${ctx.roomId}: ${String(error)}`,
+				`RatingAnnouncer: rating lookup failed for room ${ctx.roomId}: ${String(error)}`,
 				{ roomId: ctx.roomId },
 			);
 
 			return;
 		}
 
-		this.snapshots.set(
-			ctx.matchId,
-			MatchRatingSnapshot.create(ratings, eligibility.banListName, ctx.season),
-		);
+		this.snapshots.set(ctx.matchId, MatchRatingSnapshot.create(ratings, rankId, ctx.season));
 		this.matchIdByRoom.set(ctx.roomId, ctx.matchId);
 
 		const teams = this.groupByTeam(

--- a/src/shared/stats/rating/domain/MatchRatingSnapshot.test.ts
+++ b/src/shared/stats/rating/domain/MatchRatingSnapshot.test.ts
@@ -9,9 +9,9 @@ describe("MatchRatingSnapshot", () => {
 				["player-2", Rating.from({ value: 980, gamesPlayed: 15, peak: 1010 })],
 			]);
 
-			const snapshot = MatchRatingSnapshot.create(ratings, "TCG", 5);
+			const snapshot = MatchRatingSnapshot.create(ratings, "rank-1", 5);
 
-			expect(snapshot.banListName).toBe("TCG");
+			expect(snapshot.rankId).toBe("rank-1");
 			expect(snapshot.season).toBe(5);
 			expect(snapshot.ratingFor("player-1")).toEqual(
 				Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 }),
@@ -26,7 +26,7 @@ describe("MatchRatingSnapshot", () => {
 				["player-1", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
 			]);
 
-			const snapshot = MatchRatingSnapshot.create(ratings, "TCG", 5);
+			const snapshot = MatchRatingSnapshot.create(ratings, "rank-1", 5);
 
 			expect(snapshot.ratingFor("player-unknown")).toBeUndefined();
 		});
@@ -36,7 +36,7 @@ describe("MatchRatingSnapshot", () => {
 				["player-1", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
 			]);
 
-			const snapshot = MatchRatingSnapshot.create(ratings, "TCG", 5);
+			const snapshot = MatchRatingSnapshot.create(ratings, "rank-1", 5);
 			ratings.set("player-1", Rating.initialize());
 			ratings.set("player-2", Rating.initialize());
 

--- a/src/shared/stats/rating/domain/MatchRatingSnapshot.ts
+++ b/src/shared/stats/rating/domain/MatchRatingSnapshot.ts
@@ -2,21 +2,21 @@ import { Rating } from "./Rating";
 
 export class MatchRatingSnapshot {
 	private readonly ratings: ReadonlyMap<string, Rating>;
-	public readonly banListName: string;
+	public readonly rankId: string;
 	public readonly season: number;
 
-	private constructor(ratings: ReadonlyMap<string, Rating>, banListName: string, season: number) {
+	private constructor(ratings: ReadonlyMap<string, Rating>, rankId: string, season: number) {
 		this.ratings = ratings;
-		this.banListName = banListName;
+		this.rankId = rankId;
 		this.season = season;
 	}
 
 	static create(
 		ratings: ReadonlyMap<string, Rating>,
-		banListName: string,
+		rankId: string,
 		season: number,
 	): MatchRatingSnapshot {
-		return new MatchRatingSnapshot(new Map(ratings), banListName, season);
+		return new MatchRatingSnapshot(new Map(ratings), rankId, season);
 	}
 
 	ratingFor(userId: string): Rating | undefined {

--- a/src/shared/stats/rating/domain/RatingRepository.test.ts
+++ b/src/shared/stats/rating/domain/RatingRepository.test.ts
@@ -4,16 +4,16 @@ import { Rating } from "./Rating";
 import { RatingRepository } from "./RatingRepository";
 
 describe("RatingRepository — findMany port contract", () => {
-	it("exposes findMany(userIds, banListName, season) returning a Promise<Map<string, Rating>>", async () => {
+	it("exposes findMany(userIds, rankId, season) returning a Promise<Map<string, Rating>>", async () => {
 		const repository = mock<RatingRepository>();
 		const ratings = new Map<string, Rating>([
 			["player-1", Rating.from({ value: 1050, gamesPlayed: 12, peak: 1080 })],
 		]);
 		repository.findMany.mockResolvedValue(ratings);
 
-		const result = await repository.findMany(["player-1"], "TCG", 5);
+		const result = await repository.findMany(["player-1"], "rank-1", 5);
 
-		expect(repository.findMany).toHaveBeenCalledWith(["player-1"], "TCG", 5);
+		expect(repository.findMany).toHaveBeenCalledWith(["player-1"], "rank-1", 5);
 		expect(result).toBe(ratings);
 	});
 });

--- a/src/shared/stats/rating/domain/RatingRepository.ts
+++ b/src/shared/stats/rating/domain/RatingRepository.ts
@@ -3,7 +3,7 @@ import { Rating } from "./Rating";
 export type RatingHistoryEntry = {
 	matchId: string;
 	userId: string;
-	banListName: string;
+	rankId: string;
 	season: number;
 	kind: "applied" | "reversal";
 	previousRating: number;
@@ -26,7 +26,7 @@ export interface RatingTransaction {
 	insertHistory(entry: RatingHistoryEntry): Promise<boolean>;
 
 	/** Upserts the derived player_ratings projection for one player. */
-	saveRating(userId: string, banListName: string, season: number, rating: Rating): Promise<void>;
+	saveRating(userId: string, rankId: string, season: number, rating: Rating): Promise<void>;
 }
 
 export interface RatingRepository {
@@ -38,7 +38,7 @@ export interface RatingRepository {
 	 */
 	transaction<T>(
 		userIds: string[],
-		banListName: string,
+		rankId: string,
 		season: number,
 		work: (ratings: Map<string, Rating>, tx: RatingTransaction) => Promise<T>,
 	): Promise<T>;
@@ -49,5 +49,5 @@ export interface RatingRepository {
 	 * display path — must never interfere with `transaction`'s write-side
 	 * locking.
 	 */
-	findMany(userIds: string[], banListName: string, season: number): Promise<Map<string, Rating>>;
+	findMany(userIds: string[], rankId: string, season: number): Promise<Map<string, Rating>>;
 }

--- a/src/shared/stats/rating/infrastructure/RatingPostgresRepository.test.ts
+++ b/src/shared/stats/rating/infrastructure/RatingPostgresRepository.test.ts
@@ -37,18 +37,18 @@ describe("RatingPostgresRepository", () => {
 
 			const result = await repository.transaction(
 				["user-b", "user-a"],
-				"TCG",
+				"rank-1",
 				5,
 				async (ratings) => ratings,
 			);
 
 			expect(manager.query).toHaveBeenCalledWith(expect.stringContaining("ORDER BY user_id ASC"), [
-				"TCG",
+				"rank-1",
 				5,
 				["user-a", "user-b"],
 			]);
 			expect(manager.query).toHaveBeenCalledWith(expect.stringContaining("FOR UPDATE"), [
-				"TCG",
+				"rank-1",
 				5,
 				["user-a", "user-b"],
 			]);
@@ -62,17 +62,17 @@ describe("RatingPostgresRepository", () => {
 		it("acquires a pg_advisory_xact_lock per participant, ordered by user_id ascending, before the FOR UPDATE row lock", async () => {
 			manager.query.mockResolvedValue([]);
 
-			await repository.transaction(["user-b", "user-a"], "TCG", 5, async (ratings) => ratings);
+			await repository.transaction(["user-b", "user-a"], "rank-1", 5, async (ratings) => ratings);
 
 			const calls = manager.query.mock.calls;
 
 			expect(calls[0]).toEqual([
 				expect.stringContaining("pg_advisory_xact_lock"),
-				["user-a", "TCG", 5],
+				["user-a", "rank-1", 5],
 			]);
 			expect(calls[1]).toEqual([
 				expect.stringContaining("pg_advisory_xact_lock"),
-				["user-b", "TCG", 5],
+				["user-b", "rank-1", 5],
 			]);
 			expect(calls[2][0]).toEqual(expect.stringContaining("FOR UPDATE"));
 
@@ -85,11 +85,11 @@ describe("RatingPostgresRepository", () => {
 		it("skips advisory locking entirely when there are no participants", async () => {
 			manager.query.mockResolvedValueOnce([]); // FOR UPDATE row lock
 
-			await repository.transaction([], "TCG", 5, async (ratings) => ratings);
+			await repository.transaction([], "rank-1", 5, async (ratings) => ratings);
 
 			expect(manager.query).toHaveBeenCalledTimes(1);
 			expect(manager.query).toHaveBeenCalledWith(expect.stringContaining("FOR UPDATE"), [
-				"TCG",
+				"rank-1",
 				5,
 				[],
 			]);
@@ -103,11 +103,11 @@ describe("RatingPostgresRepository", () => {
 				.mockResolvedValueOnce([{ id: "history-row-1" }]); // insert
 
 			let inserted = false;
-			await repository.transaction([], "TCG", 5, async (_ratings, tx) => {
+			await repository.transaction([], "rank-1", 5, async (_ratings, tx) => {
 				inserted = await tx.insertHistory({
 					matchId: "match-1",
 					userId: "user-a",
-					banListName: "TCG",
+					rankId: "rank-1",
 					season: 5,
 					kind: "applied",
 					previousRating: 1000,
@@ -120,7 +120,7 @@ describe("RatingPostgresRepository", () => {
 			expect(inserted).toBe(true);
 			expect(manager.query).toHaveBeenCalledWith(
 				expect.stringContaining("ON CONFLICT (match_id, user_id, kind) DO NOTHING"),
-				["match-1", "user-a", "TCG", 5, "applied", 1000, 10, 20, 1000],
+				["match-1", "user-a", "rank-1", 5, "applied", 1000, 10, 20, 1000],
 			);
 		});
 
@@ -130,11 +130,11 @@ describe("RatingPostgresRepository", () => {
 				.mockResolvedValueOnce([]); // conflicting insert returns no rows
 
 			let inserted = true;
-			await repository.transaction([], "TCG", 5, async (_ratings, tx) => {
+			await repository.transaction([], "rank-1", 5, async (_ratings, tx) => {
 				inserted = await tx.insertHistory({
 					matchId: "match-1",
 					userId: "user-a",
-					banListName: "TCG",
+					rankId: "rank-1",
 					season: 5,
 					kind: "applied",
 					previousRating: 1000,
@@ -154,10 +154,10 @@ describe("RatingPostgresRepository", () => {
 				{ userId: "user-a", rating: 1200, gamesPlayed: 15, peak: 1250 },
 			]);
 
-			const result = await repository.findMany(["user-a"], "TCG", 5);
+			const result = await repository.findMany(["user-a"], "rank-1", 5);
 
 			expect(dataSource.query).toHaveBeenCalledTimes(1);
-			expect(dataSource.query).toHaveBeenCalledWith(expect.any(String), ["TCG", 5, ["user-a"]]);
+			expect(dataSource.query).toHaveBeenCalledWith(expect.any(String), ["rank-1", 5, ["user-a"]]);
 			expect((dataSource.query as jest.Mock).mock.calls[0][0]).not.toEqual(
 				expect.stringContaining("FOR UPDATE"),
 			);
@@ -170,7 +170,7 @@ describe("RatingPostgresRepository", () => {
 		it("R2 — defaults a user with no rating row to the season-start value (1000)", async () => {
 			(dataSource.query as jest.Mock).mockResolvedValueOnce([]);
 
-			const result = await repository.findMany(["user-a"], "TCG", 5);
+			const result = await repository.findMany(["user-a"], "rank-1", 5);
 
 			expect(result.get("user-a")).toEqual(Rating.initialize());
 		});
@@ -178,7 +178,7 @@ describe("RatingPostgresRepository", () => {
 		it("R3 — reads without acquiring the advisory participant locks used by the write path", async () => {
 			(dataSource.query as jest.Mock).mockResolvedValueOnce([]);
 
-			await repository.findMany(["user-a", "user-b"], "TCG", 5);
+			await repository.findMany(["user-a", "user-b"], "rank-1", 5);
 
 			expect(dataSource.query).toHaveBeenCalledTimes(1);
 			expect((dataSource.query as jest.Mock).mock.calls[0][0]).not.toEqual(
@@ -188,21 +188,21 @@ describe("RatingPostgresRepository", () => {
 	});
 
 	describe("RatingTransaction.saveRating()", () => {
-		it("upserts the player_ratings projection keyed by (user_id, ban_list_name, season)", async () => {
+		it("upserts the player_ratings projection keyed by (user_id, rank_id, season)", async () => {
 			manager.query.mockResolvedValueOnce([]); // lock query
 
-			await repository.transaction([], "TCG", 5, async (_ratings, tx) => {
+			await repository.transaction([], "rank-1", 5, async (_ratings, tx) => {
 				await tx.saveRating(
 					"user-a",
-					"TCG",
+					"rank-1",
 					5,
 					Rating.from({ value: 1010, gamesPlayed: 21, peak: 1010 }),
 				);
 			});
 
 			expect(manager.query).toHaveBeenCalledWith(
-				expect.stringContaining("ON CONFLICT (user_id, ban_list_name, season)"),
-				["user-a", "TCG", 5, 1010, 21, 1010],
+				expect.stringContaining("ON CONFLICT (user_id, rank_id, season)"),
+				["user-a", "rank-1", 5, 1010, 21, 1010],
 			);
 		});
 	});

--- a/src/shared/stats/rating/infrastructure/RatingPostgresRepository.ts
+++ b/src/shared/stats/rating/infrastructure/RatingPostgresRepository.ts
@@ -8,7 +8,7 @@ import {
 } from "../domain/RatingRepository";
 import { dataSource } from "../../../../evolution-types/src/data-source";
 
-// Encodes (user_id, ban_list_name, season) with a length-prefixed field so
+// Encodes (user_id, rank_id, season) with a length-prefixed field so
 // the concatenation stays injective even when a value contains the
 // delimiter — a plain "a|b|c" join can collide for two different inputs.
 const ADVISORY_LOCK_QUERY = `
@@ -18,7 +18,7 @@ const ADVISORY_LOCK_QUERY = `
 const LOCK_RATINGS_QUERY = `
 	SELECT user_id AS "userId", rating, games_played AS "gamesPlayed", peak
 	FROM player_ratings
-	WHERE ban_list_name = $1 AND season = $2 AND user_id = ANY($3)
+	WHERE rank_id = $1 AND season = $2 AND user_id = ANY($3)
 	ORDER BY user_id ASC
 	FOR UPDATE
 `;
@@ -28,21 +28,21 @@ const LOCK_RATINGS_QUERY = `
 const FIND_RATINGS_QUERY = `
 	SELECT user_id AS "userId", rating, games_played AS "gamesPlayed", peak
 	FROM player_ratings
-	WHERE ban_list_name = $1 AND season = $2 AND user_id = ANY($3)
+	WHERE rank_id = $1 AND season = $2 AND user_id = ANY($3)
 	ORDER BY user_id ASC
 `;
 
 const INSERT_HISTORY_QUERY = `
-	INSERT INTO rating_history (match_id, user_id, ban_list_name, season, kind, previous_rating, delta, k_factor, opponent_rating)
+	INSERT INTO rating_history (match_id, user_id, rank_id, season, kind, previous_rating, delta, k_factor, opponent_rating)
 	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 	ON CONFLICT (match_id, user_id, kind) DO NOTHING
 	RETURNING id
 `;
 
 const UPSERT_RATING_QUERY = `
-	INSERT INTO player_ratings (user_id, ban_list_name, season, rating, games_played, peak)
+	INSERT INTO player_ratings (user_id, rank_id, season, rating, games_played, peak)
 	VALUES ($1, $2, $3, $4, $5, $6)
-	ON CONFLICT (user_id, ban_list_name, season)
+	ON CONFLICT (user_id, rank_id, season)
 	DO UPDATE SET rating = EXCLUDED.rating, games_played = EXCLUDED.games_played, peak = EXCLUDED.peak, updated_at = now()
 `;
 
@@ -51,15 +51,15 @@ type PlayerRatingRow = { userId: string; rating: number; gamesPlayed: number; pe
 export class RatingPostgresRepository implements RatingRepository {
 	async transaction<T>(
 		userIds: string[],
-		banListName: string,
+		rankId: string,
 		season: number,
 		work: (ratings: Map<string, Rating>, tx: RatingTransaction) => Promise<T>,
 	): Promise<T> {
 		return dataSource.transaction(async (manager) => {
 			const orderedIds = [...userIds].sort();
 
-			await this.acquireParticipantLocks(manager, orderedIds, banListName, season);
-			const ratings = await this.lockRatings(manager, orderedIds, banListName, season);
+			await this.acquireParticipantLocks(manager, orderedIds, rankId, season);
+			const ratings = await this.lockRatings(manager, orderedIds, rankId, season);
 			const tx = new RatingPostgresTransaction(manager);
 
 			return work(ratings, tx);
@@ -67,7 +67,7 @@ export class RatingPostgresRepository implements RatingRepository {
 	}
 
 	// SELECT ... FOR UPDATE cannot lock a row that does not exist yet: for a
-	// player's first rated match in a (ban list, season), two concurrent
+	// player's first rated match in a (rank, season), two concurrent
 	// GAME_OVER transactions can both see "no row", both default to
 	// Rating.initialize(), and the later UPSERT overwrites the earlier one —
 	// the projection drops a match while rating_history keeps both. A
@@ -78,22 +78,22 @@ export class RatingPostgresRepository implements RatingRepository {
 	private async acquireParticipantLocks(
 		manager: EntityManager,
 		orderedIds: string[],
-		banListName: string,
+		rankId: string,
 		season: number,
 	): Promise<void> {
 		for (const userId of orderedIds) {
-			await manager.query(ADVISORY_LOCK_QUERY, [userId, banListName, season]);
+			await manager.query(ADVISORY_LOCK_QUERY, [userId, rankId, season]);
 		}
 	}
 
 	private async lockRatings(
 		manager: EntityManager,
 		orderedIds: string[],
-		banListName: string,
+		rankId: string,
 		season: number,
 	): Promise<Map<string, Rating>> {
 		const rows: PlayerRatingRow[] = await manager.query(LOCK_RATINGS_QUERY, [
-			banListName,
+			rankId,
 			season,
 			orderedIds,
 		]);
@@ -101,13 +101,9 @@ export class RatingPostgresRepository implements RatingRepository {
 		return toRatingsMap(orderedIds, rows);
 	}
 
-	async findMany(
-		userIds: string[],
-		banListName: string,
-		season: number,
-	): Promise<Map<string, Rating>> {
+	async findMany(userIds: string[], rankId: string, season: number): Promise<Map<string, Rating>> {
 		const rows: PlayerRatingRow[] = await dataSource.query(FIND_RATINGS_QUERY, [
-			banListName,
+			rankId,
 			season,
 			userIds,
 		]);
@@ -138,7 +134,7 @@ class RatingPostgresTransaction implements RatingTransaction {
 		const rows = await this.manager.query(INSERT_HISTORY_QUERY, [
 			entry.matchId,
 			entry.userId,
-			entry.banListName,
+			entry.rankId,
 			entry.season,
 			entry.kind,
 			entry.previousRating,
@@ -150,15 +146,10 @@ class RatingPostgresTransaction implements RatingTransaction {
 		return rows.length > 0;
 	}
 
-	async saveRating(
-		userId: string,
-		banListName: string,
-		season: number,
-		rating: Rating,
-	): Promise<void> {
+	async saveRating(userId: string, rankId: string, season: number, rating: Rating): Promise<void> {
 		await this.manager.query(UPSERT_RATING_QUERY, [
 			userId,
-			banListName,
+			rankId,
 			season,
 			rating.value,
 			rating.gamesPlayed,

--- a/src/test-support/mothers/player/PlayerStatsMother.ts
+++ b/src/test-support/mothers/player/PlayerStatsMother.ts
@@ -5,7 +5,7 @@ export class PlayerStatsMother {
 	static create(params?: Partial<PlayerStatsProperties>): PlayerStats {
 		return PlayerStats.from({
 			id: faker.string.uuid(),
-			banListName: faker.lorem.word(),
+			rankId: faker.string.uuid(),
 			wins: faker.number.int(),
 			losses: faker.number.int(),
 			points: faker.number.int(),

--- a/src/test-support/mothers/rank/RankMother.ts
+++ b/src/test-support/mothers/rank/RankMother.ts
@@ -1,0 +1,14 @@
+import { faker } from "@faker-js/faker";
+import { Rank } from "@shared/rank/domain/Rank";
+
+export class RankMother {
+	static create(params?: Partial<Rank>): Rank {
+		return {
+			id: faker.string.uuid(),
+			name: faker.lorem.word(),
+			type: "banlist",
+			enabled: true,
+			...params,
+		};
+	}
+}


### PR DESCRIPTION
## Summary

Write side of the rank_id migration (evolution-types#6):

- New shared Rank domain with a concurrency-safe `findOrCreateByName` (`INSERT … ON CONFLICT (name) DO NOTHING` + select), resolved once per match.
- `BasicStatsCalculator` and the rating path (announcer, elo calculator, postgres repositories, advisory locks) persist by `(user_id, rank_id, season)`.
- Stats math, the `N/A` skip and the eligibility gate are unchanged; match/duel resumes and unranked tables keep `ban_list_name` by design.
- Bumps `evolution-types` to the ranks schema.

## Verification

- `tsc --noEmit` clean, jest full suite 179 suites / 1706 tests green, biome clean.

Deploy note: requires the backfill migration; the enforce migration ships separately at cutover.