### PR TITLE
feat(rating): announce the rating players keep

### DIFF
--- a/src/shared/stats/rating/application/RatingAnnouncer.test.ts
+++ b/src/shared/stats/rating/application/RatingAnnouncer.test.ts
@@ -41,6 +41,7 @@ describe("RatingAnnouncer", () => {
 		rankRepository = mock<RankRepository>();
 		rankGroupResolver = mock<RankGroupResolver>();
 		rankGroupResolver.resolveAlias.mockImplementation((name) => name);
+		rankGroupResolver.groupsFor.mockReturnValue([]);
 		rank = RankMother.create({ name: "TCG" });
 		rankRepository.findOrCreateByName.mockResolvedValue(rank);
 		logger = new LoggerMock();
@@ -312,6 +313,121 @@ describe("RatingAnnouncer", () => {
 			expect(rankGroupResolver.resolveAlias).toHaveBeenCalledWith("JTP");
 			expect(rankRepository.findOrCreateByName).toHaveBeenCalledWith("JTP (Original)");
 			expect(ctx.announce).toHaveBeenCalledWith("[Rating v1 start] Diango 1000 | Rival 1000");
+		});
+	});
+
+	describe("announced pool", () => {
+		const groupRank = RankMother.create({ name: "TCG Advanced", type: "group" });
+
+		function useGroups(...names: string[]): void {
+			rankGroupResolver.groupsFor.mockReturnValue(names);
+			rankRepository.findOrCreateByName.mockImplementation(async (name) =>
+				name === "TCG" ? rank : RankMother.create({ name, type: "group", id: groupRank.id }),
+			);
+		}
+
+		it("announces the ratings of the group ladder the played banlist feeds", async () => {
+			useGroups("TCG Advanced");
+			repository.findMany.mockResolvedValue(
+				new Map([
+					["p1", Rating.from({ value: 1400, gamesPlayed: 40, peak: 1400 })],
+					["p2", Rating.from({ value: 1300, gamesPlayed: 40, peak: 1300 })],
+				]),
+			);
+			const ctx = makeContext();
+
+			await announcer.onMatchStarted(ctx);
+
+			expect(rankGroupResolver.groupsFor).toHaveBeenCalledWith("TCG");
+			expect(rankRepository.findOrCreateByName).toHaveBeenCalledTimes(1);
+			expect(rankRepository.findOrCreateByName).toHaveBeenCalledWith("TCG Advanced", "group");
+			expect(repository.findMany).toHaveBeenCalledWith(["p1", "p2"], groupRank.id, 5);
+			expect(ctx.announce).toHaveBeenCalledWith("[Rating v1 start] Diango 1400 | Rival 1300");
+		});
+
+		it("looks the groups up by the alias-resolved banlist name", async () => {
+			rankGroupResolver.resolveAlias.mockImplementation((name) =>
+				name === "JTP" ? "JTP (Original)" : name,
+			);
+			useGroups("JTP");
+			repository.findMany.mockResolvedValue(new Map());
+			const ctx = makeContext({ banListName: "JTP" });
+
+			await announcer.onMatchStarted(ctx);
+
+			expect(rankGroupResolver.groupsFor).toHaveBeenCalledWith("JTP (Original)");
+		});
+
+		it("announces the first group when the list feeds several, keeping the resolver's order", async () => {
+			useGroups("TCG Advanced", "TCG All Time");
+			repository.findMany.mockResolvedValue(new Map());
+			const ctx = makeContext();
+
+			await announcer.onMatchStarted(ctx);
+
+			expect(rankRepository.findOrCreateByName).toHaveBeenCalledTimes(1);
+			expect(rankRepository.findOrCreateByName).toHaveBeenCalledWith("TCG Advanced", "group");
+		});
+
+		it("falls back to the banlist's own pool when the list belongs to no group", async () => {
+			rankGroupResolver.groupsFor.mockReturnValue([]);
+			repository.findMany.mockResolvedValue(
+				new Map([
+					["p1", Rating.from({ value: 1050, gamesPlayed: 12, peak: 1080 })],
+					["p2", Rating.from({ value: 950, gamesPlayed: 12, peak: 980 })],
+				]),
+			);
+			const ctx = makeContext({ banListName: "Genesys" });
+
+			await announcer.onMatchStarted(ctx);
+
+			expect(rankRepository.findOrCreateByName).toHaveBeenCalledWith("Genesys");
+			expect(repository.findMany).toHaveBeenCalledWith(["p1", "p2"], rank.id, 5);
+			expect(ctx.announce).toHaveBeenCalledWith("[Rating v1 start] Diango 1050 | Rival 950");
+		});
+
+		it("ends on the same pool it started on, resolving it once per match", async () => {
+			useGroups("TCG Advanced");
+			repository.findMany.mockResolvedValue(
+				new Map([
+					["p1", Rating.from({ value: 1000, gamesPlayed: 12, peak: 1000 })],
+					["p2", Rating.from({ value: 1000, gamesPlayed: 12, peak: 1000 })],
+				]),
+			);
+			const startCtx = makeContext();
+			await announcer.onMatchStarted(startCtx);
+
+			const endCtx = makeContext({
+				players: [
+					{ id: "p1", team: Team.PLAYER, name: "Diango", winner: true },
+					{ id: "p2", team: Team.OPPONENT, name: "Rival", winner: false },
+				],
+			});
+
+			await announcer.onMatchEnding(endCtx);
+
+			expect(rankGroupResolver.groupsFor).toHaveBeenCalledTimes(1);
+			expect(rankRepository.findOrCreateByName).toHaveBeenCalledTimes(1);
+			expect(repository.findMany).toHaveBeenCalledTimes(1);
+			expect(repository.findMany).toHaveBeenCalledWith(["p1", "p2"], groupRank.id, 5);
+			expect(endCtx.announce).toHaveBeenCalledWith(
+				"[Rating v1 end] Diango 1010 (+10) | Rival 990 (-10)",
+			);
+		});
+
+		it("warns and stays silent when group resolution fails", async () => {
+			const warn = jest.spyOn(logger, "warn");
+			rankGroupResolver.groupsFor.mockImplementation(() => {
+				throw new Error("groups unavailable");
+			});
+			const ctx = makeContext();
+
+			await expect(announcer.onMatchStarted(ctx)).resolves.toBeUndefined();
+
+			expect(warn).toHaveBeenCalled();
+			expect(rankRepository.findOrCreateByName).not.toHaveBeenCalled();
+			expect(repository.findMany).not.toHaveBeenCalled();
+			expect(ctx.announce).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/shared/stats/rating/application/RatingAnnouncer.ts
+++ b/src/shared/stats/rating/application/RatingAnnouncer.ts
@@ -72,16 +72,24 @@ export class RatingAnnouncer implements MatchLifecycleHook {
 			return;
 		}
 
-		// Eligibility stays keyed on the raw banlist name; the rank is
-		// resolved exactly once per match — by its alias-resolved canonical
-		// name — here at start, and carried in the snapshot. Announcements
-		// stay on the banlist pool only: group ladders are silent.
+		// Eligibility stays keyed on the raw banlist name; the announced rank
+		// is resolved exactly once per match — from its alias-resolved
+		// canonical name — here at start, and carried in the snapshot so end
+		// reports the very same pool. Announcements follow the group ladder
+		// the played list feeds, because that is the rating that survives a
+		// list rotation and that players read as theirs; a list feeding no
+		// group falls back to its own banlist pool so those players still see
+		// a rating. Only the first group is announced: the frame has no room
+		// for several numbers, and the resolver's order is deterministic.
 		let rankId: string;
 		let ratings: Map<string, Rating>;
 		try {
-			const rank = await this.rankRepository.findOrCreateByName(
-				this.rankGroupResolver.resolveAlias(eligibility.banListName),
-			);
+			const banListName = this.rankGroupResolver.resolveAlias(eligibility.banListName);
+			const [groupName] = this.rankGroupResolver.groupsFor(banListName);
+			const rank =
+				groupName === undefined
+					? await this.rankRepository.findOrCreateByName(banListName)
+					: await this.rankRepository.findOrCreateByName(groupName, "group");
 			rankId = rank.id;
 			ratings = await this.ratingRepository.findMany(
 				eligibility.players.map((player) => player.id),


### PR DESCRIPTION
The chat announces each seated duelist's Elo at match start and their delta at the end. It announced the **ban list** pool — the one that resets the moment a list rotates.

The **format ladder** is the rating that carries a whole season, is shown as the headline rating on the site, and is what a player calls "my rating". That is the number a duel should show.

- A ban list that feeds a format announces that format's pool.
- A list belonging to no format (Genesys, retro lists, anything ungrouped) **falls back to its own pool**, so those duels never lose the announcement.
- Start and end are structurally the same pool: resolution happens once and the resulting `rankId` travels in the match snapshot, which `onMatchEnding` is the only thing that reads.

Today both pools hold the same number, since exactly one list feeds each format. They diverge at the next rotation — precisely when announcing the wrong one would start to matter.

**Unchanged**: which pools receive Elo. The calculator still writes the ban list ladder *and* every format it feeds; this only picks which of them the chat shows. The eligibility gate and the message grammar (`[Rating v1 start] Name 1020 | Name 980`) are untouched.

## Notes

- When a list feeds several formats, the first in the resolver's order is announced — that order follows the boot config's `groups[]`, so the pick is stable across restarts and costs one lookup instead of N. Announcing several numbers would blow past the chat's width budget.
- The group is looked up with type `"group"`, matching the calculator, so the announcer can never create a format ladder mistyped as a ban list.
- The resolver call sits inside the existing fail-silent try/catch: a throw warns and skips the announcement rather than propagating.
- The suite's `groupsFor` mock returned `undefined`, which would have thrown into that catch; it now defaults to `[]`, which also makes the pre-existing tests read as explicit fallback cases. No existing assertion was changed.

## Verification

`tsc` clean · full jest **186 suites / 1795 tests** (+6) · biome clean.