### PR TITLE
fix(rating): write a history row per ladder

### DIFF
--- a/src/plugins/elo-rating/application/EloRatingCalculator.test.ts
+++ b/src/plugins/elo-rating/application/EloRatingCalculator.test.ts
@@ -329,6 +329,89 @@ describe("EloRatingCalculator", () => {
 			);
 		});
 
+		// rating_history is UNIQUE on (match_id, user_id, kind, rank_id): one
+		// match feeds several ladders and each needs its own row. This fake
+		// enforces that exact key, so a narrower one would collide, report the
+		// row as already recorded, and fail the assertions below.
+		function uniqueHistoryStore(): {
+			tx: RatingTransaction;
+			historyKeys: string[];
+			savedRanks: string[];
+		} {
+			const historyKeys: string[] = [];
+			const savedRanks: string[] = [];
+			const tx: RatingTransaction = {
+				insertHistory: async (entry) => {
+					const key = [entry.matchId, entry.userId, entry.kind, entry.rankId].join("|");
+					if (historyKeys.includes(key)) {
+						return false;
+					}
+					historyKeys.push(key);
+
+					return true;
+				},
+				saveRating: async (_userId, rankId) => {
+					savedRanks.push(rankId);
+				},
+			};
+
+			return { tx, historyKeys, savedRanks };
+		}
+
+		it("writes history and a rating for the ban list rank and for the group rank it feeds", async () => {
+			const groupRank = RankMother.create({ name: "TCG Ladder", type: "group" });
+			rankGroupResolver.groupsFor.mockReturnValue(["TCG Ladder"]);
+			rankRepository.findOrCreateByName.mockImplementation(async (name) =>
+				name === "TCG Ladder" ? groupRank : rank,
+			);
+			resolveAccounts();
+			const store = uniqueHistoryStore();
+			ratingRepository.transaction.mockImplementation(async (_userIds, _rankId, _season, work) =>
+				work(
+					new Map<string, Rating>([
+						["player-1", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+						["player-2", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+					]),
+					store.tx,
+				),
+			);
+
+			await calculator.handle(makeEligibleEvent());
+
+			expect(store.historyKeys).toEqual([
+				`match-1|player-1|applied|${rank.id}`,
+				`match-1|player-2|applied|${rank.id}`,
+				`match-1|player-1|applied|${groupRank.id}`,
+				`match-1|player-2|applied|${groupRank.id}`,
+			]);
+			expect(store.savedRanks).toEqual([rank.id, rank.id, groupRank.id, groupRank.id]);
+		});
+
+		it("still treats a replay of the same match on the same ladders as a no-op", async () => {
+			const groupRank = RankMother.create({ name: "TCG Ladder", type: "group" });
+			rankGroupResolver.groupsFor.mockReturnValue(["TCG Ladder"]);
+			rankRepository.findOrCreateByName.mockImplementation(async (name) =>
+				name === "TCG Ladder" ? groupRank : rank,
+			);
+			resolveAccounts();
+			const store = uniqueHistoryStore();
+			ratingRepository.transaction.mockImplementation(async (_userIds, _rankId, _season, work) =>
+				work(
+					new Map<string, Rating>([
+						["player-1", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+						["player-2", Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 })],
+					]),
+					store.tx,
+				),
+			);
+
+			await calculator.handle(makeEligibleEvent());
+			await calculator.handle(makeEligibleEvent());
+
+			expect(store.historyKeys).toHaveLength(4);
+			expect(store.savedRanks).toHaveLength(4);
+		});
+
 		it("resolves the alias before the rank lookup and resolves groups from the canonical name", async () => {
 			rankGroupResolver.resolveAlias.mockImplementation((name) =>
 				name === "JTP" ? "JTP (Original)" : name,

--- a/src/shared/stats/rating/domain/RatingRepository.ts
+++ b/src/shared/stats/rating/domain/RatingRepository.ts
@@ -19,9 +19,10 @@ export type RatingHistoryEntry = {
 export interface RatingTransaction {
 	/**
 	 * Inserts one rating_history row. Returns false instead of throwing when
-	 * the row already exists for (matchId, userId, kind) — the UNIQUE
+	 * the row already exists for (matchId, userId, kind, rankId) — the UNIQUE
 	 * constraint makes a replayed write a no-op the caller can detect and
-	 * skip projecting.
+	 * skip projecting. It is scoped per rank, so the several ladders one match
+	 * feeds each get their own row.
 	 */
 	insertHistory(entry: RatingHistoryEntry): Promise<boolean>;
 

--- a/src/shared/stats/rating/infrastructure/RatingPostgresRepository.test.ts
+++ b/src/shared/stats/rating/infrastructure/RatingPostgresRepository.test.ts
@@ -6,8 +6,8 @@ import { dataSource } from "../../../../evolution-types/src/data-source";
 // `UserProfilePostgresRepository.test.ts`): the repo has no real-Postgres
 // jest harness. It proves the exact SQL/parameter contract issued to
 // Postgres (ON CONFLICT target, row-lock ordering) but not that Postgres
-// enforces it — the UNIQUE(match_id, user_id, kind) index this adapter
-// targets is created and exercised by the CreateRatingTables migration.
+// enforces it — the UNIQUE(match_id, user_id, kind, rank_id) index this
+// adapter targets is created by the WidenRatingHistoryUniqueIndex migration.
 jest.mock("../../../../evolution-types/src/data-source", () => ({
 	dataSource: {
 		transaction: jest.fn(),
@@ -119,12 +119,12 @@ describe("RatingPostgresRepository", () => {
 
 			expect(inserted).toBe(true);
 			expect(manager.query).toHaveBeenCalledWith(
-				expect.stringContaining("ON CONFLICT (match_id, user_id, kind) DO NOTHING"),
+				expect.stringContaining("ON CONFLICT (match_id, user_id, kind, rank_id) DO NOTHING"),
 				["match-1", "user-a", "rank-1", 5, "applied", 1000, 10, 20, 1000],
 			);
 		});
 
-		it("returns false — a no-op — when the row already exists for (match_id, user_id, kind)", async () => {
+		it("returns false — a no-op — when the row already exists for (match_id, user_id, kind, rank_id)", async () => {
 			manager.query
 				.mockResolvedValueOnce([]) // lock query
 				.mockResolvedValueOnce([]); // conflicting insert returns no rows

--- a/src/shared/stats/rating/infrastructure/RatingPostgresRepository.ts
+++ b/src/shared/stats/rating/infrastructure/RatingPostgresRepository.ts
@@ -35,7 +35,7 @@ const FIND_RATINGS_QUERY = `
 const INSERT_HISTORY_QUERY = `
 	INSERT INTO rating_history (match_id, user_id, rank_id, season, kind, previous_rating, delta, k_factor, opponent_rating)
 	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-	ON CONFLICT (match_id, user_id, kind) DO NOTHING
+	ON CONFLICT (match_id, user_id, kind, rank_id) DO NOTHING
 	RETURNING id
 `;
 


### PR DESCRIPTION
Server side of evolution-types#10.

A ranked match updates the ban list ladder and every format ladder it feeds, but the history insert's conflict target still matched the old `(match_id, user_id, kind)` index. The ban list row landed; every format row came back as a conflict, `insertHistory` returned false, and the caller — which treats false as "already processed" — skipped saving that rating. Dev showed 4 ban-list ratings and **0** format ratings on the first season-7 duels.

The conflict target now includes `rank_id`. A genuine replay of the *same* ladder still returns false and still skips the save, which is the behaviour that check exists for.

## The regression test

The new tests drive a `RatingTransaction` fake that enforces the composite key in memory: one match across a ban list rank and a group rank must produce 4 history rows and 4 `saveRating` calls, and handling the same event twice must add nothing. Dropping `rankId` from the fake's key makes both fail — confirmed before restoring it, so the test genuinely covers the bug rather than passing by construction.

## Verification

`tsc` clean · full jest **186 suites / 1789 tests** · biome clean on touched paths.

**Deploy**: this must ship together with the migration — Postgres errors rather than degrading when `ON CONFLICT` finds no matching index, so neither half works alone. See the deploy note in evolution-types#10.