### PR TITLE
feat(rank): configurable group ranks fed by current ban lists

### DIFF
--- a/config/rank-groups.json
+++ b/config/rank-groups.json
@@ -1,0 +1,68 @@
+{
+	"aliases": {
+		"2011.09 Tengu Plant": "2011.09 Tengu",
+		"JTP (Original)": "JTP"
+	},
+	"groups": [
+		{
+			"name": "TCG",
+			"enabled": true,
+			"onlyCurrent": true,
+			"members": ["* TCG"]
+		},
+		{
+			"name": "OCG",
+			"enabled": true,
+			"onlyCurrent": true,
+			"members": ["* OCG"]
+		},
+		{
+			"name": "Rush",
+			"enabled": true,
+			"onlyCurrent": true,
+			"members": ["* Rush Duel", "RD"]
+		},
+		{
+			"name": "Speed",
+			"enabled": true,
+			"onlyCurrent": true,
+			"members": ["* Speed Duel"]
+		},
+		{
+			"name": "Traditional",
+			"enabled": true,
+			"onlyCurrent": true,
+			"members": ["* Traditional"]
+		},
+		{
+			"name": "Worlds",
+			"enabled": true,
+			"onlyCurrent": true,
+			"members": ["* Worlds"]
+		},
+		{
+			"name": "MD",
+			"enabled": true,
+			"onlyCurrent": true,
+			"members": ["* MD"]
+		},
+		{
+			"name": "Edison",
+			"enabled": true,
+			"onlyCurrent": false,
+			"members": ["* Edison"]
+		},
+		{
+			"name": "HAT",
+			"enabled": true,
+			"onlyCurrent": false,
+			"members": ["* HAT"]
+		},
+		{
+			"name": "JTP All",
+			"enabled": true,
+			"onlyCurrent": false,
+			"members": ["JTP", "JTP Adv 2007-03"]
+		}
+	]
+}

--- a/resources.manifest.json
+++ b/resources.manifest.json
@@ -80,6 +80,18 @@
 			"from": "evolution-lflists"
 		},
 		{
+			"comment": "Canonical JTP lflist from evolution-assets (overrides the stale jtp-oficial copy)",
+			"target": "edopro/evolution-lflists/jtp-oficial.lflist.conf",
+			"from": "evolution-assets",
+			"file": "lflist/jtp.lflist.conf"
+		},
+		{
+			"comment": "JTP Adv 2007-03 lflist from evolution-assets",
+			"target": "edopro/evolution-lflists/jtp-adv-2007-03.lflist.conf",
+			"from": "evolution-assets",
+			"file": "lflist/jtp-advanced-marzo-2007.lflist.conf"
+		},
+		{
 			"comment": "EDOPro databases",
 			"target": "edopro/databases",
 			"from": "edopro-cdbs"

--- a/src/bootstrap/bootstrapPersistence.ts
+++ b/src/bootstrap/bootstrapPersistence.ts
@@ -2,6 +2,14 @@ import { Redis } from "@shared/db/redis/infrastructure/Redis";
 import { EdoProCardDbHotReload } from "@edopro/card/infrastructure/sqlite/EdoProCardDbHotReload";
 import { EdoProSQLiteTypeORM } from "@edopro/card/infrastructure/sqlite/EdoProSQLiteTypeORM";
 import { Logger } from "@shared/logger/domain/Logger";
+import { formatRankGroupsSummary } from "@shared/rank/application/RankGroupsSummary";
+import { InMemoryLoadedBanListNamesProvider } from "@shared/rank/infrastructure/InMemoryLoadedBanListNamesProvider";
+import { RankGroupPostgresRepository } from "@shared/rank/infrastructure/RankGroupPostgresRepository";
+import { RankGroupSeeder } from "@shared/rank/infrastructure/RankGroupSeeder";
+import {
+	loadRankGroupsConfig,
+	setActiveRankGroupsConfig,
+} from "@shared/rank/infrastructure/RankGroupsConfigLoader";
 
 import { config } from "src/config";
 import { PostgresTypeORM } from "src/evolution-types/src/PostgresTypeORM";
@@ -22,6 +30,23 @@ export async function bootstrapPersistence(logger: Logger): Promise<void> {
 		const postgres = new PostgresTypeORM();
 		await postgres.connect();
 		logger.info("🗄️  Postgres connected · ranking ON");
+
+		// A missing config file degrades to zero groups; malformed or invalid
+		// content throws here and fails boot loudly (see loadRankGroupsConfig).
+		const rankGroupsConfig = loadRankGroupsConfig(config.rankGroups.path, logger);
+		setActiveRankGroupsConfig(rankGroupsConfig);
+		await new RankGroupSeeder(new RankGroupPostgresRepository(), logger).seed(rankGroupsConfig);
+
+		// Banlists are loaded before persistence boots, so the summary reflects
+		// the lists each enabled group is actually fed by right now.
+		const summary = formatRankGroupsSummary(
+			rankGroupsConfig,
+			new InMemoryLoadedBanListNamesProvider().names(),
+			new Date(),
+		);
+		if (summary !== null) {
+			logger.info(summary);
+		}
 	}
 
 	const redis = new Redis();

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -48,3 +48,25 @@ describe("config.rateLimit.join.limit", () => {
 		expect(loadConfig().rateLimit.join.limit).toBe(7);
 	});
 });
+
+describe("config.rankGroups.path", () => {
+	const originalValue = process.env.RANK_GROUPS_PATH;
+
+	afterEach(() => {
+		if (originalValue === undefined) {
+			delete process.env.RANK_GROUPS_PATH;
+		} else {
+			process.env.RANK_GROUPS_PATH = originalValue;
+		}
+	});
+
+	it("defaults to the repository seed file when unset", () => {
+		delete process.env.RANK_GROUPS_PATH;
+		expect(loadConfig().rankGroups.path).toBe("./config/rank-groups.json");
+	});
+
+	it("honors an explicit RANK_GROUPS_PATH override", () => {
+		process.env.RANK_GROUPS_PATH = "/etc/evolution/rank-groups.json";
+		expect(loadConfig().rankGroups.path).toBe("/etc/evolution/rank-groups.json");
+	});
+});

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -33,6 +33,9 @@ export const config = {
 	ranking: {
 		enabled: process.env.RANK_ENABLED === "true",
 	},
+	rankGroups: {
+		path: process.env.RANK_GROUPS_PATH ?? "./config/rank-groups.json",
+	},
 	season: Number(process.env.SEASON),
 	allowedOrigins: process.env.ALLOWED_ORIGINS?.split(",") ?? ["*"],
 	rateLimit: {

--- a/src/plugins/basic-stats/application/BasicStatsCalculator.test.ts
+++ b/src/plugins/basic-stats/application/BasicStatsCalculator.test.ts
@@ -7,6 +7,7 @@ import { MatchResumeCreator } from "@shared/stats/match-resume/application/Match
 import { DuelResumeCreator } from "@shared/stats/match-resume/duel-resume/application/DuelResumeCreator";
 import { PlayerStats } from "@shared/stats/player-stats/domain/PlayerStats";
 import { PlayerStatsRepository } from "@shared/stats/player-stats/domain/PlayerStatsRepository";
+import { RankGroupResolver } from "@shared/rank/application/RankGroupResolver";
 import { Rank } from "@shared/rank/domain/Rank";
 import { RankRepository } from "@shared/rank/domain/RankRepository";
 import { UserProfile } from "@shared/user-profile/domain/UserProfile";
@@ -29,6 +30,7 @@ describe("BasicStatsCalculator", () => {
 	let userProfileRepository: MockProxy<UserProfileRepository>;
 	let playerStatsRepository: MockProxy<PlayerStatsRepository>;
 	let rankRepository: MockProxy<RankRepository>;
+	let rankGroupResolver: MockProxy<RankGroupResolver>;
 	let matchResumeCreator: MockProxy<MatchResumeCreator>;
 	let duelResumeCreator: MockProxy<DuelResumeCreator>;
 	let playerUserProfile: UserProfile;
@@ -45,6 +47,9 @@ describe("BasicStatsCalculator", () => {
 		userProfileRepository = mock();
 		playerStatsRepository = mock<PlayerStatsRepository>();
 		rankRepository = mock<RankRepository>();
+		rankGroupResolver = mock<RankGroupResolver>();
+		rankGroupResolver.resolveAlias.mockImplementation((name) => name);
+		rankGroupResolver.groupsFor.mockReturnValue([]);
 		matchResumeCreator = mock();
 		duelResumeCreator = mock();
 		playerUserProfile = UserProfileMother.create();
@@ -65,6 +70,7 @@ describe("BasicStatsCalculator", () => {
 			userProfileRepository,
 			playerStatsRepository,
 			rankRepository,
+			rankGroupResolver,
 			matchResumeCreator,
 			duelResumeCreator,
 		);
@@ -292,5 +298,71 @@ describe("BasicStatsCalculator", () => {
 			globalRank.id,
 		);
 		expect(playerStatsRepository.save).toHaveBeenCalledTimes(4);
+	});
+
+	it("writes one extra row per resolved group rank for every player", async () => {
+		const groupRank = RankMother.create({ name: "TCG", type: "group" });
+		rankGroupResolver.groupsFor.mockReturnValue(["TCG"]);
+		rankRepository.findOrCreateByName.mockImplementation(async (name, type) =>
+			name === "Global" ? globalRank : type === "group" ? groupRank : { ...formatRank, name },
+		);
+		playerStatsRepository.findByUserIdAndRankId
+			.mockReset()
+			.mockImplementation(async () => PlayerStatsMother.create());
+		const event = GameOverDomainEventMother.create({
+			players: [player.toPresentation(), opponent.toPresentation()],
+			ranked: true,
+			banListName: "2026.05 TCG",
+		});
+
+		await basicStatsCalculator.handle(event);
+
+		expect(rankGroupResolver.groupsFor).toHaveBeenCalledWith("2026.05 TCG");
+		expect(rankRepository.findOrCreateByName).toHaveBeenCalledWith("TCG", "group");
+		expect(playerStatsRepository.findByUserIdAndRankId).toHaveBeenCalledWith(
+			playerUserProfile.id,
+			groupRank.id,
+		);
+		expect(playerStatsRepository.findByUserIdAndRankId).toHaveBeenCalledWith(
+			opponentUserProfile.id,
+			groupRank.id,
+		);
+		// 3 ranks (banlist, Global, group) × 2 players.
+		expect(playerStatsRepository.save).toHaveBeenCalledTimes(6);
+	});
+
+	it("resolves the alias before any rank lookup but keeps the raw name in resumes", async () => {
+		rankGroupResolver.resolveAlias.mockImplementation((name) =>
+			name === "JTP" ? "JTP (Original)" : name,
+		);
+		playerStatsRepository.findByUserIdAndRankId
+			.mockReset()
+			.mockImplementation(async () => PlayerStatsMother.create());
+		const event = GameOverDomainEventMother.create({
+			players: [player.toPresentation(), opponent.toPresentation()],
+			ranked: true,
+			banListName: "JTP",
+		});
+
+		await basicStatsCalculator.handle(event);
+
+		expect(rankRepository.findOrCreateByName).toHaveBeenCalledWith("JTP (Original)");
+		expect(rankRepository.findOrCreateByName).not.toHaveBeenCalledWith("JTP");
+		expect(rankGroupResolver.groupsFor).toHaveBeenCalledWith("JTP (Original)");
+		expect(matchResumeCreator.run).toHaveBeenCalledWith(
+			expect.objectContaining({ banListName: "JTP" }),
+		);
+	});
+
+	it("resolves no groups when banListName is N/A", async () => {
+		const event = GameOverDomainEventMother.create({
+			players: [player.toPresentation(), opponent.toPresentation()],
+			ranked: true,
+			banListName: "N/A",
+		});
+
+		await basicStatsCalculator.handle(event);
+
+		expect(rankGroupResolver.groupsFor).not.toHaveBeenCalled();
 	});
 });

--- a/src/plugins/basic-stats/application/BasicStatsCalculator.ts
+++ b/src/plugins/basic-stats/application/BasicStatsCalculator.ts
@@ -1,5 +1,7 @@
 import { Logger } from "src/shared/logger/domain/Logger";
 import { Player } from "src/shared/player/domain/Player";
+import { RankGroupResolver } from "src/shared/rank/application/RankGroupResolver";
+import { Rank } from "src/shared/rank/domain/Rank";
 import { RankRepository } from "src/shared/rank/domain/RankRepository";
 import { UserProfileRepository } from "src/shared/user-profile/domain/UserProfileRepository";
 
@@ -18,6 +20,7 @@ export class BasicStatsCalculator implements DomainEventSubscriber<GameOverDomai
 		private readonly userProfileRepository: UserProfileRepository,
 		private readonly playerStatsRepository: PlayerStatsRepository,
 		private readonly rankRepository: RankRepository,
+		private readonly rankGroupResolver: RankGroupResolver,
 		private readonly matchResumeCreator: MatchResumeCreator,
 		private readonly duelResumeCreator: DuelResumeCreator,
 	) {
@@ -40,11 +43,24 @@ export class BasicStatsCalculator implements DomainEventSubscriber<GameOverDomai
 
 		const gameId = event.data.matchId;
 
-		const banListRank =
-			banListName && banListName !== "N/A"
-				? await this.rankRepository.findOrCreateByName(banListName)
-				: null;
+		// The alias resolves before any rank lookup so a renamed header keeps
+		// feeding its canonical rank.
+		const hasRankedBanList = Boolean(banListName) && banListName !== "N/A";
+		const resolvedBanListName = hasRankedBanList
+			? this.rankGroupResolver.resolveAlias(banListName)
+			: banListName;
+
+		const banListRank = hasRankedBanList
+			? await this.rankRepository.findOrCreateByName(resolvedBanListName)
+			: null;
 		const globalRank = await this.rankRepository.findOrCreateByName("Global");
+		const groupNames = hasRankedBanList
+			? this.rankGroupResolver.groupsFor(resolvedBanListName)
+			: [];
+		const groupRanks: Rank[] = [];
+		for (const groupName of groupNames) {
+			groupRanks.push(await this.rankRepository.findOrCreateByName(groupName, "group"));
+		}
 
 		for (const player of players) {
 			const userProfile = await this.userProfileRepository.findByUsername(player.name);
@@ -65,23 +81,19 @@ export class BasicStatsCalculator implements DomainEventSubscriber<GameOverDomai
 				.map((element) => element.id);
 			const points = player.calculateMatchPoints();
 			this.logger.info(`Player ${player.name} and id: ${userProfile.id} gain ${points} points`);
-			if (banListRank) {
+			// One row per rank with the same wins/losses/points math: the
+			// banlist rank (when played on a real list), Global, and every
+			// group ladder the played list feeds.
+			const statsRanks = [...(banListRank ? [banListRank] : []), globalRank, ...groupRanks];
+			for (const rank of statsRanks) {
 				const playerStats = await this.playerStatsRepository.findByUserIdAndRankId(
 					userProfile.id,
-					banListRank.id,
+					rank.id,
 				);
 				playerStats.addPoints(points);
 				player.winner ? playerStats.increaseWins() : playerStats.increaseLosses();
 				void this.playerStatsRepository.save(playerStats);
 			}
-
-			const globalPlayerStats = await this.playerStatsRepository.findByUserIdAndRankId(
-				userProfile.id,
-				globalRank.id,
-			);
-			globalPlayerStats.addPoints(points);
-			player.winner ? globalPlayerStats.increaseWins() : globalPlayerStats.increaseLosses();
-			void this.playerStatsRepository.save(globalPlayerStats);
 
 			const { id: matchId } = await this.matchResumeCreator.run({
 				userId: userProfile.id,

--- a/src/plugins/basic-stats/index.ts
+++ b/src/plugins/basic-stats/index.ts
@@ -3,7 +3,10 @@ import { PluginDeps, ServerPlugin } from "@shared/plugin/ServerPlugin";
 import { MatchResumeCreator } from "@shared/stats/match-resume/application/MatchResumeCreator";
 import { DuelResumeCreator } from "@shared/stats/match-resume/duel-resume/application/DuelResumeCreator";
 import { MatchResumePostgresRepository } from "@shared/stats/match-resume/infrastructure/postgres/MatchResumePostgresRepository";
+import { RankGroupResolver } from "@shared/rank/application/RankGroupResolver";
+import { InMemoryLoadedBanListNamesProvider } from "@shared/rank/infrastructure/InMemoryLoadedBanListNamesProvider";
 import { RankPostgresRepository } from "@shared/rank/infrastructure/RankPostgresRepository";
+import { getActiveRankGroupsConfig } from "@shared/rank/infrastructure/RankGroupsConfigLoader";
 import { PlayerStatsPostgresRepository } from "@shared/stats/player-stats/infrastructure/PlayerStatsPostgresRepository";
 import { UserProfilePostgresRepository } from "@shared/user-profile/infrastructure/postgres/UserProfilePostgresRepository";
 
@@ -23,6 +26,7 @@ const plugin: ServerPlugin = {
 				new UserProfilePostgresRepository(),
 				new PlayerStatsPostgresRepository(),
 				new RankPostgresRepository(),
+				new RankGroupResolver(getActiveRankGroupsConfig, new InMemoryLoadedBanListNamesProvider()),
 				new MatchResumeCreator(new MatchResumePostgresRepository()),
 				new DuelResumeCreator(new MatchResumePostgresRepository()),
 			),

--- a/src/plugins/elo-rating/application/EloRatingCalculator.test.ts
+++ b/src/plugins/elo-rating/application/EloRatingCalculator.test.ts
@@ -1,5 +1,6 @@
 import { mock, MockProxy } from "jest-mock-extended";
 import { Logger } from "@shared/logger/domain/Logger";
+import { RankGroupResolver } from "@shared/rank/application/RankGroupResolver";
 import { Rank } from "@shared/rank/domain/Rank";
 import { RankRepository } from "@shared/rank/domain/RankRepository";
 import { Team } from "@shared/room/Team";
@@ -21,6 +22,7 @@ describe("EloRatingCalculator", () => {
 	let userProfileRepository: MockProxy<UserProfileRepository>;
 	let ratingRepository: MockProxy<RatingRepository>;
 	let rankRepository: MockProxy<RankRepository>;
+	let rankGroupResolver: MockProxy<RankGroupResolver>;
 	let rank: Rank;
 	let tx: MockProxy<RatingTransaction>;
 
@@ -30,6 +32,9 @@ describe("EloRatingCalculator", () => {
 		userProfileRepository = mock<UserProfileRepository>();
 		ratingRepository = mock<RatingRepository>();
 		rankRepository = mock<RankRepository>();
+		rankGroupResolver = mock<RankGroupResolver>();
+		rankGroupResolver.resolveAlias.mockImplementation((name) => name);
+		rankGroupResolver.groupsFor.mockReturnValue([]);
 		rank = RankMother.create({ name: "TCG" });
 		rankRepository.findOrCreateByName.mockResolvedValue(rank);
 		tx = mock<RatingTransaction>();
@@ -40,6 +45,7 @@ describe("EloRatingCalculator", () => {
 			userProfileRepository,
 			ratingRepository,
 			rankRepository,
+			rankGroupResolver,
 		);
 	});
 
@@ -263,6 +269,84 @@ describe("EloRatingCalculator", () => {
 
 			expect(ratingRepository.transaction).not.toHaveBeenCalled();
 			expect(logger.warn).toHaveBeenCalled();
+		});
+	});
+
+	describe("group ranks", () => {
+		function resolveAccounts(): void {
+			const winnerProfile = UserProfileMother.create({ id: "player-1" });
+			const loserProfile = UserProfileMother.create({ id: "player-2" });
+			userProfileRepository.findById.mockImplementation(async (id) =>
+				id === "player-1" ? winnerProfile : loserProfile,
+			);
+		}
+
+		it("processes one independent Elo transaction per resolved group rank", async () => {
+			const groupRank = RankMother.create({ name: "TCG Ladder", type: "group" });
+			rankGroupResolver.groupsFor.mockReturnValue(["TCG Ladder"]);
+			rankRepository.findOrCreateByName.mockImplementation(async (name) =>
+				name === "TCG Ladder" ? groupRank : rank,
+			);
+			resolveAccounts();
+			ratingRepository.transaction.mockImplementation(async (_userIds, _rankId, _season, work) =>
+				work(
+					new Map<string, Rating>([
+						["player-1", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+						["player-2", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+					]),
+					tx,
+				),
+			);
+
+			await calculator.handle(makeEligibleEvent());
+
+			expect(rankRepository.findOrCreateByName).toHaveBeenCalledWith("TCG");
+			expect(rankRepository.findOrCreateByName).toHaveBeenCalledWith("TCG Ladder", "group");
+			expect(ratingRepository.transaction).toHaveBeenCalledTimes(2);
+			expect(ratingRepository.transaction).toHaveBeenCalledWith(
+				expect.arrayContaining(["player-1", "player-2"]),
+				rank.id,
+				config.season,
+				expect.any(Function),
+			);
+			expect(ratingRepository.transaction).toHaveBeenCalledWith(
+				expect.arrayContaining(["player-1", "player-2"]),
+				groupRank.id,
+				config.season,
+				expect.any(Function),
+			);
+			expect(tx.insertHistory).toHaveBeenCalledWith(
+				expect.objectContaining({ userId: "player-1", rankId: rank.id }),
+			);
+			expect(tx.insertHistory).toHaveBeenCalledWith(
+				expect.objectContaining({ userId: "player-1", rankId: groupRank.id }),
+			);
+			expect(tx.saveRating).toHaveBeenCalledWith(
+				"player-1",
+				groupRank.id,
+				config.season,
+				expect.anything(),
+			);
+		});
+
+		it("resolves the alias before the rank lookup and resolves groups from the canonical name", async () => {
+			rankGroupResolver.resolveAlias.mockImplementation((name) =>
+				name === "JTP" ? "JTP (Original)" : name,
+			);
+			resolveAccounts();
+
+			await calculator.handle(makeEligibleEvent({ banListName: "JTP" }));
+
+			expect(rankGroupResolver.resolveAlias).toHaveBeenCalledWith("JTP");
+			expect(rankRepository.findOrCreateByName).toHaveBeenCalledWith("JTP (Original)");
+			expect(rankGroupResolver.groupsFor).toHaveBeenCalledWith("JTP (Original)");
+		});
+
+		it("consults the resolver only after the eligibility gate", async () => {
+			await calculator.handle(makeEligibleEvent({ ranked: false }));
+
+			expect(rankGroupResolver.resolveAlias).not.toHaveBeenCalled();
+			expect(rankGroupResolver.groupsFor).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/plugins/elo-rating/application/EloRatingCalculator.ts
+++ b/src/plugins/elo-rating/application/EloRatingCalculator.ts
@@ -1,4 +1,6 @@
 import { Logger } from "src/shared/logger/domain/Logger";
+import { RankGroupResolver } from "src/shared/rank/application/RankGroupResolver";
+import { Rank } from "src/shared/rank/domain/Rank";
 import { RankRepository } from "src/shared/rank/domain/RankRepository";
 import { EloCalculator, RatedPlayer } from "src/shared/stats/rating/domain/EloCalculator";
 import { Rating } from "src/shared/stats/rating/domain/Rating";
@@ -18,6 +20,7 @@ export class EloRatingCalculator implements DomainEventSubscriber<GameOverDomain
 		private readonly userProfileRepository: UserProfileRepository,
 		private readonly ratingRepository: RatingRepository,
 		private readonly rankRepository: RankRepository,
+		private readonly rankGroupResolver: RankGroupResolver,
 	) {
 		this.logger = logger.child({ file: "EloRatingCalculator" });
 	}
@@ -63,39 +66,48 @@ export class EloRatingCalculator implements DomainEventSubscriber<GameOverDomain
 			team: player.team,
 			winner: player.winner,
 		}));
-		const banListName = eligibility.banListName;
 		const season = config.season;
-		// Eligibility stays keyed on the banlist name; persistence is keyed by
-		// the rank resolved (or created) for that name, once per match.
-		const rank = await this.rankRepository.findOrCreateByName(banListName);
+		// Eligibility stays keyed on the raw banlist name; persistence is
+		// keyed by the ranks resolved (or created) once per match. The alias
+		// resolves before any rank lookup, and each group ladder the played
+		// list feeds is an independent Elo pool with its own ratings and
+		// history. Global stays out of Elo.
+		const banListName = this.rankGroupResolver.resolveAlias(eligibility.banListName);
+		const groupNames = this.rankGroupResolver.groupsFor(banListName);
+		const ranks: Rank[] = [await this.rankRepository.findOrCreateByName(banListName)];
+		for (const groupName of groupNames) {
+			ranks.push(await this.rankRepository.findOrCreateByName(groupName, "group"));
+		}
 
-		await this.ratingRepository.transaction(playerIds, rank.id, season, async (ratings, tx) => {
-			const deltas = EloCalculator.deltasFor(ratedPlayers, ratings);
+		for (const rank of ranks) {
+			await this.ratingRepository.transaction(playerIds, rank.id, season, async (ratings, tx) => {
+				const deltas = EloCalculator.deltasFor(ratedPlayers, ratings);
 
-			for (const delta of deltas) {
-				const inserted = await tx.insertHistory({
-					matchId: data.matchId,
-					userId: delta.userId,
-					rankId: rank.id,
-					season,
-					kind: "applied",
-					previousRating: delta.previousRating,
-					delta: delta.delta,
-					kFactor: delta.kFactor,
-					opponentRating: delta.opponentRating,
-				});
+				for (const delta of deltas) {
+					const inserted = await tx.insertHistory({
+						matchId: data.matchId,
+						userId: delta.userId,
+						rankId: rank.id,
+						season,
+						kind: "applied",
+						previousRating: delta.previousRating,
+						delta: delta.delta,
+						kFactor: delta.kFactor,
+						opponentRating: delta.opponentRating,
+					});
 
-				if (!inserted) {
-					this.logger.info(
-						`Rating for match ${data.matchId} / user ${delta.userId} was already recorded — replay no-op.`,
-					);
-					continue;
+					if (!inserted) {
+						this.logger.info(
+							`Rating for match ${data.matchId} / user ${delta.userId} was already recorded — replay no-op.`,
+						);
+						continue;
+					}
+
+					const currentRating = ratings.get(delta.userId) as Rating;
+					const updatedRating = currentRating.applyDelta(delta.delta);
+					await tx.saveRating(delta.userId, rank.id, season, updatedRating);
 				}
-
-				const currentRating = ratings.get(delta.userId) as Rating;
-				const updatedRating = currentRating.applyDelta(delta.delta);
-				await tx.saveRating(delta.userId, rank.id, season, updatedRating);
-			}
-		});
+			});
+		}
 	}
 }

--- a/src/plugins/elo-rating/index.ts
+++ b/src/plugins/elo-rating/index.ts
@@ -1,6 +1,9 @@
 import { EventBus } from "@shared/event-bus/EventBus";
 import { PluginDeps, ServerPlugin } from "@shared/plugin/ServerPlugin";
+import { RankGroupResolver } from "@shared/rank/application/RankGroupResolver";
+import { InMemoryLoadedBanListNamesProvider } from "@shared/rank/infrastructure/InMemoryLoadedBanListNamesProvider";
 import { RankPostgresRepository } from "@shared/rank/infrastructure/RankPostgresRepository";
+import { getActiveRankGroupsConfig } from "@shared/rank/infrastructure/RankGroupsConfigLoader";
 import { RatingPostgresRepository } from "@shared/stats/rating/infrastructure/RatingPostgresRepository";
 import { UserProfilePostgresRepository } from "@shared/user-profile/infrastructure/postgres/UserProfilePostgresRepository";
 
@@ -20,6 +23,7 @@ const plugin: ServerPlugin = {
 				new UserProfilePostgresRepository(),
 				new RatingPostgresRepository(),
 				new RankPostgresRepository(),
+				new RankGroupResolver(getActiveRankGroupsConfig, new InMemoryLoadedBanListNamesProvider()),
 			),
 		);
 	},

--- a/src/plugins/rating-announcer/index.ts
+++ b/src/plugins/rating-announcer/index.ts
@@ -1,5 +1,8 @@
 import LoggerFactory from "@shared/logger/infrastructure/LoggerFactory";
+import { RankGroupResolver } from "@shared/rank/application/RankGroupResolver";
+import { InMemoryLoadedBanListNamesProvider } from "@shared/rank/infrastructure/InMemoryLoadedBanListNamesProvider";
 import { RankPostgresRepository } from "@shared/rank/infrastructure/RankPostgresRepository";
+import { getActiveRankGroupsConfig } from "@shared/rank/infrastructure/RankGroupsConfigLoader";
 import { ServerPlugin } from "@shared/plugin/ServerPlugin";
 import { RatingAnnouncer } from "@shared/stats/rating/application/RatingAnnouncer";
 import { RatingPostgresRepository } from "@shared/stats/rating/infrastructure/RatingPostgresRepository";
@@ -16,6 +19,7 @@ const plugin: ServerPlugin = {
 		new RatingAnnouncer(
 			new RatingPostgresRepository(),
 			new RankPostgresRepository(),
+			new RankGroupResolver(getActiveRankGroupsConfig, new InMemoryLoadedBanListNamesProvider()),
 			LoggerFactory.getLogger({ file: "RatingAnnouncer" }),
 		),
 	],

--- a/src/shared/rank/application/RankGroupResolver.test.ts
+++ b/src/shared/rank/application/RankGroupResolver.test.ts
@@ -1,0 +1,76 @@
+import { LoadedBanListNamesProvider } from "../domain/LoadedBanListNamesProvider";
+import { RankGroupsConfig } from "../domain/RankGroupConfig";
+import { RankGroupResolver } from "./RankGroupResolver";
+
+function makeResolver(
+	config: RankGroupsConfig,
+	loadedNames: string[],
+	now: Date,
+): RankGroupResolver {
+	const provider: LoadedBanListNamesProvider = { names: () => loadedNames };
+
+	return new RankGroupResolver(
+		() => config,
+		provider,
+		() => now,
+	);
+}
+
+describe("RankGroupResolver", () => {
+	const today = new Date(Date.UTC(2026, 7, 1)); // 2026-08-01
+
+	it("resolves aliases from the bound config", () => {
+		const resolver = makeResolver({ aliases: { JTP: "JTP (Original)" }, groups: [] }, [], today);
+
+		expect(resolver.resolveAlias("JTP")).toBe("JTP (Original)");
+		expect(resolver.resolveAlias("2026.05 TCG")).toBe("2026.05 TCG");
+	});
+
+	it("resolves groups against the live loaded banlist names", () => {
+		const resolver = makeResolver(
+			{
+				aliases: {},
+				groups: [{ name: "TCG", enabled: true, onlyCurrent: true, members: ["* TCG"] }],
+			},
+			["2026.05 TCG", "2025.04 TCG"],
+			today,
+		);
+
+		expect(resolver.groupsFor("2026.05 TCG")).toEqual(["TCG"]);
+		expect(resolver.groupsFor("2025.04 TCG")).toEqual([]);
+	});
+
+	it("alias-resolves loaded names so a renamed header competes for currency canonically", () => {
+		const resolver = makeResolver(
+			{
+				aliases: { "2026.07 TCG Header": "2026.07 TCG" },
+				groups: [{ name: "TCG", enabled: true, onlyCurrent: true, members: ["* TCG"] }],
+			},
+			["2026.05 TCG", "2026.07 TCG Header"],
+			today,
+		);
+
+		// The aliased loaded name is the newer current TCG list, so the
+		// older played list must not resolve as current.
+		expect(resolver.groupsFor("2026.05 TCG")).toEqual([]);
+		expect(resolver.groupsFor("2026.07 TCG")).toEqual(["TCG"]);
+	});
+
+	it("re-reads loaded names on every call so a hot reload is reflected", () => {
+		const names = ["2026.05 TCG"];
+		const provider: LoadedBanListNamesProvider = { names: () => [...names] };
+		const resolver = new RankGroupResolver(
+			() => ({
+				aliases: {},
+				groups: [{ name: "TCG", enabled: true, onlyCurrent: true, members: ["* TCG"] }],
+			}),
+			provider,
+			() => today,
+		);
+
+		expect(resolver.groupsFor("2026.05 TCG")).toEqual(["TCG"]);
+
+		names.push("2026.07 TCG");
+		expect(resolver.groupsFor("2026.05 TCG")).toEqual([]);
+	});
+});

--- a/src/shared/rank/application/RankGroupResolver.ts
+++ b/src/shared/rank/application/RankGroupResolver.ts
@@ -1,0 +1,33 @@
+import { LoadedBanListNamesProvider } from "../domain/LoadedBanListNamesProvider";
+import { RankGroupsConfig } from "../domain/RankGroupConfig";
+import { resolveAlias, resolveGroupsFor } from "../domain/RankGroupResolution";
+
+/**
+ * Match-time facade over the pure group-resolution domain: binds the boot
+ * config, the live in-memory banlist names, and the clock, so writers resolve
+ * aliases and group ranks with one call each.
+ */
+export class RankGroupResolver {
+	constructor(
+		private readonly configProvider: () => RankGroupsConfig,
+		private readonly loadedBanListNames: LoadedBanListNamesProvider,
+		private readonly now: () => Date = () => new Date(),
+	) {}
+
+	/** Canonical rank name for a played banlist header name. */
+	resolveAlias(name: string): string {
+		return resolveAlias(name, this.configProvider().aliases);
+	}
+
+	/**
+	 * Group rank names the given (already alias-resolved) banlist name feeds
+	 * right now. Loaded names are alias-resolved too, so a renamed header
+	 * competes for currency under its canonical name.
+	 */
+	groupsFor(banListName: string): string[] {
+		const { aliases, groups } = this.configProvider();
+		const loadedNames = this.loadedBanListNames.names().map((name) => resolveAlias(name, aliases));
+
+		return resolveGroupsFor(banListName, groups, loadedNames, this.now());
+	}
+}

--- a/src/shared/rank/application/RankGroupsSummary.test.ts
+++ b/src/shared/rank/application/RankGroupsSummary.test.ts
@@ -1,0 +1,68 @@
+import { RankGroupsConfig } from "../domain/RankGroupConfig";
+import { formatRankGroupsSummary } from "./RankGroupsSummary";
+
+describe("formatRankGroupsSummary", () => {
+	const config: RankGroupsConfig = {
+		aliases: {},
+		groups: [
+			{ name: "TCG", enabled: true, onlyCurrent: true, members: ["* TCG"] },
+			{ name: "OCG", enabled: true, onlyCurrent: true, members: ["* OCG"] },
+			{ name: "Rush", enabled: true, onlyCurrent: true, members: ["* Rush Duel", "RD"] },
+			{ name: "Speed", enabled: true, onlyCurrent: false, members: ["* Speed Duel"] },
+		],
+	};
+	const loaded = ["2026.05 TCG", "2026.07 OCG", "2026.07.01 Rush Duel", "RD"];
+	const today = new Date(Date.UTC(2026, 7, 31)); // 2026-08-31
+
+	it("shows the lists feeding every enabled group in one boot-style line", () => {
+		expect(formatRankGroupsSummary(config, loaded, today)).toBe(
+			"🏆 Rank groups → TCG: 2026.05 TCG · OCG: 2026.07 OCG · Rush: 2026.07.01 Rush Duel + RD · Speed: (no loaded list)",
+		);
+	});
+
+	it("omits disabled groups", () => {
+		const withDisabled: RankGroupsConfig = {
+			aliases: {},
+			groups: [
+				{ name: "TCG", enabled: true, onlyCurrent: true, members: ["* TCG"] },
+				{ name: "Worlds", enabled: false, onlyCurrent: false, members: ["* Worlds"] },
+			],
+		};
+
+		expect(formatRankGroupsSummary(withDisabled, loaded, today)).toBe(
+			"🏆 Rank groups → TCG: 2026.05 TCG",
+		);
+	});
+
+	it("shows only the current list, not retro or future-dated matches", () => {
+		const names = ["2025.04 TCG", "2026.05 TCG", "2026.10 TCG"];
+
+		expect(formatRankGroupsSummary(config, names, today)).toBe(
+			"🏆 Rank groups → TCG: 2026.05 TCG · OCG: (no loaded list) · Rush: (no loaded list) · Speed: (no loaded list)",
+		);
+	});
+
+	it("alias-resolves the loaded names before matching", () => {
+		const aliased: RankGroupsConfig = {
+			aliases: { "2011.09 Tengu Plant": "2011.09 Tengu" },
+			groups: [{ name: "Tengu", enabled: true, onlyCurrent: true, members: ["* Tengu"] }],
+		};
+
+		expect(formatRankGroupsSummary(aliased, ["2011.09 Tengu Plant"], today)).toBe(
+			"🏆 Rank groups → Tengu: 2011.09 Tengu",
+		);
+	});
+
+	it("returns null when the config has no groups", () => {
+		expect(formatRankGroupsSummary({ aliases: {}, groups: [] }, loaded, today)).toBeNull();
+	});
+
+	it("returns null when every group is disabled", () => {
+		const allDisabled: RankGroupsConfig = {
+			aliases: {},
+			groups: [{ name: "Worlds", enabled: false, onlyCurrent: false, members: ["* Worlds"] }],
+		};
+
+		expect(formatRankGroupsSummary(allDisabled, loaded, today)).toBeNull();
+	});
+});

--- a/src/shared/rank/application/RankGroupsSummary.ts
+++ b/src/shared/rank/application/RankGroupsSummary.ts
@@ -1,0 +1,28 @@
+import { RankGroupsConfig } from "../domain/RankGroupConfig";
+import { currentListsFor, resolveAlias } from "../domain/RankGroupResolution";
+
+/**
+ * One boot-log line showing which loaded banlists feed each enabled group
+ * right now, e.g. `🏆 Rank groups → TCG: 2026.05 TCG · Speed: (no loaded list)`.
+ * Loaded names are alias-resolved before matching, mirroring the resolver.
+ * Returns null when no group is enabled, so boot logs nothing.
+ */
+export function formatRankGroupsSummary(
+	config: RankGroupsConfig,
+	loadedBanListNames: string[],
+	today: Date,
+): string | null {
+	const enabledGroups = config.groups.filter((group) => group.enabled);
+	if (enabledGroups.length === 0) {
+		return null;
+	}
+
+	const resolvedNames = loadedBanListNames.map((name) => resolveAlias(name, config.aliases));
+	const segments = enabledGroups.map((group) => {
+		const { current } = currentListsFor(group, resolvedNames, today);
+
+		return `${group.name}: ${current.length === 0 ? "(no loaded list)" : current.join(" + ")}`;
+	});
+
+	return `🏆 Rank groups → ${segments.join(" · ")}`;
+}

--- a/src/shared/rank/domain/LoadedBanListNamesProvider.ts
+++ b/src/shared/rank/domain/LoadedBanListNamesProvider.ts
@@ -1,0 +1,8 @@
+/**
+ * Names of every banlist currently loaded in memory, across both server
+ * protocols. Read at match time so a banlist hot-reload is reflected in
+ * group-currency decisions without a restart.
+ */
+export interface LoadedBanListNamesProvider {
+	names(): string[];
+}

--- a/src/shared/rank/domain/RankGroupConfig.ts
+++ b/src/shared/rank/domain/RankGroupConfig.ts
@@ -1,0 +1,23 @@
+/** Maps a played banlist header name to the canonical rank name it feeds. */
+export type RankGroupAliases = Record<string, string>;
+
+/**
+ * One configurable group rank: a persistent ladder fed by every banlist whose
+ * name matches one of `members`. A `"* X"` member matches any name ending in
+ * `" X"`; any other member string is an exact match.
+ */
+export type RankGroupDefinition = {
+	name: string;
+	enabled: boolean;
+	onlyCurrent: boolean;
+	members: string[];
+};
+
+export type RankGroupsConfig = {
+	aliases: RankGroupAliases;
+	groups: RankGroupDefinition[];
+};
+
+export function emptyRankGroupsConfig(): RankGroupsConfig {
+	return { aliases: {}, groups: [] };
+}

--- a/src/shared/rank/domain/RankGroupRepository.ts
+++ b/src/shared/rank/domain/RankGroupRepository.ts
@@ -1,0 +1,21 @@
+export type RankGroupUpsert = {
+	name: string;
+	enabled: boolean;
+	onlyCurrent: boolean;
+};
+
+/** Persistence port for seeding configured group ranks at boot. */
+export interface RankGroupRepository {
+	/**
+	 * Upserts a `type: "group"` rank by its unique name, updating enabled and
+	 * only_current on an existing group. Returns null when the name belongs
+	 * to a rank of another type — those are never touched.
+	 */
+	upsertGroup(group: RankGroupUpsert): Promise<{ id: string } | null>;
+
+	/** Replaces every rank_members row of the given rank with these patterns. */
+	replaceMembers(rankId: string, patterns: string[]): Promise<void>;
+
+	/** Names of every rank with type "group". */
+	findGroupNames(): Promise<string[]>;
+}

--- a/src/shared/rank/domain/RankGroupResolution.test.ts
+++ b/src/shared/rank/domain/RankGroupResolution.test.ts
@@ -1,0 +1,247 @@
+import { RankGroupDefinition } from "./RankGroupConfig";
+import {
+	currentListsFor,
+	memberMatches,
+	parseBanListDatePrefix,
+	resolveAlias,
+	resolveGroupsFor,
+} from "./RankGroupResolution";
+
+const aliases = {
+	JTP: "JTP (Original)",
+	"2011.09 Tengu Plant": "2011.09 Tengu",
+};
+
+describe("resolveAlias", () => {
+	it("maps an aliased name to its canonical rank name", () => {
+		expect(resolveAlias("JTP", aliases)).toBe("JTP (Original)");
+		expect(resolveAlias("2011.09 Tengu Plant", aliases)).toBe("2011.09 Tengu");
+	});
+
+	it("passes an unmapped name through unchanged", () => {
+		expect(resolveAlias("2026.05 TCG", aliases)).toBe("2026.05 TCG");
+		expect(resolveAlias("RD", aliases)).toBe("RD");
+	});
+
+	it("passes everything through when there are no aliases", () => {
+		expect(resolveAlias("JTP", {})).toBe("JTP");
+	});
+});
+
+describe("memberMatches", () => {
+	it('matches a "* X" member against any name ending in " X"', () => {
+		expect(memberMatches("2026.05 TCG", "* TCG")).toBe(true);
+		expect(memberMatches("2025.10 Rush Duel", "* Rush Duel")).toBe(true);
+	});
+
+	it('does not match "* X" against the bare suffix without a preceding space', () => {
+		expect(memberMatches("TCG", "* TCG")).toBe(false);
+	});
+
+	it('does not match "* X" against a different suffix', () => {
+		expect(memberMatches("2026.05 OCG", "* TCG")).toBe(false);
+		expect(memberMatches("2026.05 TCG Beta", "* TCG")).toBe(false);
+	});
+
+	it("matches a plain member only exactly", () => {
+		expect(memberMatches("RD", "RD")).toBe(true);
+		expect(memberMatches("2025.10 RD", "RD")).toBe(false);
+		expect(memberMatches("RD Extra", "RD")).toBe(false);
+	});
+});
+
+describe("parseBanListDatePrefix", () => {
+	it("parses a leading YYYY.MM prefix, defaulting the day to 1", () => {
+		expect(parseBanListDatePrefix("2026.05 TCG")).toEqual({ year: 2026, month: 5, day: 1 });
+	});
+
+	it("parses a leading YYYY.MM.DD prefix", () => {
+		expect(parseBanListDatePrefix("2010.03.15 Edison")).toEqual({
+			year: 2010,
+			month: 3,
+			day: 15,
+		});
+	});
+
+	it("parses a name that is only a date", () => {
+		expect(parseBanListDatePrefix("2026.05")).toEqual({ year: 2026, month: 5, day: 1 });
+	});
+
+	it("returns null for a name without a date prefix", () => {
+		expect(parseBanListDatePrefix("RD")).toBeNull();
+		expect(parseBanListDatePrefix("JTP (Original)")).toBeNull();
+	});
+
+	it("returns null when the date prefix is not followed by a break", () => {
+		expect(parseBanListDatePrefix("2026.05TCG")).toBeNull();
+	});
+
+	it("returns null when the prefix is not zero-padded to the expected width", () => {
+		expect(parseBanListDatePrefix("2026.5 TCG")).toBeNull();
+	});
+});
+
+describe("resolveGroupsFor", () => {
+	const groups: RankGroupDefinition[] = [
+		{ name: "TCG", enabled: true, onlyCurrent: true, members: ["* TCG"] },
+		{ name: "Rush", enabled: true, onlyCurrent: true, members: ["* Rush Duel", "RD"] },
+		{ name: "Edison Forever", enabled: true, onlyCurrent: false, members: ["* Edison"] },
+		{ name: "Disabled TCG", enabled: false, onlyCurrent: false, members: ["* TCG"] },
+	];
+	const loaded = [
+		"2025.04 TCG",
+		"2026.05 TCG",
+		"2026.10 TCG",
+		"2026.05 OCG",
+		"RD",
+		"2010.03 Edison",
+		"2005.04 Edison",
+	];
+	const today = new Date(Date.UTC(2026, 5, 1)); // 2026-06-01
+
+	it("resolves the current dated list of an onlyCurrent group, ignoring future-dated siblings", () => {
+		expect(resolveGroupsFor("2026.05 TCG", groups, loaded, today)).toEqual(["TCG"]);
+	});
+
+	it("does not resolve a retro list into an onlyCurrent group", () => {
+		expect(resolveGroupsFor("2025.04 TCG", groups, loaded, today)).toEqual([]);
+	});
+
+	it("does not resolve a future-dated list into an onlyCurrent group", () => {
+		expect(resolveGroupsFor("2026.10 TCG", groups, loaded, today)).toEqual([]);
+	});
+
+	it("treats a dateless matching name as always current", () => {
+		expect(resolveGroupsFor("RD", groups, loaded, today)).toEqual(["Rush"]);
+	});
+
+	it("resolves any matching member into a group that is not onlyCurrent", () => {
+		expect(resolveGroupsFor("2010.03 Edison", groups, loaded, today)).toEqual(["Edison Forever"]);
+		expect(resolveGroupsFor("2005.04 Edison", groups, loaded, today)).toEqual(["Edison Forever"]);
+	});
+
+	it("never resolves a disabled group", () => {
+		const resolved = resolveGroupsFor("2026.05 TCG", groups, loaded, today);
+		expect(resolved).not.toContain("Disabled TCG");
+	});
+
+	it('never resolves "N/A" or "Global" into any group', () => {
+		expect(resolveGroupsFor("N/A", groups, loaded, today)).toEqual([]);
+		expect(resolveGroupsFor("Global", groups, loaded, today)).toEqual([]);
+	});
+
+	it("resolves nothing for a name no member matches", () => {
+		expect(resolveGroupsFor("JTP (Original)", groups, loaded, today)).toEqual([]);
+	});
+
+	it("treats a played list newer than every loaded sibling as current even if not loaded itself", () => {
+		expect(resolveGroupsFor("2026.06 TCG", groups, loaded, today)).toEqual(["TCG"]);
+	});
+
+	it("treats a list dated exactly today as current", () => {
+		const firstOfMay = new Date(Date.UTC(2026, 4, 1)); // 2026-05-01
+		expect(resolveGroupsFor("2026.05 TCG", groups, loaded, firstOfMay)).toEqual(["TCG"]);
+	});
+
+	it("can resolve several groups at once", () => {
+		const multi: RankGroupDefinition[] = [
+			{ name: "TCG", enabled: true, onlyCurrent: true, members: ["* TCG"] },
+			{ name: "All Formats", enabled: true, onlyCurrent: false, members: ["* TCG", "* OCG"] },
+		];
+		expect(resolveGroupsFor("2026.05 TCG", multi, loaded, today)).toEqual(["TCG", "All Formats"]);
+	});
+});
+
+describe("currentListsFor", () => {
+	const tcg: RankGroupDefinition = {
+		name: "TCG",
+		enabled: true,
+		onlyCurrent: true,
+		members: ["* TCG"],
+	};
+	const rush: RankGroupDefinition = {
+		name: "Rush",
+		enabled: true,
+		onlyCurrent: true,
+		members: ["* Rush Duel", "RD"],
+	};
+	const loaded = [
+		"2025.04 TCG",
+		"2026.05 TCG",
+		"2026.10 TCG",
+		"2026.05 OCG",
+		"2026.07.01 Rush Duel",
+		"RD",
+	];
+	const today = new Date(Date.UTC(2026, 7, 1)); // 2026-08-01
+
+	it("collects every loaded name matching a member as matched", () => {
+		expect(currentListsFor(tcg, loaded, today).matched).toEqual([
+			"2025.04 TCG",
+			"2026.05 TCG",
+			"2026.10 TCG",
+		]);
+	});
+
+	it("marks only the max-dated match not after today as current", () => {
+		expect(currentListsFor(tcg, loaded, today).current).toEqual(["2026.05 TCG"]);
+	});
+
+	it("keeps a future-dated match out of current while still matched", () => {
+		const { matched, current } = currentListsFor(tcg, loaded, today);
+		expect(matched).toContain("2026.10 TCG");
+		expect(current).not.toContain("2026.10 TCG");
+	});
+
+	it("treats every dateless match as current alongside the max-dated one", () => {
+		expect(currentListsFor(rush, loaded, today)).toEqual({
+			matched: ["2026.07.01 Rush Duel", "RD"],
+			current: ["2026.07.01 Rush Duel", "RD"],
+		});
+	});
+
+	it("returns empty sets when nothing loaded matches the group", () => {
+		const speed: RankGroupDefinition = {
+			name: "Speed",
+			enabled: true,
+			onlyCurrent: false,
+			members: ["* Speed Duel"],
+		};
+		expect(currentListsFor(speed, loaded, today)).toEqual({ matched: [], current: [] });
+	});
+
+	it("leaves current empty when every dated match is in the future", () => {
+		const early = new Date(Date.UTC(2024, 0, 1));
+		expect(currentListsFor(tcg, loaded, early)).toEqual({
+			matched: ["2025.04 TCG", "2026.05 TCG", "2026.10 TCG"],
+			current: [],
+		});
+	});
+
+	it("includes a list dated exactly today as current", () => {
+		const firstOfMay = new Date(Date.UTC(2026, 4, 1)); // 2026-05-01
+		expect(currentListsFor(tcg, loaded, firstOfMay).current).toEqual(["2026.05 TCG"]);
+	});
+
+	it("keeps every tied max-dated match current, consistently with resolveGroupsFor", () => {
+		const tied = ["2026.05 TCG", "2026.05.01 Extra TCG"];
+		const { current } = currentListsFor(tcg, tied, today);
+		expect(current).toEqual(tied);
+		for (const name of tied) {
+			expect(resolveGroupsFor(name, [tcg], tied, today)).toEqual(["TCG"]);
+		}
+	});
+
+	it("never reports a non-groupable name as current", () => {
+		const global: RankGroupDefinition = {
+			name: "Everything",
+			enabled: true,
+			onlyCurrent: false,
+			members: ["Global"],
+		};
+		expect(currentListsFor(global, ["Global"], today)).toEqual({
+			matched: ["Global"],
+			current: [],
+		});
+	});
+});

--- a/src/shared/rank/domain/RankGroupResolution.ts
+++ b/src/shared/rank/domain/RankGroupResolution.ts
@@ -1,0 +1,159 @@
+import { RankGroupAliases, RankGroupDefinition } from "./RankGroupConfig";
+
+export type BanListDatePrefix = {
+	year: number;
+	month: number;
+	day: number;
+};
+
+// Names that are rank concepts of their own and must never feed a group.
+const NON_GROUPABLE_NAMES = new Set(["N/A", "Global"]);
+
+// Leading `YYYY.MM` or `YYYY.MM.DD` of an already zero-padded name; the
+// prefix must be the whole name or be followed by whitespace.
+const DATE_PREFIX_PATTERN = /^(\d{4})\.(\d{2})(?:\.(\d{2}))?(?=\s|$)/;
+
+/**
+ * Resolves a banlist header name to its canonical rank name. Applied before
+ * any rank lookup so a renamed header keeps feeding the rank its history
+ * lives under instead of re-creating a ladder that was merged historically.
+ */
+export function resolveAlias(name: string, aliases: RankGroupAliases): string {
+	return Object.hasOwn(aliases, name) ? aliases[name] : name;
+}
+
+/**
+ * A `"* X"` member matches any name ending in `" X"` (the suffix must follow
+ * a space); any other member string is an exact match. There are no other
+ * wildcard forms.
+ */
+export function memberMatches(banListName: string, member: string): boolean {
+	if (member.startsWith("* ")) {
+		return banListName.endsWith(` ${member.slice(2)}`);
+	}
+
+	return banListName === member;
+}
+
+export function parseBanListDatePrefix(name: string): BanListDatePrefix | null {
+	const match = DATE_PREFIX_PATTERN.exec(name);
+	if (!match) {
+		return null;
+	}
+
+	return {
+		year: Number(match[1]),
+		month: Number(match[2]),
+		day: match[3] === undefined ? 1 : Number(match[3]),
+	};
+}
+
+// Collapses a date into one comparable integer (YYYYMMDD).
+function dateKey(date: BanListDatePrefix): number {
+	return date.year * 10000 + date.month * 100 + date.day;
+}
+
+// Calendar days compare in UTC so currency flips at a deterministic instant
+// regardless of the host timezone.
+function todayKey(today: Date): number {
+	return today.getUTCFullYear() * 10000 + (today.getUTCMonth() + 1) * 100 + today.getUTCDate();
+}
+
+function matchesGroup(name: string, group: RankGroupDefinition): boolean {
+	return group.members.some((member) => memberMatches(name, member));
+}
+
+/**
+ * Group names the given (already alias-resolved) banlist name feeds.
+ *
+ * A group resolves when a member matches the name and, for onlyCurrent
+ * groups, the name is CURRENT: among the loaded banlist names matching the
+ * group with a date not after `today`, it carries the max date. A dateless
+ * matching name is always current; a future-dated one never is.
+ */
+export function resolveGroupsFor(
+	banListName: string,
+	groups: RankGroupDefinition[],
+	loadedBanListNames: string[],
+	today: Date,
+): string[] {
+	if (!banListName || NON_GROUPABLE_NAMES.has(banListName)) {
+		return [];
+	}
+
+	const referenceKey = todayKey(today);
+	const playedDate = parseBanListDatePrefix(banListName);
+	const playedKey = playedDate === null ? null : dateKey(playedDate);
+
+	return groups
+		.filter((group) => group.enabled)
+		.filter((group) => matchesGroup(banListName, group))
+		.filter(
+			(group) =>
+				!group.onlyCurrent || isCurrent(playedKey, group, loadedBanListNames, referenceKey),
+		)
+		.map((group) => group.name);
+}
+
+function isCurrent(
+	playedKey: number | null,
+	group: RankGroupDefinition,
+	loadedBanListNames: string[],
+	referenceKey: number,
+): boolean {
+	if (playedKey === null) {
+		return true;
+	}
+	if (playedKey > referenceKey) {
+		return false;
+	}
+
+	const maxLoadedKey = maxCurrentDatedKey(group, loadedBanListNames, referenceKey);
+
+	return maxLoadedKey === null || playedKey >= maxLoadedKey;
+}
+
+// Max YYYYMMDD key not after the reference day among the loaded names
+// matching the group, or null when no such dated match is loaded.
+function maxCurrentDatedKey(
+	group: RankGroupDefinition,
+	loadedBanListNames: string[],
+	referenceKey: number,
+): number | null {
+	const keys = loadedBanListNames
+		.filter((name) => matchesGroup(name, group))
+		.map(parseBanListDatePrefix)
+		.filter((date): date is BanListDatePrefix => date !== null)
+		.map(dateKey)
+		.filter((key) => key <= referenceKey);
+
+	return keys.length === 0 ? null : Math.max(...keys);
+}
+
+/**
+ * Splits the loaded (already alias-resolved) banlist names into the ones
+ * matching the group's members and the subset feeding it right now: every
+ * dateless match plus the max-dated match not after `today`. Future-dated
+ * matches are matched but never current. Currency mirrors `resolveGroupsFor`,
+ * so a tie on the max date keeps every tied list current.
+ */
+export function currentListsFor(
+	group: RankGroupDefinition,
+	loadedNames: string[],
+	today: Date,
+): { matched: string[]; current: string[] } {
+	const matched = loadedNames.filter((name) => matchesGroup(name, group));
+	const referenceKey = todayKey(today);
+	const maxKey = maxCurrentDatedKey(group, matched, referenceKey);
+	const current = matched.filter((name) => {
+		if (NON_GROUPABLE_NAMES.has(name)) {
+			return false;
+		}
+
+		const date = parseBanListDatePrefix(name);
+
+		return date === null ? true : dateKey(date) === maxKey;
+	});
+
+	return { matched, current };
+}

--- a/src/shared/rank/domain/RankRepository.ts
+++ b/src/shared/rank/domain/RankRepository.ts
@@ -1,4 +1,4 @@
-import { Rank } from "./Rank";
+import { Rank, RankType } from "./Rank";
 
 export interface RankRepository {
 	/**
@@ -10,5 +10,5 @@ export interface RankRepository {
 	 * literal name "Global", which is `type: "global"`. An explicit `type`
 	 * argument overrides that default.
 	 */
-	findOrCreateByName(name: string, type?: "banlist" | "global"): Promise<Rank>;
+	findOrCreateByName(name: string, type?: RankType): Promise<Rank>;
 }

--- a/src/shared/rank/infrastructure/InMemoryLoadedBanListNamesProvider.test.ts
+++ b/src/shared/rank/infrastructure/InMemoryLoadedBanListNamesProvider.test.ts
@@ -1,0 +1,55 @@
+import edoproBanListMemoryRepository from "src/edopro/ban-list/infrastructure/BanListMemoryRepository";
+import { EdoproBanList } from "src/edopro/ban-list/domain/BanList";
+import ygoproBanListMemoryRepository from "src/ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository";
+import { YGOProBanList } from "src/ygopro/ban-list/domain/YGOProBanList";
+
+import { InMemoryLoadedBanListNamesProvider } from "./InMemoryLoadedBanListNamesProvider";
+
+function edoproList(name: string): EdoproBanList {
+	const banList = new EdoproBanList();
+	banList.setName(name);
+
+	return banList;
+}
+
+function ygoproList(name?: string): YGOProBanList {
+	const banList = new YGOProBanList();
+	if (name !== undefined) {
+		banList.setName(name);
+	}
+
+	return banList;
+}
+
+describe("InMemoryLoadedBanListNamesProvider", () => {
+	const provider = new InMemoryLoadedBanListNamesProvider();
+
+	afterEach(() => {
+		edoproBanListMemoryRepository.replaceAll([]);
+		ygoproBanListMemoryRepository.replaceAll([]);
+	});
+
+	it("combines the names loaded in both servers' repositories", () => {
+		edoproBanListMemoryRepository.replaceAll([edoproList("2026.05 TCG")]);
+		ygoproBanListMemoryRepository.replaceAll([ygoproList("2026.05 OCG")]);
+
+		expect(provider.names().sort()).toEqual(["2026.05 OCG", "2026.05 TCG"]);
+	});
+
+	it("dedupes a name loaded on both sides and skips nameless lists", () => {
+		edoproBanListMemoryRepository.replaceAll([edoproList("2026.05 TCG")]);
+		ygoproBanListMemoryRepository.replaceAll([ygoproList("2026.05 TCG"), ygoproList()]);
+
+		expect(provider.names()).toEqual(["2026.05 TCG"]);
+	});
+
+	it("reflects a hot reload on the next call", () => {
+		edoproBanListMemoryRepository.replaceAll([edoproList("2026.05 TCG")]);
+		ygoproBanListMemoryRepository.replaceAll([]);
+
+		expect(provider.names()).toEqual(["2026.05 TCG"]);
+
+		edoproBanListMemoryRepository.replaceAll([edoproList("2026.07 TCG")]);
+		expect(provider.names()).toEqual(["2026.07 TCG"]);
+	});
+});

--- a/src/shared/rank/infrastructure/InMemoryLoadedBanListNamesProvider.ts
+++ b/src/shared/rank/infrastructure/InMemoryLoadedBanListNamesProvider.ts
@@ -1,0 +1,20 @@
+import edoproBanListMemoryRepository from "src/edopro/ban-list/infrastructure/BanListMemoryRepository";
+import ygoproBanListMemoryRepository from "src/ygopro/ban-list/infrastructure/YGOProBanListMemoryRepository";
+
+import { LoadedBanListNamesProvider } from "../domain/LoadedBanListNamesProvider";
+
+/**
+ * Loaded banlist names across both servers' in-memory repositories, deduped.
+ * Reads live on every call so banlist hot reloads are reflected immediately.
+ */
+export class InMemoryLoadedBanListNamesProvider implements LoadedBanListNamesProvider {
+	names(): string[] {
+		const edoproNames = edoproBanListMemoryRepository.getOnlyWithName();
+		const ygoproNames = ygoproBanListMemoryRepository
+			.get()
+			.map((banList) => banList.name)
+			.filter((name): name is string => name !== null);
+
+		return [...new Set([...edoproNames, ...ygoproNames])];
+	}
+}

--- a/src/shared/rank/infrastructure/RankGroupPostgresRepository.test.ts
+++ b/src/shared/rank/infrastructure/RankGroupPostgresRepository.test.ts
@@ -1,0 +1,128 @@
+import { dataSource } from "../../../evolution-types/src/data-source";
+import { RankGroupPostgresRepository } from "./RankGroupPostgresRepository";
+
+// Mocks TypeORM's `dataSource` (same pattern as RankPostgresRepository.test.ts):
+// proves the exact SQL/parameter contract issued to Postgres.
+jest.mock("../../../evolution-types/src/data-source", () => ({
+	dataSource: {
+		query: jest.fn(),
+	},
+}));
+
+describe("RankGroupPostgresRepository", () => {
+	let repository: RankGroupPostgresRepository;
+	let query: jest.Mock;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		query = dataSource.query as jest.Mock;
+		repository = new RankGroupPostgresRepository();
+	});
+
+	describe("upsertGroup", () => {
+		it("inserts a missing group with type 'group' and only_current, then re-selects it", async () => {
+			query
+				.mockResolvedValueOnce([]) // select by name: missing
+				.mockResolvedValueOnce([]) // insert
+				.mockResolvedValueOnce([{ id: "rank-1", type: "group" }]); // re-select
+
+			const result = await repository.upsertGroup({
+				name: "TCG",
+				enabled: true,
+				onlyCurrent: true,
+			});
+
+			expect(result).toEqual({ id: "rank-1" });
+			expect(query).toHaveBeenNthCalledWith(2, expect.stringContaining("'group'"), [
+				"TCG",
+				true,
+				true,
+			]);
+			expect(query.mock.calls[1][0]).toContain("ON CONFLICT (name) DO NOTHING");
+			expect(query.mock.calls[1][0]).toContain("only_current");
+		});
+
+		it("updates enabled and only_current on an existing group rank", async () => {
+			query
+				.mockResolvedValueOnce([{ id: "rank-1", type: "group" }]) // select by name
+				.mockResolvedValueOnce([[], 1]); // update
+
+			const result = await repository.upsertGroup({
+				name: "TCG",
+				enabled: false,
+				onlyCurrent: false,
+			});
+
+			expect(result).toEqual({ id: "rank-1" });
+			expect(query).toHaveBeenNthCalledWith(2, expect.stringContaining("UPDATE ranks"), [
+				"rank-1",
+				false,
+				false,
+			]);
+			expect(query.mock.calls[1][0]).toContain("type = 'group'");
+		});
+
+		it("returns null and issues no write when the name belongs to a non-group rank", async () => {
+			query.mockResolvedValueOnce([{ id: "rank-1", type: "banlist" }]);
+
+			const result = await repository.upsertGroup({
+				name: "TCG",
+				enabled: true,
+				onlyCurrent: true,
+			});
+
+			expect(result).toBeNull();
+			expect(query).toHaveBeenCalledTimes(1);
+		});
+
+		it("returns null when a concurrent writer claimed the name with another type", async () => {
+			query
+				.mockResolvedValueOnce([]) // select: missing
+				.mockResolvedValueOnce([]) // insert conflicts silently
+				.mockResolvedValueOnce([{ id: "rank-9", type: "banlist" }]); // re-select
+
+			const result = await repository.upsertGroup({
+				name: "TCG",
+				enabled: true,
+				onlyCurrent: true,
+			});
+
+			expect(result).toBeNull();
+		});
+	});
+
+	describe("replaceMembers", () => {
+		it("deletes existing members and inserts each pattern", async () => {
+			query.mockResolvedValue([]);
+
+			await repository.replaceMembers("rank-1", ["* TCG", "RD"]);
+
+			expect(query).toHaveBeenNthCalledWith(
+				1,
+				expect.stringContaining("DELETE FROM rank_members"),
+				["rank-1"],
+			);
+			expect(query).toHaveBeenNthCalledWith(
+				2,
+				expect.stringContaining("INSERT INTO rank_members"),
+				["rank-1", "* TCG"],
+			);
+			expect(query).toHaveBeenNthCalledWith(
+				3,
+				expect.stringContaining("INSERT INTO rank_members"),
+				["rank-1", "RD"],
+			);
+		});
+	});
+
+	describe("findGroupNames", () => {
+		it("selects the names of every type 'group' rank", async () => {
+			query.mockResolvedValueOnce([{ name: "TCG" }, { name: "Rush" }]);
+
+			const names = await repository.findGroupNames();
+
+			expect(names).toEqual(["TCG", "Rush"]);
+			expect(query.mock.calls[0][0]).toContain("type = 'group'");
+		});
+	});
+});

--- a/src/shared/rank/infrastructure/RankGroupPostgresRepository.ts
+++ b/src/shared/rank/infrastructure/RankGroupPostgresRepository.ts
@@ -1,0 +1,88 @@
+import { dataSource } from "../../../evolution-types/src/data-source";
+import { RankType } from "../domain/Rank";
+import { RankGroupRepository, RankGroupUpsert } from "../domain/RankGroupRepository";
+
+const SELECT_RANK_BY_NAME_QUERY = `
+	SELECT id, type
+	FROM ranks
+	WHERE name = $1
+`;
+
+// Same concurrency-safe idiom as RankPostgresRepository: DO NOTHING plus a
+// re-SELECT, so a racing creator of the same name never breaks the seeder.
+const INSERT_GROUP_QUERY = `
+	INSERT INTO ranks (name, type, enabled, only_current)
+	VALUES ($1, 'group', $2, $3)
+	ON CONFLICT (name) DO NOTHING
+`;
+
+const UPDATE_GROUP_QUERY = `
+	UPDATE ranks
+	SET enabled = $2, only_current = $3
+	WHERE id = $1 AND type = 'group'
+`;
+
+const DELETE_MEMBERS_QUERY = `
+	DELETE FROM rank_members
+	WHERE rank_id = $1
+`;
+
+const INSERT_MEMBER_QUERY = `
+	INSERT INTO rank_members (rank_id, pattern)
+	VALUES ($1, $2)
+	ON CONFLICT DO NOTHING
+`;
+
+const SELECT_GROUP_NAMES_QUERY = `
+	SELECT name
+	FROM ranks
+	WHERE type = 'group'
+`;
+
+type RankTypeRow = { id: string; type: RankType };
+
+export class RankGroupPostgresRepository implements RankGroupRepository {
+	async upsertGroup(group: RankGroupUpsert): Promise<{ id: string } | null> {
+		const existing = await this.findByName(group.name);
+		if (existing && existing.type !== "group") {
+			return null;
+		}
+
+		if (existing) {
+			await dataSource.query(UPDATE_GROUP_QUERY, [existing.id, group.enabled, group.onlyCurrent]);
+
+			return { id: existing.id };
+		}
+
+		await dataSource.query(INSERT_GROUP_QUERY, [group.name, group.enabled, group.onlyCurrent]);
+		const created = await this.findByName(group.name);
+		if (!created) {
+			throw new Error(`Group rank "${group.name}" could not be created`);
+		}
+		if (created.type !== "group") {
+			// A concurrent writer claimed the name with another type first.
+			return null;
+		}
+
+		return { id: created.id };
+	}
+
+	async replaceMembers(rankId: string, patterns: string[]): Promise<void> {
+		await dataSource.query(DELETE_MEMBERS_QUERY, [rankId]);
+		for (const pattern of patterns) {
+			await dataSource.query(INSERT_MEMBER_QUERY, [rankId, pattern]);
+		}
+	}
+
+	async findGroupNames(): Promise<string[]> {
+		const rows: { name: string }[] = await dataSource.query(SELECT_GROUP_NAMES_QUERY);
+
+		return rows.map((row) => row.name);
+	}
+
+	private async findByName(name: string): Promise<RankTypeRow | null> {
+		const rows: RankTypeRow[] = await dataSource.query(SELECT_RANK_BY_NAME_QUERY, [name]);
+
+		return rows[0] ?? null;
+	}
+}

--- a/src/shared/rank/infrastructure/RankGroupSeeder.test.ts
+++ b/src/shared/rank/infrastructure/RankGroupSeeder.test.ts
@@ -1,0 +1,124 @@
+import { mock, MockProxy } from "jest-mock-extended";
+import { Logger } from "@shared/logger/domain/Logger";
+
+import { RankGroupsConfig } from "../domain/RankGroupConfig";
+import { RankGroupRepository } from "../domain/RankGroupRepository";
+import { RankGroupSeeder } from "./RankGroupSeeder";
+
+describe("RankGroupSeeder", () => {
+	let repository: MockProxy<RankGroupRepository>;
+	let logger: MockProxy<Logger>;
+	let seeder: RankGroupSeeder;
+
+	const config: RankGroupsConfig = {
+		aliases: {},
+		groups: [
+			{ name: "TCG", enabled: true, onlyCurrent: true, members: ["* TCG"] },
+			{ name: "Rush", enabled: true, onlyCurrent: true, members: ["* Rush Duel", "RD"] },
+		],
+	};
+
+	beforeEach(() => {
+		repository = mock<RankGroupRepository>();
+		logger = mock<Logger>();
+		logger.child.mockReturnValue(logger);
+		repository.findGroupNames.mockResolvedValue([]);
+		repository.upsertGroup.mockImplementation(async (group) => ({ id: `id-${group.name}` }));
+		seeder = new RankGroupSeeder(repository, logger);
+	});
+
+	it("upserts every configured group and replaces its members", async () => {
+		await seeder.seed(config);
+
+		expect(repository.upsertGroup).toHaveBeenCalledWith({
+			name: "TCG",
+			enabled: true,
+			onlyCurrent: true,
+		});
+		expect(repository.upsertGroup).toHaveBeenCalledWith({
+			name: "Rush",
+			enabled: true,
+			onlyCurrent: true,
+		});
+		expect(repository.replaceMembers).toHaveBeenCalledWith("id-TCG", ["* TCG"]);
+		expect(repository.replaceMembers).toHaveBeenCalledWith("id-Rush", ["* Rush Duel", "RD"]);
+	});
+
+	it("warns and skips a group whose name collides with a non-group rank", async () => {
+		repository.upsertGroup.mockImplementation(async (group) =>
+			group.name === "TCG" ? null : { id: `id-${group.name}` },
+		);
+
+		await seeder.seed(config);
+
+		expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('"TCG"'));
+		expect(repository.replaceMembers).not.toHaveBeenCalledWith("id-TCG", expect.anything());
+		expect(repository.replaceMembers).toHaveBeenCalledWith("id-Rush", ["* Rush Duel", "RD"]);
+	});
+
+	it("warns about group ranks absent from the config without deleting them", async () => {
+		repository.findGroupNames.mockResolvedValue(["TCG", "Legacy Ladder"]);
+
+		await seeder.seed(config);
+
+		expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Legacy Ladder"));
+		// Only upserts and member replacement — the seeder owns no delete operation.
+		expect(repository.upsertGroup).toHaveBeenCalledTimes(2);
+	});
+
+	it("logs one boot-style info line per seeded group", async () => {
+		await seeder.seed(config);
+
+		expect(logger.info).toHaveBeenCalledWith(
+			'🏆 Group rank "TCG" · enabled · only-current · members: [* TCG]',
+		);
+		expect(logger.info).toHaveBeenCalledWith(
+			'🏆 Group rank "Rush" · enabled · only-current · members: [* Rush Duel, RD]',
+		);
+	});
+
+	it("marks a disabled group and omits only-current when it is off", async () => {
+		await seeder.seed({
+			aliases: {},
+			groups: [{ name: "Worlds", enabled: false, onlyCurrent: false, members: ["* Worlds"] }],
+		});
+
+		expect(logger.info).toHaveBeenCalledWith(
+			'🏆 Group rank "Worlds" · DISABLED · members: [* Worlds]',
+		);
+	});
+
+	it("logs no group line for a config entry skipped by a type collision", async () => {
+		repository.upsertGroup.mockImplementation(async (group) =>
+			group.name === "TCG" ? null : { id: `id-${group.name}` },
+		);
+
+		await seeder.seed(config);
+
+		expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining('"TCG"'));
+	});
+
+	it("logs the configured aliases in one boot-style line", async () => {
+		await seeder.seed({
+			aliases: { JTP: "JTP (Original)", "2011.09 Tengu Plant": "2011.09 Tengu" },
+			groups: config.groups,
+		});
+
+		expect(logger.info).toHaveBeenCalledWith(
+			"🏷️  Rank aliases: JTP → JTP (Original) · 2011.09 Tengu Plant → 2011.09 Tengu",
+		);
+	});
+
+	it("logs no alias line when the config has no aliases", async () => {
+		await seeder.seed(config);
+
+		expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining("Rank aliases"));
+	});
+
+	it("does nothing but the orphan check for an empty config", async () => {
+		await seeder.seed({ aliases: {}, groups: [] });
+
+		expect(repository.upsertGroup).not.toHaveBeenCalled();
+		expect(repository.replaceMembers).not.toHaveBeenCalled();
+	});
+});

--- a/src/shared/rank/infrastructure/RankGroupSeeder.ts
+++ b/src/shared/rank/infrastructure/RankGroupSeeder.ts
@@ -1,0 +1,61 @@
+import { Logger } from "@shared/logger/domain/Logger";
+
+import { RankGroupDefinition, RankGroupsConfig } from "../domain/RankGroupConfig";
+import { RankGroupRepository } from "../domain/RankGroupRepository";
+
+/**
+ * Boot-time seeder: upserts every configured group rank (type "group") and
+ * replaces its member patterns. Ranks of other types are never touched, and
+ * group ranks absent from the config are left in place with a warning — the
+ * config drives creation and updates, never deletion.
+ */
+export class RankGroupSeeder {
+	constructor(
+		private readonly repository: RankGroupRepository,
+		private readonly logger: Logger,
+	) {
+		this.logger = logger.child({ file: "RankGroupSeeder" });
+	}
+
+	async seed(config: RankGroupsConfig): Promise<void> {
+		const existingNames = await this.repository.findGroupNames();
+		const configuredNames = new Set(config.groups.map((group) => group.name));
+		const orphans = existingNames.filter((name) => !configuredNames.has(name));
+		if (orphans.length > 0) {
+			this.logger.warn(
+				`Group ranks in DB but absent from config (left untouched): ${orphans.join(", ")}`,
+			);
+		}
+
+		for (const group of config.groups) {
+			const upserted = await this.repository.upsertGroup({
+				name: group.name,
+				enabled: group.enabled,
+				onlyCurrent: group.onlyCurrent,
+			});
+			if (upserted === null) {
+				this.logger.warn(
+					`Rank "${group.name}" already exists with a non-group type — group config entry skipped`,
+				);
+				continue;
+			}
+
+			await this.repository.replaceMembers(upserted.id, group.members);
+			this.logger.info(describeGroup(group));
+		}
+
+		const aliases = Object.entries(config.aliases);
+		if (aliases.length > 0) {
+			this.logger.info(
+				`🏷️  Rank aliases: ${aliases.map(([from, to]) => `${from} → ${to}`).join(" · ")}`,
+			);
+		}
+	}
+}
+
+function describeGroup(group: RankGroupDefinition): string {
+	const state = group.enabled ? "enabled" : "DISABLED";
+	const onlyCurrent = group.onlyCurrent ? " · only-current" : "";
+
+	return `🏆 Group rank "${group.name}" · ${state}${onlyCurrent} · members: [${group.members.join(", ")}]`;
+}

--- a/src/shared/rank/infrastructure/RankGroupsConfigLoader.test.ts
+++ b/src/shared/rank/infrastructure/RankGroupsConfigLoader.test.ts
@@ -1,0 +1,114 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { mock, MockProxy } from "jest-mock-extended";
+import { Logger } from "@shared/logger/domain/Logger";
+
+import {
+	getActiveRankGroupsConfig,
+	loadRankGroupsConfig,
+	setActiveRankGroupsConfig,
+} from "./RankGroupsConfigLoader";
+
+describe("loadRankGroupsConfig", () => {
+	let dir: string;
+	let logger: MockProxy<Logger>;
+
+	beforeEach(() => {
+		dir = fs.mkdtempSync(path.join(os.tmpdir(), "rank-groups-"));
+		logger = mock<Logger>();
+	});
+
+	afterEach(() => {
+		fs.rmSync(dir, { recursive: true, force: true });
+	});
+
+	function writeConfig(content: string): string {
+		const file = path.join(dir, "rank-groups.json");
+		fs.writeFileSync(file, content);
+
+		return file;
+	}
+
+	it("parses a valid config file", () => {
+		const file = writeConfig(
+			JSON.stringify({
+				aliases: { JTP: "JTP (Original)" },
+				groups: [{ name: "TCG", enabled: true, onlyCurrent: true, members: ["* TCG"] }],
+			}),
+		);
+
+		expect(loadRankGroupsConfig(file, logger)).toEqual({
+			aliases: { JTP: "JTP (Original)" },
+			groups: [{ name: "TCG", enabled: true, onlyCurrent: true, members: ["* TCG"] }],
+		});
+	});
+
+	it("defaults aliases to an empty map when omitted", () => {
+		const file = writeConfig(JSON.stringify({ groups: [] }));
+
+		expect(loadRankGroupsConfig(file, logger)).toEqual({ aliases: {}, groups: [] });
+	});
+
+	it("returns the empty config and logs info when the file is missing", () => {
+		const config = loadRankGroupsConfig(path.join(dir, "does-not-exist.json"), logger);
+
+		expect(config).toEqual({ aliases: {}, groups: [] });
+		expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("does-not-exist.json"));
+	});
+
+	it("throws loudly on malformed JSON", () => {
+		const file = writeConfig("{ this is not json");
+
+		expect(() => loadRankGroupsConfig(file, logger)).toThrow();
+	});
+
+	it("throws loudly on a structurally invalid config", () => {
+		const file = writeConfig(JSON.stringify({ groups: "nope" }));
+
+		expect(() => loadRankGroupsConfig(file, logger)).toThrow('"groups" must be an array');
+	});
+
+	it("throws loudly on a group missing required fields", () => {
+		const file = writeConfig(JSON.stringify({ groups: [{ name: "TCG" }] }));
+
+		expect(() => loadRankGroupsConfig(file, logger)).toThrow("groups[0].enabled");
+	});
+
+	it("parses the repository seed file, matching the deployed shape", () => {
+		const config = loadRankGroupsConfig("./config/rank-groups.json", logger);
+
+		expect(config.aliases).toEqual({
+			"2011.09 Tengu Plant": "2011.09 Tengu",
+			"JTP (Original)": "JTP",
+		});
+		expect(config.groups.map((group) => group.name)).toEqual([
+			"TCG",
+			"OCG",
+			"Rush",
+			"Speed",
+			"Traditional",
+			"Worlds",
+			"MD",
+			"Edison",
+			"HAT",
+			"JTP All",
+		]);
+	});
+});
+
+describe("active rank groups config holder", () => {
+	it("defaults to the empty config and returns whatever was set", () => {
+		expect(getActiveRankGroupsConfig()).toEqual({ aliases: {}, groups: [] });
+
+		const config = {
+			aliases: {},
+			groups: [{ name: "TCG", enabled: true, onlyCurrent: true, members: ["* TCG"] }],
+		};
+		setActiveRankGroupsConfig(config);
+		expect(getActiveRankGroupsConfig()).toBe(config);
+
+		setActiveRankGroupsConfig({ aliases: {}, groups: [] });
+	});
+});

--- a/src/shared/rank/infrastructure/RankGroupsConfigLoader.ts
+++ b/src/shared/rank/infrastructure/RankGroupsConfigLoader.ts
@@ -1,0 +1,102 @@
+import fs from "node:fs";
+
+import { Logger } from "@shared/logger/domain/Logger";
+
+import {
+	RankGroupAliases,
+	RankGroupDefinition,
+	RankGroupsConfig,
+	emptyRankGroupsConfig,
+} from "../domain/RankGroupConfig";
+
+// Boot-time holder: loaded once at bootstrap, read by the writers through
+// RankGroupResolver. Defaults to the empty config so nothing resolves when
+// bootstrap never loaded a file (e.g. ranking disabled).
+let activeRankGroupsConfig: RankGroupsConfig = emptyRankGroupsConfig();
+
+export function setActiveRankGroupsConfig(config: RankGroupsConfig): void {
+	activeRankGroupsConfig = config;
+}
+
+export function getActiveRankGroupsConfig(): RankGroupsConfig {
+	return activeRankGroupsConfig;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseAliases(value: unknown, path: string): RankGroupAliases {
+	if (value === undefined) {
+		return {};
+	}
+	if (!isRecord(value)) {
+		throw new Error(`Rank groups config ${path}: "aliases" must be an object of strings`);
+	}
+	for (const [alias, canonical] of Object.entries(value)) {
+		if (typeof canonical !== "string" || canonical === "") {
+			throw new Error(
+				`Rank groups config ${path}: alias "${alias}" must map to a non-empty string`,
+			);
+		}
+	}
+
+	return value as RankGroupAliases;
+}
+
+function parseGroup(value: unknown, index: number, path: string): RankGroupDefinition {
+	if (!isRecord(value)) {
+		throw new Error(`Rank groups config ${path}: groups[${index}] must be an object`);
+	}
+	const { name, enabled, onlyCurrent, members } = value;
+	if (typeof name !== "string" || name === "") {
+		throw new Error(`Rank groups config ${path}: groups[${index}].name must be a non-empty string`);
+	}
+	if (typeof enabled !== "boolean") {
+		throw new Error(`Rank groups config ${path}: groups[${index}].enabled must be a boolean`);
+	}
+	if (typeof onlyCurrent !== "boolean") {
+		throw new Error(`Rank groups config ${path}: groups[${index}].onlyCurrent must be a boolean`);
+	}
+	if (!Array.isArray(members) || members.some((member) => typeof member !== "string")) {
+		throw new Error(
+			`Rank groups config ${path}: groups[${index}].members must be an array of strings`,
+		);
+	}
+
+	return { name, enabled, onlyCurrent, members: members as string[] };
+}
+
+/**
+ * Reads the rank-groups config file. A missing file is a supported setup (no
+ * group ranks) and only logs info; anything unreadable, malformed, or
+ * structurally invalid throws so a config bug fails boot loudly instead of
+ * silently seeding nothing.
+ */
+export function loadRankGroupsConfig(path: string, logger: Logger): RankGroupsConfig {
+	let raw: string;
+	try {
+		raw = fs.readFileSync(path, "utf8");
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+			logger.info(`Rank groups config not found at ${path} — no group ranks configured`);
+
+			return emptyRankGroupsConfig();
+		}
+		throw error;
+	}
+
+	const parsed: unknown = JSON.parse(raw);
+	if (!isRecord(parsed)) {
+		throw new Error(`Rank groups config ${path}: root must be an object`);
+	}
+	const groupsValue = parsed.groups ?? [];
+	if (!Array.isArray(groupsValue)) {
+		throw new Error(`Rank groups config ${path}: "groups" must be an array`);
+	}
+
+	return {
+		aliases: parseAliases(parsed.aliases, path),
+		groups: groupsValue.map((group, index) => parseGroup(group, index, path)),
+	};
+}

--- a/src/shared/rank/infrastructure/RankPostgresRepository.ts
+++ b/src/shared/rank/infrastructure/RankPostgresRepository.ts
@@ -22,7 +22,7 @@ const SELECT_RANK_QUERY = `
 type RankRow = { id: string; name: string; type: RankType; enabled: boolean };
 
 export class RankPostgresRepository implements RankRepository {
-	async findOrCreateByName(name: string, type?: "banlist" | "global"): Promise<Rank> {
+	async findOrCreateByName(name: string, type?: RankType): Promise<Rank> {
 		const effectiveType: RankType = type ?? (name === GLOBAL_RANK_NAME ? "global" : "banlist");
 
 		await dataSource.query(INSERT_RANK_QUERY, [name, effectiveType, true]);

--- a/src/shared/stats/rating/application/RatingAnnouncer.test.ts
+++ b/src/shared/stats/rating/application/RatingAnnouncer.test.ts
@@ -1,5 +1,6 @@
 import { mock } from "jest-mock-extended";
 
+import { RankGroupResolver } from "@shared/rank/application/RankGroupResolver";
 import { Rank } from "@shared/rank/domain/Rank";
 import { RankRepository } from "@shared/rank/domain/RankRepository";
 import { Team } from "@shared/room/Team";
@@ -30,6 +31,7 @@ function makeContext(overrides?: Partial<MatchContext>): MatchContext {
 describe("RatingAnnouncer", () => {
 	let repository: ReturnType<typeof mock<RatingRepository>>;
 	let rankRepository: ReturnType<typeof mock<RankRepository>>;
+	let rankGroupResolver: ReturnType<typeof mock<RankGroupResolver>>;
 	let rank: Rank;
 	let logger: LoggerMock;
 	let announcer: RatingAnnouncer;
@@ -37,10 +39,12 @@ describe("RatingAnnouncer", () => {
 	beforeEach(() => {
 		repository = mock<RatingRepository>();
 		rankRepository = mock<RankRepository>();
+		rankGroupResolver = mock<RankGroupResolver>();
+		rankGroupResolver.resolveAlias.mockImplementation((name) => name);
 		rank = RankMother.create({ name: "TCG" });
 		rankRepository.findOrCreateByName.mockResolvedValue(rank);
 		logger = new LoggerMock();
-		announcer = new RatingAnnouncer(repository, rankRepository, logger);
+		announcer = new RatingAnnouncer(repository, rankRepository, rankGroupResolver, logger);
 	});
 
 	describe("onMatchStarted", () => {
@@ -292,6 +296,22 @@ describe("RatingAnnouncer", () => {
 
 		it("never throws, isolating the runner's per-hook try/catch from any internal failure", async () => {
 			await expect(announcer.onRoomClosed({ roomId: 1, matchId: "x" })).resolves.not.toThrow();
+		});
+	});
+
+	describe("alias resolution", () => {
+		it("looks the rank up by the alias-resolved banlist name, keeping announcements otherwise unchanged", async () => {
+			rankGroupResolver.resolveAlias.mockImplementation((name) =>
+				name === "JTP" ? "JTP (Original)" : name,
+			);
+			repository.findMany.mockResolvedValue(new Map());
+			const ctx = makeContext({ banListName: "JTP" });
+
+			await announcer.onMatchStarted(ctx);
+
+			expect(rankGroupResolver.resolveAlias).toHaveBeenCalledWith("JTP");
+			expect(rankRepository.findOrCreateByName).toHaveBeenCalledWith("JTP (Original)");
+			expect(ctx.announce).toHaveBeenCalledWith("[Rating v1 start] Diango 1000 | Rival 1000");
 		});
 	});
 });

--- a/src/shared/stats/rating/application/RatingAnnouncer.ts
+++ b/src/shared/stats/rating/application/RatingAnnouncer.ts
@@ -1,4 +1,5 @@
 import { Logger } from "@shared/logger/domain/Logger";
+import { RankGroupResolver } from "@shared/rank/application/RankGroupResolver";
 import { RankRepository } from "@shared/rank/domain/RankRepository";
 import { Team } from "@shared/room/Team";
 import {
@@ -48,6 +49,7 @@ export class RatingAnnouncer implements MatchLifecycleHook {
 	constructor(
 		private readonly ratingRepository: RatingRepository,
 		private readonly rankRepository: RankRepository,
+		private readonly rankGroupResolver: RankGroupResolver,
 		private readonly logger: Logger,
 	) {}
 
@@ -70,12 +72,16 @@ export class RatingAnnouncer implements MatchLifecycleHook {
 			return;
 		}
 
-		// Eligibility stays keyed on the banlist name; the rank is resolved
-		// exactly once per match, here at start, and carried in the snapshot.
+		// Eligibility stays keyed on the raw banlist name; the rank is
+		// resolved exactly once per match — by its alias-resolved canonical
+		// name — here at start, and carried in the snapshot. Announcements
+		// stay on the banlist pool only: group ladders are silent.
 		let rankId: string;
 		let ratings: Map<string, Rating>;
 		try {
-			const rank = await this.rankRepository.findOrCreateByName(eligibility.banListName);
+			const rank = await this.rankRepository.findOrCreateByName(
+				this.rankGroupResolver.resolveAlias(eligibility.banListName),
+			);
 			rankId = rank.id;
 			ratings = await this.ratingRepository.findMany(
 				eligibility.players.map((player) => player.id),


### PR DESCRIPTION
## Summary

Persistent per-format ladders that survive ban list rotation within a season, on top of the rank_id schema (#355):

- **Seed config** `config/rank-groups.json` (`RANK_GROUPS_PATH` override): 10 groups — TCG, OCG, Rush, Speed, Traditional, Worlds, MD (rotating, only-current) and Edison, HAT, JTP All (frozen, always accumulate) — plus aliases that canonicalize renamed headers before any rank lookup.
- **Pure domain resolver**: `* X` suffix / exact member patterns; currency = newest loaded, group-matching list whose date is ≤ today (dateless members always current; future-dated lists wait their turn). Injected clock and names — no hidden I/O.
- **Boot seeder**: upserts groups + members into `ranks`/`rank_members`; never deletes, warns on orphans, fails boot loudly on malformed config.
- **Writers**: one stats row per matching group next to the ban list and Global rows; the Elo path runs an independent rating pool per group. Chat announcements unchanged (ban list pool only).
- **Boot logs**: per-group seed lines, active aliases, and a currency summary (`🏆 Rank groups → TCG: 2026.05 TCG · …`) resolved against the actually loaded lists.
- **JTP normalization**: evolution-assets `JTP` (1038) and `JTP Adv 2007-03` become canonical on both engines — the assembled stale `jtp-oficial` copy (779) is overridden via manifest rules; `JTP (Original)` plays and history funnel into `JTP`; `JTP All` groups both variants.

## Verification

- `tsc --noEmit` clean · full jest **186 suites / 1784 tests** green · biome clean.
- Resolver and summary formatter share one currency implementation, consistency pinned by tests.