### PR TITLE
feat(rank): let formats reach the ban lists they retired

### DIFF
--- a/config/rank-groups.json
+++ b/config/rank-groups.json
@@ -62,7 +62,7 @@
 			"name": "JTP All",
 			"enabled": true,
 			"onlyCurrent": false,
-			"members": ["JTP", "JTP Adv 2007-03", "JTP (AllCards)"]
+			"members": ["JTP", "JTP Adv 2007-03", "JTP (AllCards)", "JTP (Original)"]
 		},
 		{
 			"name": "GOAT",
@@ -74,7 +74,7 @@
 			"name": "Tengu",
 			"enabled": true,
 			"onlyCurrent": false,
-			"members": ["* Tengu"]
+			"members": ["* Tengu", "2011.09 Tengu Plant"]
 		},
 		{
 			"name": "Duel Terminal",


### PR DESCRIPTION
Found while fixing match filtering for format ladders (evolution-api).

Merging a duplicated ladder moved its stats onto the canonical rank, but every match row keeps the ban list name it was actually played under. Those names no longer have a rank row, so their matches fell out of reach of every selector:

| Name on the match rows | Duels stranded |
|---|---:|
| `JTP (Original)` | 320 |
| `2011.09 Tengu Plant` | 182 |

Each name joins the format that covers it — `JTP All` and `Tengu` — which is exactly what member patterns are for. `* Tengu` does not catch `2011.09 Tengu Plant` (it ends in "Tengu Plant"), hence the exact member.

**Why not rewrite the match rows instead:** it would claim those duels were played on the canonical list, which is false — `JTP (Original)` carried 779 cards against that list's 1038. They are different formats; only the ladder was retired.

Config only, no code. `tsc` clean, rank + config suites **82/82**.