### PR TITLE
fix(rating): make a lopsided duel cost something, and never go negative

### DIFF
--- a/src/plugins/elo-rating/application/EloRatingCalculator.test.ts
+++ b/src/plugins/elo-rating/application/EloRatingCalculator.test.ts
@@ -5,7 +5,11 @@ import { Rank } from "@shared/rank/domain/Rank";
 import { RankRepository } from "@shared/rank/domain/RankRepository";
 import { Team } from "@shared/room/Team";
 import { Rating } from "@shared/stats/rating/domain/Rating";
-import { RatingRepository, RatingTransaction } from "@shared/stats/rating/domain/RatingRepository";
+import {
+	RatingHistoryEntry,
+	RatingRepository,
+	RatingTransaction,
+} from "@shared/stats/rating/domain/RatingRepository";
 import { UserProfileRepository } from "@shared/user-profile/domain/UserProfileRepository";
 import { GameOverDomainEventMother } from "@test-support/mothers/player/GameOverDomainEventMother";
 import { PlayerMother } from "@test-support/mothers/player/PlayerMother";
@@ -221,6 +225,73 @@ describe("EloRatingCalculator", () => {
 
 			expect(tx.insertHistory).toHaveBeenCalledTimes(2);
 			expect(tx.saveRating).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("rating floor — history stays reconcilable with the stored rating", () => {
+		it("records the delta the floor let through, so previousRating + delta is the saved rating", async () => {
+			const winnerProfile = UserProfileMother.create({ id: "player-1" });
+			const loserProfile = UserProfileMother.create({ id: "player-2" });
+			userProfileRepository.findById.mockImplementation(async (id) =>
+				id === "player-1" ? winnerProfile : loserProfile,
+			);
+			// Both sit 5 points above the floor, so the curve's -10 loss cannot be
+			// paid in full and the floor truncates it to -5.
+			const ratings = new Map<string, Rating>([
+				["player-1", Rating.from({ value: 105, gamesPlayed: 20, peak: 1400 })],
+				["player-2", Rating.from({ value: 105, gamesPlayed: 20, peak: 1400 })],
+			]);
+			ratingRepository.transaction.mockImplementation(async (_userIds, _banList, _season, work) =>
+				work(ratings, tx),
+			);
+
+			await calculator.handle(makeEligibleEvent());
+
+			expect(tx.insertHistory).toHaveBeenCalledWith(
+				expect.objectContaining({ userId: "player-2", previousRating: 105, delta: -5 }),
+			);
+			expect(tx.saveRating).toHaveBeenCalledWith(
+				"player-2",
+				rank.id,
+				config.season,
+				Rating.from({ value: 100, gamesPlayed: 21, peak: 1400 }),
+			);
+
+			const loserEntry = tx.insertHistory.mock.calls
+				.map(([entry]) => entry)
+				.find((entry) => entry.userId === "player-2") as RatingHistoryEntry;
+			const [, , , savedLoserRating] = tx.saveRating.mock.calls.find(
+				([userId]) => userId === "player-2",
+			) as [string, string, number, Rating];
+
+			expect(loserEntry.previousRating + loserEntry.delta).toBe(savedLoserRating.value);
+		});
+
+		it("leaves an unfloored delta exactly as the curve produced it", async () => {
+			const winnerProfile = UserProfileMother.create({ id: "player-1" });
+			const loserProfile = UserProfileMother.create({ id: "player-2" });
+			userProfileRepository.findById.mockImplementation(async (id) =>
+				id === "player-1" ? winnerProfile : loserProfile,
+			);
+			const ratings = new Map<string, Rating>([
+				["player-1", Rating.from({ value: 105, gamesPlayed: 20, peak: 1400 })],
+				["player-2", Rating.from({ value: 105, gamesPlayed: 20, peak: 1400 })],
+			]);
+			ratingRepository.transaction.mockImplementation(async (_userIds, _banList, _season, work) =>
+				work(ratings, tx),
+			);
+
+			await calculator.handle(makeEligibleEvent());
+
+			expect(tx.insertHistory).toHaveBeenCalledWith(
+				expect.objectContaining({ userId: "player-1", previousRating: 105, delta: 10 }),
+			);
+			expect(tx.saveRating).toHaveBeenCalledWith(
+				"player-1",
+				rank.id,
+				config.season,
+				Rating.from({ value: 115, gamesPlayed: 21, peak: 1400 }),
+			);
 		});
 	});
 

--- a/src/plugins/elo-rating/application/EloRatingCalculator.ts
+++ b/src/plugins/elo-rating/application/EloRatingCalculator.ts
@@ -84,6 +84,13 @@ export class EloRatingCalculator implements DomainEventSubscriber<GameOverDomain
 				const deltas = EloCalculator.deltasFor(ratedPlayers, ratings);
 
 				for (const delta of deltas) {
+					const currentRating = ratings.get(delta.userId) as Rating;
+					// History records the delta the rating actually absorbed, not the one
+					// the curve produced: the two differ only when the rating floor
+					// truncates a loss, and a row whose delta does not reconcile with the
+					// stored rating would over-restore when replayed in reverse.
+					const appliedDelta = currentRating.effectiveDelta(delta.delta);
+
 					const inserted = await tx.insertHistory({
 						matchId: data.matchId,
 						userId: delta.userId,
@@ -91,7 +98,7 @@ export class EloRatingCalculator implements DomainEventSubscriber<GameOverDomain
 						season,
 						kind: "applied",
 						previousRating: delta.previousRating,
-						delta: delta.delta,
+						delta: appliedDelta,
 						kFactor: delta.kFactor,
 						opponentRating: delta.opponentRating,
 					});
@@ -103,8 +110,7 @@ export class EloRatingCalculator implements DomainEventSubscriber<GameOverDomain
 						continue;
 					}
 
-					const currentRating = ratings.get(delta.userId) as Rating;
-					const updatedRating = currentRating.applyDelta(delta.delta);
+					const updatedRating = currentRating.applyDelta(appliedDelta);
 					await tx.saveRating(delta.userId, rank.id, season, updatedRating);
 				}
 			});

--- a/src/shared/stats/rating/application/RatingAnnouncer.ts
+++ b/src/shared/stats/rating/application/RatingAnnouncer.ts
@@ -155,7 +155,10 @@ export class RatingAnnouncer implements MatchLifecycleHook {
 
 		const teams = this.groupByTeam(eligibility.players, (player): RatingAnnouncementDeltaEntry => {
 			const delta = deltaByUserId.get(player.id);
-			const magnitude = delta?.delta ?? 0;
+			// Announce the delta the rating floor lets through, so the number shown
+			// is the one that will be stored rather than a below-floor projection.
+			const startRating = startRatings.get(player.id) ?? Rating.initialize();
+			const magnitude = delta === undefined ? 0 : startRating.effectiveDelta(delta.delta);
 
 			return {
 				name: player.name,

--- a/src/shared/stats/rating/domain/EloCalculator.test.ts
+++ b/src/shared/stats/rating/domain/EloCalculator.test.ts
@@ -18,6 +18,29 @@ describe("EloCalculator", () => {
 			expect(lower).toBeLessThan(0.5);
 			expect(higher + lower).toBeCloseTo(1);
 		});
+
+		it("leaves the curve untouched for gaps under the 500-point bound", () => {
+			for (const gap of [0, 100, 400, 499]) {
+				const raw = 1 / (1 + 10 ** (-gap / 400));
+
+				expect(EloCalculator.expectedScore(1000 + gap, 1000)).toBeCloseTo(raw, 10);
+			}
+		});
+
+		it("caps the gap at 500 points, so wider gaps all score as a 500-point gap", () => {
+			const atBound = EloCalculator.expectedScore(1500, 1000);
+
+			expect(EloCalculator.expectedScore(1600, 1000)).toBeCloseTo(atBound, 10);
+			expect(EloCalculator.expectedScore(4000, 1000)).toBeCloseTo(atBound, 10);
+			expect(EloCalculator.expectedScore(1000, 4000)).toBeCloseTo(1 - atBound, 10);
+		});
+
+		it("stays symmetric beyond the bound", () => {
+			const higher = EloCalculator.expectedScore(3000, 1000);
+			const lower = EloCalculator.expectedScore(1000, 3000);
+
+			expect(higher + lower).toBeCloseTo(1, 10);
+		});
 	});
 
 	describe("kFactorFor()", () => {
@@ -96,6 +119,66 @@ describe("EloCalculator", () => {
 			// Opposing team average for o1/o2 is (1000+1000)/2 = 1000; o1 (rated 1100) was
 			// favored to win against that average and lost, so it loses more than 10.
 			expect(o1Delta).toMatchObject({ opponentRating: 1000, delta: -13 });
+		});
+	});
+
+	describe("deltasFor() — bounded gap", () => {
+		// Each pair sits in a single K tier on both sides, so the asserted
+		// minimum is unambiguous: provisional (K=40), established under 2300
+		// (K=20), and established at or above 2300 (K=10), which is the tier
+		// an unbounded gap silences first.
+		const tiers = [
+			{ name: "K=40 (provisional)", favorite: 4000, underdog: 1000, gamesPlayed: 3 },
+			{ name: "K=20 (established)", favorite: 2000, underdog: 1000, gamesPlayed: 20 },
+			{ name: "K=10 (high rated)", favorite: 3300, underdog: 2300, gamesPlayed: 20 },
+		];
+
+		it.each(
+			tiers,
+		)("$name — the favorite still gains and the underdog still pays across a huge gap", ({
+			favorite,
+			underdog,
+			gamesPlayed,
+		}) => {
+			const players = [
+				{ id: "favorite", team: Team.PLAYER, winner: true },
+				{ id: "underdog", team: Team.OPPONENT, winner: false },
+			];
+			const ratings = new Map([
+				["favorite", Rating.from({ value: favorite, gamesPlayed, peak: favorite })],
+				["underdog", Rating.from({ value: underdog, gamesPlayed, peak: underdog })],
+			]);
+
+			const deltas = EloCalculator.deltasFor(players, ratings);
+
+			expect(deltas.find((d) => d.userId === "favorite")?.delta).toBeGreaterThanOrEqual(1);
+			expect(deltas.find((d) => d.userId === "underdog")?.delta).toBeLessThanOrEqual(-1);
+		});
+
+		it("makes a long losing streak settle on the rating floor rather than drifting free", () => {
+			let player = Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 });
+			const opponent = Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 });
+			const players = [
+				{ id: "player", team: Team.PLAYER, winner: false },
+				{ id: "opponent", team: Team.OPPONENT, winner: true },
+			];
+
+			for (let game = 0; game < 800; game++) {
+				const deltas = EloCalculator.deltasFor(
+					players,
+					new Map([
+						["player", player],
+						["opponent", opponent],
+					]),
+				);
+				const playerDelta = deltas.find((d) => d.userId === "player")?.delta as number;
+
+				expect(playerDelta).toBeLessThanOrEqual(-1);
+				player = player.applyDelta(playerDelta);
+				expect(player.value).toBeGreaterThanOrEqual(100);
+			}
+
+			expect(player.value).toBe(100);
 		});
 	});
 

--- a/src/shared/stats/rating/domain/EloCalculator.ts
+++ b/src/shared/stats/rating/domain/EloCalculator.ts
@@ -3,6 +3,19 @@ import { Team } from "@shared/room/Team";
 import { Rating } from "./Rating";
 
 const RATING_SCALE = 400;
+/**
+ * Upper bound on the rating gap fed into the expected score. The Elo curve
+ * itself degrades gracefully at any gap; integer rounding does not. Deltas are
+ * rounded to whole points, so past roughly 640 points of gap the underdog's
+ * loss rounds to exactly 0 and the favourite's win pays exactly 0: losing
+ * becomes free for the weaker player and beating a newcomer becomes worthless
+ * to the stronger one, who can still drop 20 by slipping. Bounding the gap at
+ * 500 keeps every K tier — including K=10 above 2300, where a 600 bound
+ * already rounds a win down to 0 — paying at least one point in both
+ * directions. Gaps under the bound are untouched, so ordinary matchups score
+ * exactly as before.
+ */
+const MAX_EXPECTED_SCORE_GAP = 500;
 const HIGH_RATED_THRESHOLD = 2300;
 
 const K_PROVISIONAL = 40;
@@ -25,7 +38,12 @@ export type RatingDelta = {
 
 export class EloCalculator {
 	static expectedScore(playerRating: number, opponentRating: number): number {
-		return 1 / (1 + 10 ** ((opponentRating - playerRating) / RATING_SCALE));
+		const gap = Math.min(
+			MAX_EXPECTED_SCORE_GAP,
+			Math.max(-MAX_EXPECTED_SCORE_GAP, opponentRating - playerRating),
+		);
+
+		return 1 / (1 + 10 ** (gap / RATING_SCALE));
 	}
 
 	static kFactorFor(rating: Rating): number {

--- a/src/shared/stats/rating/domain/Rating.test.ts
+++ b/src/shared/stats/rating/domain/Rating.test.ts
@@ -55,5 +55,71 @@ describe("Rating", () => {
 			expect(updated.gamesPlayed).toBe(21);
 			expect(updated.peak).toBe(1500);
 		});
+
+		it("stops the value at the 100 floor instead of dropping below it", () => {
+			const rating = Rating.from({ value: 105, gamesPlayed: 40, peak: 1200 });
+
+			const updated = rating.applyDelta(-20);
+
+			expect(updated.value).toBe(100);
+			expect(updated.gamesPlayed).toBe(41);
+		});
+
+		it("still counts the game and leaves peak untouched when the floor truncates the loss", () => {
+			const rating = Rating.from({ value: 105, gamesPlayed: 40, peak: 1200 });
+
+			const updated = rating.applyDelta(-900);
+
+			expect(updated.value).toBe(100);
+			expect(updated.gamesPlayed).toBe(41);
+			expect(updated.peak).toBe(1200);
+		});
+
+		it("keeps raising peak normally once a floored rating climbs again", () => {
+			const floored = Rating.from({ value: 100, gamesPlayed: 60, peak: 1200 });
+
+			expect(floored.applyDelta(40).peak).toBe(1200);
+			expect(Rating.from({ value: 100, gamesPlayed: 60, peak: 100 }).applyDelta(40).peak).toBe(140);
+		});
+
+		it("bottoms out at the floor over a long losing streak instead of going negative", () => {
+			let rating = Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 });
+
+			for (let game = 0; game < 500; game++) {
+				rating = rating.applyDelta(-20);
+				expect(rating.value).toBeGreaterThanOrEqual(100);
+			}
+
+			expect(rating.value).toBe(100);
+			expect(rating.gamesPlayed).toBe(520);
+			expect(rating.peak).toBe(1000);
+		});
+	});
+
+	describe("effectiveDelta()", () => {
+		it("returns the delta untouched while the floor does not bind", () => {
+			const rating = Rating.from({ value: 1000, gamesPlayed: 20, peak: 1000 });
+
+			expect(rating.effectiveDelta(-20)).toBe(-20);
+			expect(rating.effectiveDelta(20)).toBe(20);
+			expect(rating.effectiveDelta(-900)).toBe(-900);
+		});
+
+		it("truncates a loss to the distance left above the floor", () => {
+			const rating = Rating.from({ value: 105, gamesPlayed: 40, peak: 1200 });
+
+			expect(rating.effectiveDelta(-20)).toBe(-5);
+			expect(Rating.from({ value: 100, gamesPlayed: 40, peak: 1200 }).effectiveDelta(-20)).toBe(0);
+		});
+
+		it("always reconciles: previous value plus the effective delta is the applied value", () => {
+			for (const value of [1000, 140, 120, 105, 100]) {
+				const rating = Rating.from({ value, gamesPlayed: 40, peak: 1200 });
+
+				for (const delta of [-40, -20, -1, 0, 20]) {
+					expect(rating.value + rating.effectiveDelta(delta)).toBe(rating.applyDelta(delta).value);
+				}
+			}
+		});
 	});
 });

--- a/src/shared/stats/rating/domain/Rating.ts
+++ b/src/shared/stats/rating/domain/Rating.ts
@@ -5,6 +5,12 @@ export type RatingProperties = {
 };
 
 const INITIAL_RATING = 1000;
+/**
+ * Lowest rating a player can be projected down to. Bounding the expected-score
+ * gap means a loss always costs at least one point, so a long enough losing
+ * streak would otherwise walk a rating down through zero and into negatives.
+ */
+const RATING_FLOOR = 100;
 const PROVISIONAL_GAMES_THRESHOLD = 10;
 
 export class Rating {
@@ -30,8 +36,18 @@ export class Rating {
 		return this.gamesPlayed < PROVISIONAL_GAMES_THRESHOLD;
 	}
 
+	/**
+	 * The part of `delta` this rating can actually absorb: identical to `delta`
+	 * unless the floor truncates it. Callers that persist or display a delta
+	 * must use this value, so that `previousRating + delta` always equals the
+	 * resulting rating and a recorded delta stays exactly reversible.
+	 */
+	effectiveDelta(delta: number): number {
+		return Math.max(RATING_FLOOR, this.value + delta) - this.value;
+	}
+
 	applyDelta(delta: number): Rating {
-		const value = this.value + delta;
+		const value = this.value + this.effectiveDelta(delta);
 
 		return new Rating({
 			value,


### PR DESCRIPTION
Two changes that belong together — the second exists because of the first.

## The gap feeding the expectation is bounded at ±500

Past roughly a 640-point gap, `Math.round` collapsed the underdog's loss to **exactly 0**. The curve says −0.0126; rounding says free. Two consequences, both real:

- the weaker player got **unlimited free attempts** at a stronger one — every loss cost nothing, every win paid full;
- the stronger player earned **0** for winning and lost 20 for slipping, a standing reason for the top of the ladder to avoid newcomers.

Checked at every K tier before picking the bound:

| gap | K=10 favourite win | K=10 underdog loss |
|---|---|---|
| 500 | **+1** | **−1** |
| 600 | 0 | 0 |

500 is the largest bound where all three tiers still move by at least a point in both directions — including K=10 above 2300, which is exactly the tier the disincentive hurt most. Below 500 the clamp is a no-op, so ordinary matchups are untouched, and symmetry survives because the clamp is odd.

## An explicit floor at 100

The rounding was also an *accidental* floor: a 1000-rated player losing repeatedly to a 1000-rated field stalled at **363 after 317 losses**, because eventually the losses rounded to zero. Bounding the gap removes that accident — the same streak now crosses zero at ~680 losses and keeps falling. So the floor becomes explicit, in `Rating.applyDelta`, where it is an invariant of the aggregate rather than of one call site.

## History records what the rating absorbed

A bare floor would break reconciliation: `rating_history` stores the **delta**, and annulment compensation reverses a match by replaying it. A player at 105 losing 10 stores 100 — replaying the un-floored delta would return them to **120**, minting 15 points out of a floored loss, on precisely the ratings least able to absorb it.

`Rating.effectiveDelta(delta)` returns the portion the floor admits, `applyDelta` is defined in terms of it, and the calculator writes that value to history. So `previousRating + delta` always equals the stored rating, pinned by tests on both sides.

The announcer needed the same rule: it built its end-of-match number by hand, bypassing `applyDelta`, so it would have announced a rating below the floor that the database never holds.

`Rating.from()` is deliberately **not** floored — it reconstructs persisted rows, and silently rewriting history on read would hide data rather than fix it.

## Verification

`tsc` clean · full jest **186 suites / 1811 tests** (+16) · biome clean.

## Follow-up, not in this PR

The reversal writer lives in evolution-api and still stores a plain negated delta, and its reprojection sums deltas from a hardcoded 1000 with no floor. Applying the same effective-delta rule there keeps both directions consistent without the reprojection needing a floor at all.
