### PR TITLE
feat(rank): single-list formats and a maintained no-ban-list ladder

### DIFF
--- a/config/rank-groups.json
+++ b/config/rank-groups.json
@@ -14,7 +14,7 @@
 			"name": "OCG",
 			"enabled": true,
 			"onlyCurrent": true,
-			"members": ["* OCG"]
+			"members": ["* OCG", "2024.07"]
 		},
 		{
 			"name": "Rush",
@@ -38,7 +38,7 @@
 			"name": "Worlds",
 			"enabled": true,
 			"onlyCurrent": true,
-			"members": ["* Worlds"]
+			"members": ["* Worlds", "* World"]
 		},
 		{
 			"name": "MD",
@@ -62,7 +62,49 @@
 			"name": "JTP All",
 			"enabled": true,
 			"onlyCurrent": false,
-			"members": ["JTP", "JTP Adv 2007-03"]
+			"members": ["JTP", "JTP Adv 2007-03", "JTP (AllCards)"]
+		},
+		{
+			"name": "GOAT",
+			"enabled": true,
+			"onlyCurrent": false,
+			"members": ["* GOAT"]
+		},
+		{
+			"name": "Tengu",
+			"enabled": true,
+			"onlyCurrent": false,
+			"members": ["* Tengu"]
+		},
+		{
+			"name": "Duel Terminal",
+			"enabled": true,
+			"onlyCurrent": false,
+			"members": ["* Duel Terminal"]
+		},
+		{
+			"name": "Eterno",
+			"enabled": true,
+			"onlyCurrent": false,
+			"members": ["* Eterno"]
+		},
+		{
+			"name": "DAD Return",
+			"enabled": true,
+			"onlyCurrent": false,
+			"members": ["* DAD Return"]
+		},
+		{
+			"name": "Rush Prereleases",
+			"enabled": true,
+			"onlyCurrent": true,
+			"members": ["* Rush Prereleases"]
+		},
+		{
+			"name": "Evolution",
+			"enabled": true,
+			"onlyCurrent": false,
+			"members": ["Evolution S5", "Evolution S6"]
 		}
 	]
 }

--- a/src/plugins/basic-stats/application/BasicStatsCalculator.test.ts
+++ b/src/plugins/basic-stats/application/BasicStatsCalculator.test.ts
@@ -99,7 +99,8 @@ describe("BasicStatsCalculator", () => {
 
 		playerStatsRepository.findByUserIdAndRankId
 			.mockResolvedValueOnce(playerStats)
-			.mockResolvedValueOnce(opponentStats);
+			.mockResolvedValueOnce(opponentStats)
+			.mockImplementation(async () => PlayerStatsMother.create());
 
 		matchResumeCreator.run.mockResolvedValue({ id: matchId });
 	});
@@ -136,23 +137,40 @@ describe("BasicStatsCalculator", () => {
 			banListName: "N/A",
 		});
 
+		playerStatsRepository.findByUserIdAndRankId
+			.mockReset()
+			.mockResolvedValueOnce(playerStats) // "N/A" row for player
+			.mockResolvedValueOnce(playerStats) // Global row for player
+			.mockResolvedValueOnce(opponentStats) // "N/A" row for opponent
+			.mockResolvedValueOnce(opponentStats); // Global row for opponent
+
 		await basicStatsCalculator.handle(event);
 
-		expect(playerStatsRepository.findByUserIdAndRankId).toHaveBeenCalledTimes(2);
-		expect(playerStatsRepository.save).toHaveBeenCalledTimes(2);
+		expect(playerStatsRepository.findByUserIdAndRankId).toHaveBeenCalledTimes(4);
+		expect(playerStatsRepository.save).toHaveBeenCalledTimes(4);
 
 		expect(playerStatsRepository.findByUserIdAndRankId).toHaveBeenNthCalledWith(
 			1,
 			playerUserProfile.id,
-			globalRank.id,
+			formatRank.id,
 		);
 		expect(playerStatsRepository.findByUserIdAndRankId).toHaveBeenNthCalledWith(
 			2,
+			playerUserProfile.id,
+			globalRank.id,
+		);
+		expect(playerStatsRepository.findByUserIdAndRankId).toHaveBeenNthCalledWith(
+			3,
+			opponentUserProfile.id,
+			formatRank.id,
+		);
+		expect(playerStatsRepository.findByUserIdAndRankId).toHaveBeenNthCalledWith(
+			4,
 			opponentUserProfile.id,
 			globalRank.id,
 		);
 		expect(playerStatsRepository.save).toHaveBeenNthCalledWith(1, PlayerStats.from(playerStats));
-		expect(playerStatsRepository.save).toHaveBeenNthCalledWith(2, PlayerStats.from(opponentStats));
+		expect(playerStatsRepository.save).toHaveBeenNthCalledWith(3, PlayerStats.from(opponentStats));
 	});
 
 	it("uses the event's matchId as the persisted gameId instead of inventing one", async () => {
@@ -243,7 +261,15 @@ describe("BasicStatsCalculator", () => {
 		);
 	});
 
-	it("Should NOT write per-format row when banListName is N/A", async () => {
+	it('writes the "N/A" ladder row plus Global, and no group rows, when the match has no ban list', async () => {
+		const naRank = RankMother.create({ name: "N/A" });
+		rankRepository.findOrCreateByName.mockImplementation(async (name) =>
+			name === "Global" ? globalRank : naRank,
+		);
+		rankGroupResolver.groupsFor.mockReturnValue(["TCG"]);
+		playerStatsRepository.findByUserIdAndRankId
+			.mockReset()
+			.mockImplementation(async () => PlayerStatsMother.create());
 		const players = [player, opponent];
 		const event = GameOverDomainEventMother.create({
 			players: players.map((p) => p.toPresentation()),
@@ -253,11 +279,19 @@ describe("BasicStatsCalculator", () => {
 
 		await basicStatsCalculator.handle(event);
 
-		// Only Global-rank calls — no rank resolution and no row for "N/A"
-		expect(rankRepository.findOrCreateByName).not.toHaveBeenCalledWith("N/A");
-		const calls = playerStatsRepository.findByUserIdAndRankId.mock.calls;
-		const perFormatCalls = calls.filter(([, rankId]) => rankId !== globalRank.id);
-		expect(perFormatCalls).toHaveLength(0);
+		// "N/A" keeps its own ladder so it stays in sync with Global, but it is
+		// never alias-resolved and never feeds a format group.
+		expect(rankRepository.findOrCreateByName).toHaveBeenCalledWith("N/A");
+		expect(rankRepository.findOrCreateByName).toHaveBeenCalledWith("Global");
+		expect(rankGroupResolver.resolveAlias).not.toHaveBeenCalled();
+		expect(rankGroupResolver.groupsFor).not.toHaveBeenCalled();
+		expect(rankRepository.findOrCreateByName).not.toHaveBeenCalledWith("TCG", "group");
+
+		const rankIds = playerStatsRepository.findByUserIdAndRankId.mock.calls.map(
+			([, rankId]) => rankId,
+		);
+		expect(rankIds).toEqual([naRank.id, globalRank.id, naRank.id, globalRank.id]);
+		expect(playerStatsRepository.save).toHaveBeenCalledTimes(4);
 	});
 
 	it("writes one row for the banlist rank and one for the Global rank per player", async () => {
@@ -329,6 +363,41 @@ describe("BasicStatsCalculator", () => {
 		);
 		// 3 ranks (banlist, Global, group) × 2 players.
 		expect(playerStatsRepository.save).toHaveBeenCalledTimes(6);
+	});
+
+	it("writes the alias-resolved banlist row, Global and every group row for a ranked ban list", async () => {
+		const groupRank = RankMother.create({ name: "TCG", type: "group" });
+		const aliasedRank = RankMother.create({ name: "JTP (Original)" });
+		rankGroupResolver.resolveAlias.mockImplementation((name) =>
+			name === "JTP" ? "JTP (Original)" : name,
+		);
+		rankGroupResolver.groupsFor.mockReturnValue(["TCG"]);
+		rankRepository.findOrCreateByName.mockImplementation(async (name, type) =>
+			name === "Global" ? globalRank : type === "group" ? groupRank : aliasedRank,
+		);
+		playerStatsRepository.findByUserIdAndRankId
+			.mockReset()
+			.mockImplementation(async () => PlayerStatsMother.create());
+		const event = GameOverDomainEventMother.create({
+			players: [player.toPresentation(), opponent.toPresentation()],
+			ranked: true,
+			banListName: "JTP",
+		});
+
+		await basicStatsCalculator.handle(event);
+
+		expect(rankGroupResolver.groupsFor).toHaveBeenCalledWith("JTP (Original)");
+		const rankIds = playerStatsRepository.findByUserIdAndRankId.mock.calls.map(
+			([, rankId]) => rankId,
+		);
+		expect(rankIds).toEqual([
+			aliasedRank.id,
+			globalRank.id,
+			groupRank.id,
+			aliasedRank.id,
+			globalRank.id,
+			groupRank.id,
+		]);
 	});
 
 	it("resolves the alias before any rank lookup but keeps the raw name in resumes", async () => {

--- a/src/plugins/basic-stats/application/BasicStatsCalculator.ts
+++ b/src/plugins/basic-stats/application/BasicStatsCalculator.ts
@@ -43,20 +43,22 @@ export class BasicStatsCalculator implements DomainEventSubscriber<GameOverDomai
 
 		const gameId = event.data.matchId;
 
+		// "N/A" (a match played with no ban list) owns a ladder of its own so it
+		// stays in sync with Global, but it is not a real ranked list: it is
+		// never alias-resolved and never feeds a format group.
+		const hasBanList = Boolean(banListName);
+		const isRankedBanList = hasBanList && banListName !== "N/A";
 		// The alias resolves before any rank lookup so a renamed header keeps
 		// feeding its canonical rank.
-		const hasRankedBanList = Boolean(banListName) && banListName !== "N/A";
-		const resolvedBanListName = hasRankedBanList
+		const resolvedBanListName = isRankedBanList
 			? this.rankGroupResolver.resolveAlias(banListName)
 			: banListName;
 
-		const banListRank = hasRankedBanList
+		const banListRank = hasBanList
 			? await this.rankRepository.findOrCreateByName(resolvedBanListName)
 			: null;
 		const globalRank = await this.rankRepository.findOrCreateByName("Global");
-		const groupNames = hasRankedBanList
-			? this.rankGroupResolver.groupsFor(resolvedBanListName)
-			: [];
+		const groupNames = isRankedBanList ? this.rankGroupResolver.groupsFor(resolvedBanListName) : [];
 		const groupRanks: Rank[] = [];
 		for (const groupName of groupNames) {
 			groupRanks.push(await this.rankRepository.findOrCreateByName(groupName, "group"));
@@ -82,8 +84,8 @@ export class BasicStatsCalculator implements DomainEventSubscriber<GameOverDomai
 			const points = player.calculateMatchPoints();
 			this.logger.info(`Player ${player.name} and id: ${userProfile.id} gain ${points} points`);
 			// One row per rank with the same wins/losses/points math: the
-			// banlist rank (when played on a real list), Global, and every
-			// group ladder the played list feeds.
+			// banlist rank (including "N/A"), Global, and every group ladder
+			// the played list feeds.
 			const statsRanks = [...(banListRank ? [banListRank] : []), globalRank, ...groupRanks];
 			for (const rank of statsRanks) {
 				const playerStats = await this.playerStatsRepository.findByUserIdAndRankId(

--- a/src/shared/rank/domain/RankRepository.ts
+++ b/src/shared/rank/domain/RankRepository.ts
@@ -7,8 +7,10 @@ export interface RankRepository {
 	 * both end up with the same persisted rank row.
 	 *
 	 * A rank created on the fly is `type: "banlist"` and enabled, except the
-	 * literal name "Global", which is `type: "global"`. An explicit `type`
-	 * argument overrides that default.
+	 * literal name "Global", which is `type: "global"`, and the literal name
+	 * "N/A", which is created disabled because it is not a ladder players can
+	 * browse. An explicit `type` argument overrides the type default. An
+	 * already-existing row keeps its stored flags.
 	 */
 	findOrCreateByName(name: string, type?: RankType): Promise<Rank>;
 }

--- a/src/shared/rank/infrastructure/RankGroupsConfigLoader.test.ts
+++ b/src/shared/rank/infrastructure/RankGroupsConfigLoader.test.ts
@@ -94,6 +94,13 @@ describe("loadRankGroupsConfig", () => {
 			"Edison",
 			"HAT",
 			"JTP All",
+			"GOAT",
+			"Tengu",
+			"Duel Terminal",
+			"Eterno",
+			"DAD Return",
+			"Rush Prereleases",
+			"Evolution",
 		]);
 	});
 });

--- a/src/shared/rank/infrastructure/RankPostgresRepository.test.ts
+++ b/src/shared/rank/infrastructure/RankPostgresRepository.test.ts
@@ -64,6 +64,37 @@ describe("RankPostgresRepository", () => {
 		expect(rank.type).toBe("global");
 	});
 
+	it('creates the literal "N/A" name disabled — it is not a real ladder for listings', async () => {
+		query
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([{ id: "rank-na", name: "N/A", type: "banlist", enabled: false }]);
+
+		const rank = await repository.findOrCreateByName("N/A");
+
+		expect(query).toHaveBeenNthCalledWith(1, expect.stringContaining("INSERT INTO ranks"), [
+			"N/A",
+			"banlist",
+			false,
+		]);
+		expect(rank.enabled).toBe(false);
+	});
+
+	it('leaves an already-existing "N/A" row untouched instead of flipping its flags', async () => {
+		query
+			.mockResolvedValueOnce([]) // insert was a conflict no-op
+			.mockResolvedValueOnce([{ id: "rank-na", name: "N/A", type: "banlist", enabled: true }]);
+
+		const rank = await repository.findOrCreateByName("N/A");
+
+		expect(query).toHaveBeenCalledTimes(2);
+		expect(query).toHaveBeenNthCalledWith(
+			1,
+			expect.stringContaining("ON CONFLICT (name) DO NOTHING"),
+			["N/A", "banlist", false],
+		);
+		expect(rank).toEqual({ id: "rank-na", name: "N/A", type: "banlist", enabled: true });
+	});
+
 	it("honors an explicitly passed type over the name-based default", async () => {
 		query
 			.mockResolvedValueOnce([])

--- a/src/shared/rank/infrastructure/RankPostgresRepository.ts
+++ b/src/shared/rank/infrastructure/RankPostgresRepository.ts
@@ -3,6 +3,7 @@ import { RankRepository } from "../domain/RankRepository";
 import { dataSource } from "../../../evolution-types/src/data-source";
 
 const GLOBAL_RANK_NAME = "Global";
+const NO_BAN_LIST_RANK_NAME = "N/A";
 
 // INSERT ... ON CONFLICT (name) DO NOTHING followed by a plain SELECT keeps
 // find-or-create safe under concurrency: two racing callers both reach the
@@ -24,8 +25,12 @@ type RankRow = { id: string; name: string; type: RankType; enabled: boolean };
 export class RankPostgresRepository implements RankRepository {
 	async findOrCreateByName(name: string, type?: RankType): Promise<Rank> {
 		const effectiveType: RankType = type ?? (name === GLOBAL_RANK_NAME ? "global" : "banlist");
+		// "N/A" is a bookkeeping ladder, not one players can browse: it is born
+		// disabled so the API hides it. ON CONFLICT DO NOTHING keeps an
+		// already-existing row's flags untouched.
+		const enabled = name !== NO_BAN_LIST_RANK_NAME;
 
-		await dataSource.query(INSERT_RANK_QUERY, [name, effectiveType, true]);
+		await dataSource.query(INSERT_RANK_QUERY, [name, effectiveType, enabled]);
 		const rows: RankRow[] = await dataSource.query(SELECT_RANK_QUERY, [name]);
 
 		const row = rows[0];


### PR DESCRIPTION
Follow-up to #356, from reviewing the real data.

## Single-list formats

GOAT, Tengu, Duel Terminal, Eterno, DAD Return, Rush Prereleases and Evolution surfaced under their dated ban list names (`2005.04 GOAT`), reading as loose lists rather than the formats they are. Each gets a format ladder, so the name reads right today and a future second list joins the same ladder instead of splitting history.

Auditing coverage also closed three gaps:
- **Worlds** now matches `* World`, picking up the three pre-rename lists (2024.07, 2024.09, 2025.01 World).
- **OCG** picks up `2024.07`, the date-only entry from before the OCG suffix was appended.
- **JTP All** picks up `JTP (AllCards)`.

Coverage went from 20 uncovered ban lists to 1: only `Genesys` stays standalone, because a format ladder cannot share the name of an existing ban list rank — and with a single list there is nothing to aggregate anyway.

## No-ban-list ladder

Matches with no ban list (`N/A`) kept counting towards Global while their own row stopped being written, so it froze while Global grew — dev had 393 rows missing and 117 stale. The row is written again, while alias resolution and format groups stay gated on a real ban list, and the rating eligibility gate is untouched. The rank is created disabled, matching what the schema backfill does, so listings keep hiding it.

## Verification

`tsc` clean · full jest **186 suites / 1787 tests** · biome clean.